### PR TITLE
adding the doctesting ability to the end of the file. Run {filename}.…

### DIFF
--- a/10_Scripts/BandIndices.py
+++ b/10_Scripts/BandIndices.py
@@ -191,4 +191,15 @@ def tasseled_cap(sensor_data, tc_bands=['greenness', 'brightness', 'wetness'],
 
     return output_array
        
-       
+
+# If the module is being run, not being imported! 
+# to do this, do the following
+# run {modulename}.py)
+
+if __name__=='__main__':
+#print that we are running the testing
+    print('Testing..')
+#import doctest to test our module for documentation
+    import doctest
+    doctest.testmod()
+    print('Testing done')       

--- a/10_Scripts/ClassificationTools.py
+++ b/10_Scripts/ClassificationTools.py
@@ -317,3 +317,16 @@ def randomforest_eval(training_labels, training_samples, classifier_scenario,
     plt.yscale('log')
     plt.savefig(output_path, bbox_inches='tight')
     plt.show()
+
+# If the module is being run, not being imported! 
+# to do this, do the following
+# run {modulename}.py)
+
+if __name__=='__main__':
+#print that we are running the testing
+    print('Testing..')
+#import doctest to test our module for documentation
+    import doctest
+    doctest.testmod()
+    print('Testing done')
+

--- a/10_Scripts/DEADataHandling.py
+++ b/10_Scripts/DEADataHandling.py
@@ -748,3 +748,15 @@ def write_your_netcdf(data, dataset_name, filename, crs):
     
 #     #return the results as a dataframe
 #     return statistics_df
+
+# If the module is being run, not being imported! 
+# to do this, do the following
+# run {modulename}.py)
+
+if __name__=='__main__':
+#print that we are running the testing
+    print('Testing..')
+#import doctest to test our module for documentation
+    import doctest
+    doctest.testmod()
+    print('Testing done')

--- a/10_Scripts/DEAPlotting.py
+++ b/10_Scripts/DEAPlotting.py
@@ -1534,6 +1534,16 @@ def plot_WOfS(ds, figsize=(10,10), title='WOfS %', projection='projected'):
     #fig.delaxes(fig.axes[1]) #Remove pre-defined colour bar
     return fig,ax
         
-        
+# If the module is being run, not being imported! 
+# to do this, do the following
+# run {modulename}.py)
+
+if __name__=='__main__':
+#print that we are running the testing
+    print('Testing..')
+#import doctest to test our module for documentation
+    import doctest
+    doctest.testmod()
+    print('Testing done')        
         
         

--- a/10_Scripts/SignificanceTests.py
+++ b/10_Scripts/SignificanceTests.py
@@ -83,4 +83,15 @@ def significance_tests(xarray_a, xarray_b, t_test=False, levene_test=False,
         p_val_levene_xr = xr.DataArray(levene_p, coords = [lat, long], dims = ['y', 'x'], name='p_value_levene') 
         print('finished levene test')
         return levene_stat_xr, p_val_levene_xr
-      
+
+# If the module is being run, not being imported! 
+# to do this, do the following
+# run {modulename}.py)
+
+if __name__=='__main__':
+#print that we are running the testing
+    print('Testing..')
+#import doctest to test our module for documentation
+    import doctest
+    doctest.testmod()
+    print('Testing done')      

--- a/10_Scripts/SpatialTools.py
+++ b/10_Scripts/SpatialTools.py
@@ -489,3 +489,15 @@ def reproject_to_template(input_raster, template_raster, output_raster, resoluti
     
     print("Reprojected raster exported to {}".format(output_raster))
     return output_ds
+
+# If the module is being run, not being imported! 
+# to do this, do the following
+# run {modulename}.py)
+
+if __name__=='__main__':
+#print that we are running the testing
+    print('Testing..')
+#import doctest to test our module for documentation
+    import doctest
+    doctest.testmod()
+    print('Testing done')

--- a/10_Scripts/TasseledCapTools.py
+++ b/10_Scripts/TasseledCapTools.py
@@ -150,4 +150,14 @@ def pct_exceedance_tasseled_cap(sensor_data, tc_bands=['greenness', 'brightness'
 
     return pct_exceedance_array
    
+f the module is being run, not being imported! 
+# to do this, do the following
+# run {modulename}.py)
 
+if __name__=='__main__':
+#print that we are running the testing
+    print('Testing..')
+#import doctest to test our module for documentation
+    import doctest
+    doctest.testmod()
+    print('Testing done')

--- a/10_Scripts/water_classifier_and_wofs.py
+++ b/10_Scripts/water_classifier_and_wofs.py
@@ -187,3 +187,14 @@ Authors: Erin Telfer, Bex Dunn
                        'x': x})
     return dataset_out
 
+# If the module is being run, not being imported! 
+# to do this, do the following
+# run {modulename}.py)
+
+if __name__=='__main__':
+#print that we are running the testing
+    print('Testing..')
+#import doctest to test our module for documentation
+    import doctest
+    doctest.testmod()
+    print('Testing done')


### PR DESCRIPTION
This adds doctest (apparently the base level unit testing thing) to the end of our modules.
--This should only run when you run the script.
 Run {filename}.py to test the file
--I don't think this breaks anything.

**You can put your examples in the docstring and doctest will run them as tests!!!**

```
# If the module is being run, not being imported! 
# to do this, do the following
# run {modulename}.py)

if __name__=='__main__':
#print that we are running the testing
    print('Testing..')
#import doctest to test our module for documentation
    import doctest
    doctest.testmod()
    print('Testing done')
```

https://docs.python.org/3/library/doctest.html#module-doctest 