### PR TITLE
Added default aspect argument to RGB function

### DIFF
--- a/10_Scripts/DEAPlotting.py
+++ b/10_Scripts/DEAPlotting.py
@@ -40,7 +40,7 @@ from pyproj import Proj, transform
 
 
 def rgb(ds, bands=['red', 'green', 'blue'], index=None, index_dim='time', 
-        robust=True, percentile_stretch = None, col_wrap=4, size=6,
+        robust=True, percentile_stretch = None, col_wrap=4, size=6, aspect=1,
         savefig_path=None, savefig_kwargs={}, **kwargs):
     
     """
@@ -144,6 +144,8 @@ def rgb(ds, bands=['red', 'green', 'blue'], index=None, index_dim='time',
     Exporting image to output_image_test.png
     
     """   
+    # Update kwargs with default or supplied aspect value
+    kwargs.update({'aspect':aspect})   
 
     # If no value is supplied for `index` (the default), plot using default values and arguments passed via `**kwargs`
     if index is None:


### PR DESCRIPTION
If you have a non-square xarray then the current RGB function will 'squish' the output image. Passing `aspect=1` keeps it a 1 to 1 ratio with `size` as the default. 