### PR TITLE
Revise load_nbarx to work when selecting bands, rename filter_clouds to filter_pq

### DIFF
--- a/algorithms/DEADataHandling.py
+++ b/algorithms/DEADataHandling.py
@@ -23,98 +23,120 @@ import numpy as np
 import xarray as xr
 
 
-def load_nbarx(dc, sensor, query, product = 'nbart', filter_cloud = True, **bands_of_interest): 
-    '''loads nbar or nbart data for a sensor, masks using pq, then filters 
-    out terrain -999s
+def load_nbarx(dc, sensor, query, product='nbart', bands_of_interest='', filter_pq=True):
+    """
+    Loads NBAR (Nadir BRDF Adjusted Reflectance) or NBAR-T (terrain corrected NBAR) data for a
+    sensor, masks using pixel quality (PQ), then optionally filters out terrain -999s (for NBAR-T).
+    Returns an xarray dataset and CRS and Affine objects defining map projection and geotransform
 
     Last modified: March 2018
     Author: Bex Dunn
-    Modified by: Claire Krause
-    
-    This function requires the following be loaded:
-    from datacube.helpers import ga_pq_fuser
-    from datacube.storage import masking
-    from datacube import Datacube
-    
+    Modified by: Claire Krause, Robbi Bishop-Taylor
+
     inputs
-    dc - handle for the Datacube to import from. This allows you to also use dev environments
-	 if that have been imported into the environment.
+    dc - Handle for the Datacube to import from. This allows you to also use dev environments
+    if that have been imported into the environment.
     sensor - Options are 'ls5', 'ls7', 'ls8'
     query - A dict containing the query bounds. Can include lat/lon, time etc
 
     optional
     product - 'nbar' or 'nbart'. Defaults to nbart unless otherwise specified
-    filter_cloud - boolean. Will filter cloud using pq unless set to false.
-    bands_of_interest - List of strings containing the bands to be read in. Options
-                       'red', 'green', 'blue', 'nir', 'swir1', 'swir2'
+    bands_of_interest - List of strings containing the bands to be read in; defaults to all bands,
+                        options include 'red', 'green', 'blue', 'nir', 'swir1', 'swir2'
+    filter_pq - boolean. Will filter clouds and saturated pixels using PQ unless set to False
+
 
     outputs
-    ds - Extracted and pq filtered dataset
-    crs - ds coordinate reference system
-    affine - ds affine
-    '''  
-    dataset = []
+    ds - Extracted and optionally PQ filtered dataset
+    crs - CRS object defining dataset coordinate reference system
+    affine - Affine object defining dataset affine transformation
+    """
+
     product_name = '{}_{}_albers'.format(sensor, product)
-    print('loading {}'.format(product_name))
+    mask_product = '{}_{}_albers'.format(sensor, 'pq')
+    print('Loading {}'.format(product_name))
+
+    # If bands of interest are given, assign measurements in dc.load call
     if bands_of_interest:
-    	ds = dc.load(product = product_name, measurements = bands_of_interest,
-                     group_by = 'solar_day', **query)
+
+        ds = dc.load(product=product_name, measurements=bands_of_interest,
+                     group_by='solar_day', **query)
+
+    # If no bands of interest given, run without specifying measurements
     else:
-        ds = dc.load(product = product_name, group_by = 'solar_day', **query)  
+
+        ds = dc.load(product=product_name, group_by='solar_day', **query)
+
+    # Proceed if the resulting call returns data
     if ds.variables:
+
         crs = ds.crs
         affine = ds.affine
-        print('loaded {}'.format(product_name))
-        if filter_cloud:
-            mask_product = '{}_{}_albers'.format(sensor, 'pq')
-            sensor_pq = dc.load(product = mask_product, fuse_func = ga_pq_fuser,
-                                group_by = 'solar_day', **query)
+        print('Loaded {}'.format(product_name))
+
+        # If pixel quality filtering is enabled, extract PQ data to use as mask
+        if filter_pq:
+
+            sensor_pq = dc.load(product=mask_product, fuse_func=ga_pq_fuser,
+                                group_by='solar_day', **query)
+
+            # If PQ call returns data, use to mask input data
             if sensor_pq.variables:
-                print('making mask {}'.format(mask_product))
-                cloud_free = masking.make_mask(sensor_pq.pixelquality,
-                                           cloud_acca ='no_cloud',
-                                           cloud_shadow_acca = 'no_cloud_shadow',                           
-                                           cloud_shadow_fmask = 'no_cloud_shadow',
-                                           cloud_fmask = 'no_cloud',
-                                           blue_saturated = False,
-                                           green_saturated = False,
-                                           red_saturated = False,
-                                           nir_saturated = False,
-                                           swir1_saturated = False,
-                                           swir2_saturated = False,
-                                           contiguous = True)
-                ds = ds.where(cloud_free)
+                print('Generating mask {}'.format(mask_product))
+                good_quality = masking.make_mask(sensor_pq.pixelquality,
+                                                 cloud_acca='no_cloud',
+                                                 cloud_shadow_acca='no_cloud_shadow',
+                                                 cloud_shadow_fmask='no_cloud_shadow',
+                                                 cloud_fmask='no_cloud',
+                                                 blue_saturated=False,
+                                                 green_saturated=False,
+                                                 red_saturated=False,
+                                                 nir_saturated=False,
+                                                 swir1_saturated=False,
+                                                 swir2_saturated=False,
+                                                 contiguous=True)
+
+                # Apply mask to preserve only good data
+                ds = ds.where(good_quality)
+
             ds.attrs['crs'] = crs
             ds.attrs['affine'] = affine
 
-        if product=='nbart':
-            print('masked {} with {} and filtered terrain'.format(product_name,
+        # If product is NBAR-T, also correct terrain by replacing -999.0 with nan
+        if product == 'nbart':
+
+            print('Masked {} with {} and filtered terrain'.format(product_name,
                                                                   mask_product))
-            # nbarT is correctly used to correct terrain by replacing -999.0 with nan
-            ds = ds.where(ds!=-999.0)
-        elif product=='nbar':
-             print('masked {} with {}'.format(product_name, mask_product))
-        else: 
-            print('did not mask {} with {}'.format(product_name, mask_product))
-    else:
-        print ('did not load {}'.format(product_name)) 
+            ds = ds.where(ds != -999.0)
 
-    if len(ds.variables) > 0:
+        # If NBAR, simply print successful run
+        elif product == 'nbar':
+
+            print('Masked {} with {}'.format(product_name, mask_product))
+
+        else:
+
+            print('Failed to mask {} with {}'.format(product_name, mask_product))
+
         return ds, crs, affine
-    else:
-        return None
 
-def load_sentinel(dc, product, query, filter_cloud = True, **bands_of_interest): 
+    else:
+
+        print('Failed to load {}'.format(product_name))
+        return None, None, None
+
+
+def load_sentinel(dc, product, query, filter_cloud=True, **bands_of_interest):
     '''loads a sentinel granule product and masks using pq
 
     Last modified: March 2018
     Claire Krause: Bex Dunn
-    
+
     This function requires the following be loaded:
     from datacube.helpers import ga_pq_fuser
     from datacube.storage import masking
     from datacube import Datacube
-    
+
     inputs
     dc - handle for the Datacube to import from. This allows you to also use dev environments
 	 if that have been imported into the environment.
@@ -122,20 +144,20 @@ def load_sentinel(dc, product, query, filter_cloud = True, **bands_of_interest):
     query - A dict containing the query bounds. Can include lat/lon, time etc
 
     optional:
-    bands_of_interest - List of strings containing the bands to be read in. 
+    bands_of_interest - List of strings containing the bands to be read in.
 
     outputs
     ds - Extracted and pq filtered dataset
     crs - ds coordinate reference system
     affine - ds affine
-    '''  
+    '''
     dataset = []
     print('loading {}'.format(product))
     if bands_of_interest:
-        ds = dc.load(product = product, measurements = bands_of_interest,
-                     group_by = 'solar_day', **query)
+        ds = dc.load(product=product, measurements=bands_of_interest,
+                     group_by='solar_day', **query)
     else:
-        ds = dc.load(product = product, group_by = 'solar_day', **query)  
+        ds = dc.load(product=product, group_by='solar_day', **query)
     if ds.variables:
         crs = ds.crs
         affine = ds.affine
@@ -147,12 +169,13 @@ def load_sentinel(dc, product, query, filter_cloud = True, **bands_of_interest):
         ds.attrs['crs'] = crs
         ds.attrs['affine'] = affine
     else:
-        print ('did not load {}'.format(product)) 
+        print('did not load {}'.format(product))
 
     if len(ds.variables) > 0:
         return ds, crs, affine
     else:
         return None
+
 
 def tasseled_cap(sensor_data, sensor, tc_bands=['greenness', 'brightness', 'wetness'],
                  drop=True):
@@ -208,7 +231,6 @@ def tasseled_cap(sensor_data, sensor, tc_bands=['greenness', 'brightness', 'wetn
 
     # For each band, compute tasseled cap band and add to output dataset
     for tc_band in tc_bands:
-
         # Create xarray of coefficient values used to multiply each band of input
         coeff = xr.Dataset(analysis_coefficient[tc_band][sensor])
         sensor_coeff = sensor_data * coeff
@@ -220,7 +242,6 @@ def tasseled_cap(sensor_data, sensor, tc_bands=['greenness', 'brightness', 'wetn
 
     # If drop = True, remove original bands
     if drop:
-
         bands_to_drop = list(sensor_data.data_vars)
         output_array = output_array.drop(bands_to_drop)
 
@@ -259,17 +280,16 @@ def dataset_to_geotiff(filename, data):
             src.write(data[band].data, i + 1)
 
 
-
 def array_to_geotiff(fname, data, geo_transform, projection,
                      nodata_val=0, dtype=gdal.GDT_Float32):
     """
     Create a single band GeoTIFF file with data from array. Because this
     works with simple arrays rather than xarray datasets from DEA, it requires
     the use to pass in geotransform and projection data for the output raster
-    
+
     Last modified: March 2018
     Author: Robbi Bishop-Taylor
-    
+
     :attr fname: output file path
     :attr data: input array
     :attr geo_transform: geotransform for output raster


### PR DESCRIPTION
Selecting bands using `bands_of_interest` in load_nbarx should now work work correctly; the default is to now select all bands. The code had an existing `if bands_of_interest:`, so this change shouldn't break anyone's code after all.

The other thing I've changed is the name of the variable `filter_clouds`. As it's currently set up, the PQ mask currently masks both clouds _and_ saturated pixels, so I've generalised it to `filter_pq` which better describes what it does. Unfortunately this will break code if people have specifically set `filter_clouds = True` or `filter_clouds = False`, but hopefully most have just used the default value so it won't affect them. 