### PR TITLE
 Revise Intro to Landsat notebook to close #154

### DIFF
--- a/DEA_datasets/Introduction_to_Landsat.ipynb
+++ b/DEA_datasets/Introduction_to_Landsat.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Introduction to DEA Landsat surface reflectance\n",
     "\n",
-    "**Background:** Surface reflectance products from three Landsat satellites (**Landsat 5, 7 and 8**) are available for access through Geoscience Australia's Digital Earth Australia (DEA). This document includes a short introduction to the Landsat program, and describes the surface reflectance product suite (**NBAR and NBAR-T**) available through DEA. The code snippets in this doc will retrieve, modify and plot the data for `ls*_nbar_albers` and `ls*_nbart_albers`, where `*` is 5, 7 or 8 denote the satellite.\n",
+    "**Background:** Surface reflectance products from three Landsat satellites (**Landsat 5, 7 and 8**) are available for access through Geoscience Australia's Digital Earth Australia (DEA). This document includes a short introduction to the Landsat program, and describes the 'surface reflectance' (SR) product suite (**NBAR and NBAR-T**) available through DEA. The code snippets in this doc will retrieve, modify and plot the data for `ls*_nbar_albers` and `ls*_nbart_albers`, where `*` is 5, 7 or 8 denote the satellite.\n",
     "\n",
     "**What does this document do?**\n",
     "\n",
@@ -15,6 +15,10 @@
     "- Plot multiple Landsat bands as a true colour image\n",
     "- Plot multiple Landsat bands as a false colour image\n",
     "- Demonstrate how to compute and plot simple remote sensing band indices\n",
+    "\n",
+    "**Required inputs**\n",
+    "\n",
+    "This notebook requires the `DEAPlotting.three_band_image` function from the `dea-notebooks` repository. To ensure this function and all other file paths load correctly, it is recommended that you download and clone the entire `dea-notebooks` repository onto your computer and then launch this notebook from inside the cloned directory; please see the [readme document here](https://github.com/GeoscienceAustralia/dea-notebooks/) for instructions. If you find an error or bug in this notebook, please either create an 'Issue' in the Github repository, or fix it yourself and create a 'Pull' request to contribute the updated notebook back into the repository (See the repository README for instructions on creating a Pull request).\n",
     "\n",
     "**Date**: June 2018\n",
     "\n",
@@ -83,7 +87,7 @@
     "\n",
     "Surface reflectance NBAR-T includes a terrain illumination reflectance correction and has the same features of NBAR, along with some additional features.\n",
     "\n",
-    "* The SR product is created using a physics-based coupled BRDF and atmospheric correction model that can be applied to both flat and inclined surfaces. The resulting surface reflectance values are comparable both within individual images and between images acquired at different times and/or with different sensors.\n",
+    "* The surface reflectance product is created using a physics-based coupled BRDF and atmospheric correction model that can be applied to both flat and inclined surfaces. The resulting surface reflectance values are comparable both within individual images and between images acquired at different times and/or with different sensors.\n",
     "* Terrain affects optical satellite images through both irradiance and bidirectional reflectance distribution function (BRDF) effects.\n",
     "Slopes facing the sun receive enhanced solar irradiance and appear brighter compared to those facing away from the sun.\n",
     "* For anisotropic surfaces, the radiance received at the satellite sensor from a sloping surface is also affected by surface BRDF which varies with combinations of surface landcover types, sun, and satellite geometry (sun and sensor view, and their relative azimuth angle) as well as topographic geometry (primarily slope and aspect angles). Consequently, to obtain comparable surface reflectance from satellite images covering mountainous areas, it is necessary to process the images to reduce or remove the topographic effect so that the images can be used for different purposes on the same spectral base.\n",
@@ -166,8 +170,11 @@
     "import matplotlib.pyplot as plt\n",
     "from datacube.storage import masking\n",
     "\n",
-    "# Import dea-notebook functions. This assumes you are running this notebook from inside the `dea-notebooks`\n",
-    "# directory. If not, replace the relative `../Scripts` link with a path to the `dea-notebooks/Scripts` directory\n",
+    "# Import dea-notebook functions. To ensure file paths load correctly, it is recommended that you download and \n",
+    "# clone the entire `dea-notebooks` repository onto your computer and then launch this notebook from inside the \n",
+    "# cloned directory; please see the readme here for info: https://github.com/GeoscienceAustralia/dea-notebooks/\n",
+    "# Alternatively, replace the relative `../Scripts` link with an absolute path to the `dea-notebooks/Scripts` \n",
+    "# directory on your PC\n",
     "sys.path.append('../Scripts')\n",
     "import DEAPlotting\n",
     "\n",
@@ -442,10 +449,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Creating a true-colour image using three bands\n",
+    "### Creating a 'true colour' image using three bands\n",
     "We can also plot combinations of multiple bands from the data using the `DEAPlotting.three_band_image` function, using the `time` parameter to specify what time-step to plot. \n",
     "\n",
-    "By specifying the `red`, `green` and `blue` bands, we can produce a 'true colour' plot that approximates how the landscape would appear to the human eye. Note that the function used for this true colour plot enhances contrast between the bands (`contrast_enhance=True`), resulting in a colour-enhanced image:"
+    "By specifying the `red`, `green` and `blue` bands, we can produce a ['true colour' plot](https://crisp.nus.edu.sg/~research/tutorial/opt_int.htm) that approximates how the landscape would appear to the human eye. Note however that the function used for this true colour plot enhances contrast between the bands (`contrast_enhance=True`), resulting in a colour-enhanced image:"
    ]
   },
   {
@@ -472,7 +479,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Creating a false colour image using three bands\n",
+    "### Creating a 'false colour' image using three bands\n",
     "This plot uses the SWIR and NIR bands to accentuate the presence of water or vegetation in the landscape:"
    ]
   },

--- a/DEA_datasets/Introduction_to_Landsat.ipynb
+++ b/DEA_datasets/Introduction_to_Landsat.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Introduction to DEA Landsat surface reflectance\n",
     "\n",
-    "**Background:** Surface reflectance products from three Landsat satellites (**Landsat 5, 7 and 8**) are available for access through Geoscience Australia's Digital Earth Australia (DEA). This document includes a short introduction to the Landsat program, and describes the 'surface reflectance' (SR) product suite (**NBAR and NBAR-T**) available through DEA. The code snippets in this doc will retrieve, modify and plot the data for `ls*_nbar_albers` and `ls*_nbart_albers`, where `*` is 5, 7 or 8 denote the satellite.\n",
+    "**Background:** Surface reflectance products from three Landsat satellites (**Landsat 5, 7 and 8**) are available for access through Geoscience Australia's Digital Earth Australia (DEA). This document includes a short introduction to the Landsat program, and describes the surface reflectance product suite (**NBAR and NBAR-T**) available through DEA. The code snippets in this doc will retrieve, modify and plot the data for `ls*_nbar_albers` and `ls*_nbart_albers`, where `*` is 5, 7 or 8 denote the satellite.\n",
     "\n",
     "**What does this document do?**\n",
     "\n",


### PR DESCRIPTION
Comments from @walsh-andrew from #154:

> The abbreviation "SR" is introduced in the NBAR-T section, but it is not defined (presumably 'surface reflectance'). SR can be defined on the first line of the document.

Just to make things easier to read, I've replaced all 'SR' with 'surface reflectance' 

> In the first notebook input cell (In [1]:), it says "Import dea-notebook functions. This assumes you are running this notebook from inside the dea-notebooks directory. If not, replace the relative ../Scripts link with a path to the dea-notebooks/Scripts directory. It is not clear how to find the dea-notebooks/Scripts directory. I just tried it with a notebook started using the DEA desktop icon and it still didn't work. So an explanation of starting a notebook from a subdirectory inside a cloned version of dea-notebooks on GitHub is needed.

I've added a new 'required inputs' section which mimics other notebooks and gives some additional info on cloning the directory:

```
**Required inputs**

This notebook requires the `DEAPlotting.three_band_image` function from the `dea-notebooks` repository. To ensure this function and all other file paths load correctly, it is recommended that you download and clone the entire `dea-notebooks` repository onto your computer and then launch this notebook from inside the cloned directory; please see the [readme document here](https://github.com/GeoscienceAustralia/dea-notebooks/) for instructions. If you find an error or bug in this notebook, please either create an 'Issue' in the Github repository, or fix it yourself and create a 'Pull' request to contribute the updated notebook back into the repository (See the repository README for instructions on creating a Pull request).
```

> In the section "Creating a true-colour image using three bands", it is somewhat confusing to talk about making a true colour plot and then having a flag "contrast_enhance=True" that results in a "colour-enhanced image". It's not clear which one is the true colour image (with flag True or False?). Maybe clarifying this will help the user understand what's happening better?

True-colour here is used in the remote sensing use of the word (i.e. an image that uses 'red', 'green', 'blue' bands for RGB, vs a false colour than uses other bands). To add a bit of extra clarification for people who are interested, I've added a link for further reading:

`By specifying the red, green and blue bands, we can produce a ['true colour' plot](https://crisp.nus.edu.sg/~research/tutorial/opt_int.htm) that approximates how the landscape would appear to the human eye `