### PR TITLE
adding load modules to stop tasselled cap failing with no xarray

### DIFF
--- a/Scripts/BandIndices.py
+++ b/Scripts/BandIndices.py
@@ -12,6 +12,10 @@ Available functions:
 
 
 '''
+#Load modules
+import dask
+import numpy as np
+import xarray as xr
 
 def calculate_indices(ds, index):
     '''


### PR DESCRIPTION
tasseled cap function was moved to BandIndices.py, but I forgot to add in the load statements for the dependencies. 