### PR TITLE
Add autoformatter details to template notebook and move tags info upward

### DIFF
--- a/DEA_notebooks_template.ipynb
+++ b/DEA_notebooks_template.ipynb
@@ -20,13 +20,16 @@
    "source": [
     "### General advice (delete this cell before submitting for review)\n",
     "\n",
-    "- When choosing a location for your analysis, **select an area that has data on both the `NCI` and `DEA Sandbox`** to allow allow your code to be run on both environments. \n",
+    "- When choosing a location for your analysis, **select an area that has data on both the `NCI` and `DEA Sandbox`** to allow your code to be run on both environments. \n",
     "For example, you can check this for Landsat using the [DEA Explorer](https://explorer.sandbox.dea.ga.gov.au/ga_ls5t_ard_3/1990) (use the drop-down menu to view all products). \n",
     "As of September 2019, the `DEA Sandbox` has a single year of continental Landsat data for 2015-16, and the full 1987-onward time-series for three locations (Perth WA, Brisbane QLD, and western NSW).\n",
     "- When writing in Markdown cells, start each sentence is on a **new line**.\n",
     "This makes it easy to see changes through git commits.\n",
-    "- Use Australian English.\n",
-    "- Use the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code."
+    "- Use Australian English in markdown cells and code comments.\n",
+    "- Use the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. To make sure all code in the notebook is consistent, you can use the `jupyterlab_code_formatter` tool: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended). This will reformat the code in the cell to a consistent style.\n",
+    "- In the final notebook cell, include a set of relevant tags which are used to build the DEA User Guide's [Tag Index](https://docs.dea.ga.gov.au/genindex.html). \n",
+    "Use all lower-case, seperate words with spaces, and where possible re-use existing tags.\n",
+    "Ensure the tags cell below is in `Raw` format, rather than `Markdown` or `Code`.\n"
    ]
   },
   {
@@ -106,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dc = datacube.Datacube(app='notebook-template')"
+    "dc = datacube.Datacube(app='DEA_notebooks_template')"
    ]
   },
   {
@@ -222,7 +225,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.7+43.gc873f3ea.dirty\n"
+      "1.7+43.gc873f3ea\n"
      ]
     }
    ],
@@ -235,9 +238,7 @@
    "metadata": {},
    "source": [
     "## Tags\n",
-    "In the final notebook cell, include a set of relevant tags which are used to build an index of tags here: https://docs.dea.ga.gov.au/genindex.html. \n",
-    "Use all lower-case, and where possible re-use existing tags.\n",
-    "Ensure the tags cell below is in `Raw` format, rather than `Markdown` or `Code`."
+    "Browse all available tags on the DEA User Guide's [Tags Index](https://docs.dea.ga.gov.au/genindex.html)"
    ]
   },
   {
@@ -246,7 +247,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "**Tags**: :index:`template`, :index:`dc.load`, :index:`plot`, :index:`landsat8`, :index:`pixeldrill`"
+    "**Tags**: :index:`sandbox_compatible`, :index:`nci_compatible`, :index:`template`, :index:`dc.load`, :index:`plotting`, :index:`landsat8`, :index:`pixeldrill`"
    ]
   }
  ],
@@ -266,7 +267,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/DEA_notebooks_template.ipynb
+++ b/DEA_notebooks_template.ipynb
@@ -92,7 +92,7 @@
     "import sys\n",
     "import xarray as xr\n",
     "\n",
-    "sys.path.append('../Scripts')"
+    "sys.path.append(\"../Scripts\")"
    ]
   },
   {
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dc = datacube.Datacube(app='DEA_notebooks_template')"
+    "dc = datacube.Datacube(app=\"DEA_notebooks_template\")"
    ]
   },
   {
@@ -129,8 +129,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "param_name_1 = 'example_value'\n",
-    "param_name_2 = 'example_value'"
+    "param_name_1 = \"example_value\"\n",
+    "param_name_2 = \"example_value\""
    ]
   },
   {
@@ -267,7 +267,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Proposed changes
* Added a sentence pointing users to the `jupyterlab_code_formatter` (without making this compulsory)
* Moved instruction sentence about tags to the 'General advice' cell so users don't have to delete instructional text from multiple places in the notebook
* Added tags for NCI/sandbox compatibility: `:index:'sandbox_compatible', :index:'nci_compatible'`
