### PR TITLE
Referencing updated to Landsat section please update the rest

### DIFF
--- a/DEA_datasets/GettingStartedWithLandSats5-7-8.ipynb
+++ b/DEA_datasets/GettingStartedWithLandSats5-7-8.ipynb
@@ -13,17 +13,17 @@
     "\n",
     "## Retrieve and plot the data from Landsats 5, 7 and 8  \n",
     "\n",
-    "**Background:** Data from three Landsats (5,7 and 8) are available to access within DEA. This document has a short description about these satellites, scan line correction (SLC), data corrections (NBAR, NBAR-T), data bands and products within datacube. The code snippets in this doc will let you retrieve and plot the data for **lsN_nbar_albers** and **lsN_nbart_albers**, where N is 5, 7 or 8 to denote the satellite.\n",
+    "**Background:** Data from three Landsat satellites (5,7 and 8) are available to access within DEA. This document has a short description about these satellites, scan line corrector issues (SLC-off), data corrections (NBAR, NBAR-T), data bands and products within datacube. The code snippets in this doc will let you retrieve and plot the data for **lsN_nbar_albers** and **lsN_nbart_albers**, where N is 5, 7 or 8 to denote the satellite.\n",
     "\n",
     "**What does this document do?**\n",
     "\n",
-    "- Show how to open a datacube to retrieve the data for various time points and geo-coordinates.\n",
+    "- Show how to use datacube to retrieve the data for various time points and geo-coordinates.\n",
     "\n",
     "- Explain the data corrections.\n",
     "\n",
-    "- Plot a scene as true colour image.\n",
+    "- Plot a scene as a true colour image.\n",
     "\n",
-    "- Plot the same as false colour image.\n",
+    "- Plot the same as a false colour image.\n",
     "\n",
     "- Compare multiple scenes side-by-side.\n",
     "\n",
@@ -60,21 +60,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### About Landsats\n",
+    "### About Landsat\n",
     "\n",
-    "Landsat represents the world's longest continuously acquired collection of space-based moderate-resolution land remote sensing data. Four decades of imagery provides a unique resource for those who work in agriculture, geology, forestry, regional planning, education, mapping, and global change research. Landsat images are also invaluable for emergency response and disaster relief.\n",
+    "\"Landsat represents the world's longest continuously acquired collection of space-based moderate-resolution land remote sensing data. Four decades of imagery provides a unique resource for those who work in agriculture, geology, forestry, regional planning, education, mapping, and global change research. Landsat images are also invaluable for emergency response and disaster relief.\" ([USGS 2018](#Refs)][[1](https://landsat.usgs.gov/landsat-project-description)])\n",
     "\n",
-    "#### Landsat Missions TimeLine [[1](https://landsat.usgs.gov/landsat-missions-timeline)]\n",
+    "#### Landsat Missions Timeline ([USGS 2018](#Refs)][[2](https://landsat.usgs.gov/landsat-missions-timeline)])\n",
     "\n",
-    "In the mid-1960s an ambitious effort to develop and launch the first civilian Earth observation satellite was started. The goal was achieved on July 23, 1972, with the launch of the Earth Resources Technology Satellite (ERTS-1), which was later renamed Landsat 1. The launches of Landsat 2, Landsat 3, and Landsat 4 followed in 1975, 1978, and 1982, respectively.\n",
+    "In the mid-1960s an \"ambitious effort to develop and launch the first civilian Earth observation satellite\"[[2](#Refs)] was started. The \"goal was achieved on July 23, 1972, with the launch of the Earth Resources Technology Satellite (ERTS-1), which was later renamed Landsat 1\"[[2](#Refs)]. \"The launches of Landsat 2, Landsat 3, and Landsat 4 followed in 1975, 1978, and 1982, respectively.\"[[2](#Refs)]\n",
     "\n",
-    "When Landsat 5 was launched in 1984, no one could have predicted that the satellite would continue to deliver high quality, global data of Earth's land surfaces for 28 years and 10 months until its retirement in June, 2013. Landsat 6, however, failed to achieve orbit in 1993.\n",
+    "\"When Landsat 5 was launched in 1984, no one could have predicted that the satellite would continue to deliver high quality, global data of Earth's land surfaces for 28 years and 10 months\"[[2](#Refs)] until its retirement in June, 2013. Landsat 6, however, \"failed to achieve orbit in 1993.\"[[2](#Refs)]\n",
     "\n",
-    "Landsat 7 was successfully launched in 1999 and, along with Landsat 8 launched in 2013, continues to provide daily global data. Landsat 9 is planned to be launched in late 2020.\n",
+    "Landsat 7 was \"successfully launched in 1999 and, along with Landsat 8 \"[[2](#Refs)]...\" launched in 2013, continues to provide daily global data. Landsat 9 is planned to \"[[2](#Refs)] be \"launched in late 2020.\"[[2](#Refs)]\n",
     "\n",
-    "Given below is a timeline of the various Landsats.\n",
+    "Given below is a timeline of the various Landsats.[[2](#Refs)]\n",
     "\n",
-    "![Fig 1. Timeline of the working lives of Landsats since 1972](TimelineOnlyForWebRGB.jpg)"
+    "\n",
+    "![Fig 1. Timeline of the working lives of Landsats since 1972 as published at [[2](#Refs)]](TimelineOnlyForWebRGB.jpg)\n",
+    "\n",
+    "Fig 1. Timeline of the working lives of Landsats since 1972 as published at [[2](#Refs)]]"
    ]
   },
   {
@@ -612,6 +615,25 @@
    "source": [
     "three_band_image_subplots(ds, bands = ['swir1','nir','green'], num_cols = 2, figsize = [10, 10], wspace = 0.35)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"Refs\"></a>\n",
+    "### References\n",
+    "\n",
+    "1. USGS. 2018.  *Landsat Project Description*, viewed 15 May 2018, <https://landsat.usgs.gov/landsat-project-description>\n",
+    "\n",
+    "2. USGS. 2018. *Landsat Missions Timeline*, viewed 15 May 2018, <https://landsat.usgs.gov/landsat-missions-timeline>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -631,7 +653,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Further to discussions today about making sure we reference any direct quotes from previously published material, I've edited one section of this notebook to add references where direct quotes and references are needed or useful. 

I've also added a caption and a reference to the Landsat section. - please caption and reference any images used that have been previously published elsewhere.

Please edit the rest of this notebook accordingly. (and I'll add an issue so we all do this in future)

I've decided to include an internal and and external link for the first reference to any externally published content, followed by internal links for further references. These internal links go to a references cell at the end of the notebook, where references are formatted according to the GA style guide (now linked to in the dea notebooks getting started guide, or at <http://www.ga.gov.au/copyright/how-to-cite-geoscience-australia-source-of-information> )

This is necessary if you have notebooks that consistently use directly copied and pasted information from elsewhere. Please don't use anything copied-and-pasted without enclosing it in quotes and referencing, as per usual scientific publication standards, particularly as these GA- published notebooks are within GeoscienceAustralia's repository and visible to external collaborators. 

If you are able to, you can paraphrase external sources to avoid having to reference the same reference multiple times in the same paragraph, but please include a reference if you do so.

I've made some minor changes to the text for readability also