### PR TITLE
updated string and filter to correctly apply to nbarT vs nbar

### DIFF
--- a/algorithms/DEADataHandling.py
+++ b/algorithms/DEADataHandling.py
@@ -71,10 +71,14 @@ def load_nbarx(sensor, query, bands_of_interest, product = 'nbart'):
             ds = ds.where(cloud_free)
             ds.attrs['crs'] = crs
             ds.attrs['affine'] = affine
-            print('masked {} with {} and filtered terrain'.format(product_name, 
+            
+        if product=='nbart':
+            print('masked {} with {} and filtered terrain'.format(product_name,
                                                                   mask_product))
             # nbarT is correctly used to correct terrain by replacing -999.0 with nan
             ds = ds.where(ds!=-999.0)
+        elif product=='nbar':
+             print('masked {} with {}'.format(product_name, mask_product))
         else: 
             print('did not mask {} with {}'.format(product_name, mask_product))
     else:


### PR DESCRIPTION
Now when you load surface reflectance data, the function will only filter nbarT for -999 terrain values and will only tell you that it has done so if it did-
there is a new loop that tests to see if the product is nbar or nbart before printing that data is loaded and filtered.