### PR TITLE
New rgb and display map functions

### DIFF
--- a/10_Scripts/README.rst
+++ b/10_Scripts/README.rst
@@ -18,12 +18,12 @@ DEADataHandling.py: handling data using DEA functionality (i.e. dc.load or xarra
      - **write_your_netcdf**: Writes an xarray dataset or array to a NetCDF file
      
 DEAPlotting.py: plotting DEA data (e.g. xarrays)
-     - **three_band_image**: Takes three spectral bands and plots them on the RGB bands of an image
-     - **three_band_image_subplots**: Takes three spectral bands and multiple time steps, and plots them on the RGB bands of an image
+     - **rgb**: Takes an xarray dataset and plots RGB images using three imagery bands
      - **animated_timeseries**: Takes an xarray time series and exports an animation showing landscape change across time
      - **animated_doubletimeseries**: Takes two xarray datasets and exports a two panel animation
      - **animated_timeseriesline**: Plots a pandas dataframe as a line graph next to an xarray dataset
      - **plot_WOfS**: Use the DEA WOfS color ramp to plot WOfS percentage data
+     - **display_map**: Generates an interactive map with a bounded rectangle overlayed on Google Maps imagery from a set of x and y coordinates.
 
 BandIndices.py: calculating remote sensing band indices
      - **calculate_indices**: Computes a set of indices (including NDVI, GNDVI, NDWI, NDMI) from an xarray dataset


### PR DESCRIPTION
**New rgb function to replace three_band_image etc**

Currently we have a `three_band_image` and `three_band_image_subplots` functions in DEA Notebooks for plotting RGB images from xarray datasets. `three_band_image_subplots` does essentially the same thing as `three_band_image` except allows faceted plotting, however the function has been neglected for a while and produces pretty ugly outputs without a lot of fine-tuning (e.g. #248). Secondly, both functions essentially replicate functionality already available in xarray (e.g. RGB plotting with `plot.imshow()`), including faceted plots which are handled automatically (and far more nicely) via `col='time', col_wrap=2`

I propose changing to a simple function called `rgb` which serves as a wrapper around xarray's RGB plotting. For example, plotting an RGB image using the default red, green, blue bands is as simple as:

`rgb(dataset)`

Plotting subplots is like:

`rgb(dataset, col='time', col_wrap=3)`

I think this is nicer solution than the current `three_band_image` and `three_band_image_subplots` because it combines two functions into one, and uses the existing xarray-style API. 

I've included depreciation warnings for `three_band_image` and `three_band_image_subplots`. Also closes #248, closes #187 and closes #92.

**New display_map function**

New function which given a set of x and y coordinates generates an interactive map centered over that area with a bounded rectangle overlayed on Google Maps imagery; see image below. A useful use case is checking that your query covers the right area before you waste time loading in the data:
```
query = {'lat': (-35.25, -35.35), 'lon': (149.05, 149.17)}
display_map(x=query['lon'], y=query['lat'], crs='EPSG:4326')
```
![capture](https://user-images.githubusercontent.com/17680388/49203011-bd69c800-f3fa-11e8-9e0a-2fcc1cdc6981.PNG)
