### PR TITLE
Fix heading for Hovmoller_TCI_and_Rainfall

### DIFF
--- a/Temporal_analysis/Hovmoller_TCI_and_Rainfall.ipynb
+++ b/Temporal_analysis/Hovmoller_TCI_and_Rainfall.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Hovmoller of Tasselled Cap Wetness, Brightness, Greenness, Rainfall\n",
+    "# Hovmoller of Tasselled Cap Wetness, Brightness, Greenness, Rainfall\n",
     "\n",
     "__What does this notebook do?__ This notebook opens a shape file of transects, allows you to select a transect by number, and plot a hovmoller diagram of the site tasselled cap indices based on datacube landsat surface reflectance data with contextual BoM rainfall data. You can then plot hovmoller diagrams for the thresholded tasselled cap indices.\n",
     "\n",


### PR DESCRIPTION
Making only one top-level heading so that only the notebook title appears in the Table of Contents, here:
http://geoscienceaustralia.github.io/digitalearthau/notebooks/Temporal_analysis/README.html