### PR TITLE
Fix remaining where statement to reduce memory usage when removing Landsat SLC failed

### DIFF
--- a/10_Scripts/DEADataHandling.py
+++ b/10_Scripts/DEADataHandling.py
@@ -334,7 +334,7 @@ def load_clearlandsat(dc, query, sensors=('ls5', 'ls7', 'ls8'), product='nbart',
             if not ls7_slc_off and sensor == 'ls7':
 
                 print('Ignoring SLC-off observations for ls7')
-                data = data.where(data.time < np.datetime64('2003-05-30'), drop=True) 
+                data = data.sel(time=data.time < np.datetime64('2003-05-30'))
 
             # Return only Landsat observations that have matching PQ data 
             time = (data.time - pq.time).time


### PR DESCRIPTION
One last where statement snuck through the last update. Replaced with sel so that entire loaded data isn't coerced to float64 when removing Landsat SLC failed imagery.