### PR TITLE
script to load rainfall without offset

### DIFF
--- a/10_Scripts/README.rst
+++ b/10_Scripts/README.rst
@@ -51,5 +51,7 @@ TasseledCapTools.py: a set of python functions to use with the outputs of tassel
      - **thresholded_tasseled_cap**: Computes thresholded tasseled cap wetness, greenness and brightness bands from a six band xarray dataset
      - **pct_exceedance_tasseled_cap**: Counts the number of thresholded tasseled cap scenes per pixel and divides by the number of tasseled cap scenes per pixel
 
+RainfallTools.py: load rainfall from BoM rainfall grids
+     - **load_rainfall**: Loads gridded rainfall data and fixes offset in underlying BoM data
 .. toctree::
    :maxdepth: 1

--- a/10_Scripts/RainfallTools.py
+++ b/10_Scripts/RainfallTools.py
@@ -1,0 +1,26 @@
+## RainfallTools.py
+
+'''RainfallTools contains a set of python functions for working with rainfall data.
+Available functions:
+    load_rainfall
+    
+Last modified: October 2018
+Authors: Bex Dunn, Vanessa Newey 
+    
+'''
+import datacube
+import numpy as np
+import xarray as xr
+
+def load_rainfall(query):
+    ''' Loads the rainfall grids from 1901 to the most recent from the staging database,
+    pending the official publication of gridded rainfall data by BoM. 
+    Last modified: Oct 2018
+    Author: Vanessa Newey'''
+    
+    dc_rf =datacube.Datacube(config='/g/data/r78/bom_grids/rainfall.conf')
+    
+    rf_data = dc_rf.load(product = 'rainfall_grids_1901_2017',align=(0.025,0.027), **query)
+    print('These rainfall grids have been realigned by the load_rainfall function - if you think this ',
+          ' may be incorrect then check your data and metadata then contact BDunn or VNewey'
+    return rf_data


### PR DESCRIPTION
This script can be run to load the rainfall grids without the spatial offset problem. 