### PR TITLE
Fix heading for Hovmoller NDVI

### DIFF
--- a/Temporal_analysis/Hovmoller_NDVI.ipynb
+++ b/Temporal_analysis/Hovmoller_NDVI.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Hovmoller plot of NDVI and Rainfall\n",
+    "# Hovmoller plot of NDVI and Rainfall\n",
     "\n",
     "__What does this notebook do?__ This notebook opens a shape file of transects, allows you to select a transect by number (or plot all sites), and plot a hovmoller diagram of the site NDVI based on datacube landsat surface reflectance data and BoM rainfall data.\n",
     "\n",


### PR DESCRIPTION
Making only one top-level heading so that only the notebook title appears in the Table of Contents, here:
http://geoscienceaustralia.github.io/digitalearthau/notebooks/Temporal_analysis/README.html