### PR TITLE
Add initial set of scripts and funcs to `develop`

### DIFF
--- a/Scripts/dea_bandindices.py
+++ b/Scripts/dea_bandindices.py
@@ -58,10 +58,11 @@ def calculate_indices(ds,
     collection : str
         An string that tells the function what data collection is 
         being used to calculate the index. This is necessary because 
-        the GA Landsat Collection 2, Landsat Collection 3 and Sentinel 2 
-        use different names for bands covering a similar spectra. Valid 
-        options are 'ga_landsat_collection_2', 'ga_landsat_collection_3'
-        and 'ga_sentinel2_collection_1'.
+        different collections use different names for bands covering 
+        a similar spectra. Valid options are 'ga_landsat_2' (for GA 
+        Landsat Collection 2), 'ga_landsat_3' (for GA Landsat 
+        Collection 3) and 'ga_sentinel2_1' (for GA Sentinel 2 
+        Collection 1).
     custom_varname : str, optional
         By default, the original dataset will be returned with 
         a new index variable named after `index` (e.g. 'NDVI'). To 
@@ -188,13 +189,11 @@ def calculate_indices(ds,
     if collection is None:
 
         raise ValueError("'No `collection` was provided. Please specify "
-                         "either 'ga_landsat_collection_2', "
-                         "'ga_landsat_collection_3' \nor "
-                         "'ga_sentinel2_collection_1' to ensure the "
-                         "function calculates indices using the correct "
-                         "spectral bands")
+                         "either 'ga_landsat_2', 'ga_landsat_3' \nor "
+                         "'ga_sentinel2_1' to ensure the function calculates "
+                         "indices using the correct spectral bands")
     
-    elif collection == 'ga_landsat_collection_3':
+    elif collection == 'ga_landsat_3':
 
         # Dictionary mapping full data names to simpler 'red' alias names
         bandnames_dict = {
@@ -217,7 +216,7 @@ def calculate_indices(ds,
             a: b for a, b in bandnames_dict.items() if a in ds.variables
         }
 
-    elif collection == 'ga_sentinel2_collection_1':
+    elif collection == 'ga_sentinel2_1':
 
         # Dictionary mapping full data names to simpler 'red' alias names
         bandnames_dict = {
@@ -240,7 +239,7 @@ def calculate_indices(ds,
             a: b for a, b in bandnames_dict.items() if a in ds.variables
         }
 
-    elif collection == 'ga_landsat_collection_2':
+    elif collection == 'ga_landsat_2':
 
         # Pass an empty dict as no bands need renaming
         bands_to_rename = {}
@@ -249,9 +248,8 @@ def calculate_indices(ds,
     else:
         raise ValueError(f"'{collection}' is not a valid option for "
                           "`collection`. Please specify either \n"
-                          "'ga_landsat_collection_2', "
-                          "'ga_landsat_collection_3' or "
-                          "'ga_sentinel2_collection_1'")
+                          "'ga_landsat_2', 'ga_landsat_3' or "
+                          "'ga_sentinel2_1'")
         
     # Apply index function after normalising to 0.0-1.0 by dividing by 10K
     try:

--- a/Scripts/dea_bandindices.py
+++ b/Scripts/dea_bandindices.py
@@ -100,8 +100,8 @@ def calculate_indices(ds,
                                      (ds.nir + ds.swir1),
 
                   # Normalised Burn Ratio, Lopez Garcia 1991
-                  'NBR': lambda ds: (ds.nir - ds.swir1) /
-                                    (ds.nir + ds.swir1),
+                  'NBR': lambda ds: (ds.nir - ds.swir2) /
+                                    (ds.nir + ds.swir2),
 
                   # Burn Area Index, Martin 1998
                   'BAI': lambda ds: (1.0 / ((0.10 - ds.red) ** 2 +

--- a/Scripts/dea_bandindices.py
+++ b/Scripts/dea_bandindices.py
@@ -33,7 +33,7 @@ def calculate_indices(ds,
         used as inputs to calculate the selected water index.
     index : str
         A string giving the name of the index to calculate:
-        'NDVI' (Normalised Difference Vegation Index, Rouse 1973)
+        'NDVI' (Normalised Difference Vegetation Index, Rouse 1973)
         'EVI' (Enhanced Vegetation Index, Huete 2002),
         'LAI' (Leaf Area Index, Boegh 2002),
         'SAVI' (Soil Adjusted Vegetation Index, Huete 1988),
@@ -56,14 +56,14 @@ def calculate_indices(ds,
         'FMR' (Ferrous Minerals Ratio, Segal 1982),
         'IOR' (Iron Oxide Ratio, Segal 1982)   
     collection : str
-        An string that tells the function what dataset or data 
-        collection is being used to calculate the index. This is 
-        necessary because Landsat Collection 2, Landsat Collection 3 and
-        Sentinel 2 use different names for bands covering a similar 
-        spectra. Valid options are 'ga_landsat_collection_2', 
-        'ga_landsat_collection_3' and 'sentinel2'.
+        An string that tells the function what data collection is 
+        being used to calculate the index. This is necessary because 
+        the GA Landsat Collection 2, Landsat Collection 3 and Sentinel 2 
+        use different names for bands covering a similar spectra. Valid 
+        options are 'ga_landsat_collection_2', 'ga_landsat_collection_3'
+        and 'ga_sentinel2_collection_1'.
     custom_varname : str, optional
-        By default, the function will return the original dataset with 
+        By default, the original dataset will be returned with 
         a new index variable named after `index` (e.g. 'NDVI'). To 
         specify a custom name instead, you can supply e.g. 
         `custom_varname='custom_name'`. 
@@ -166,7 +166,7 @@ def calculate_indices(ds,
     index_func = index_dict.get(index)
     
     # If no index is provided or if no function is returned due to an 
-    # invalid option being provided, raise an error informing user to 
+    # invalid option being provided, raise an exception informing user to 
     # choose from the list of valid options
     if index is None:
         
@@ -181,15 +181,18 @@ def calculate_indices(ds,
                           "refer to the function documentation for a full "
                           "list of valid options for `index`")
 
-    # Rename bands to a consistent format if either 'Collection3'
-    # or 'Sentinel2' is specified by `source`
+    # Rename bands to a consistent format if depending on what collection
+    # is specified in `collection`. This allows the same index calculations
+    # to be applied to all collections. If no collection was provided, 
+    # raise an exception.
     if collection is None:
 
         raise ValueError("'No `collection` was provided. Please specify "
                          "either 'ga_landsat_collection_2', "
-                         "'ga_landsat_collection_3' \nor 'sentinel2' to "
-                         "ensure the function calculates indices using the "
-                         "correct spectral bands")
+                         "'ga_landsat_collection_3' \nor "
+                         "'ga_sentinel2_collection_1' to ensure the "
+                         "function calculates indices using the correct "
+                         "spectral bands")
     
     elif collection == 'ga_landsat_collection_3':
 
@@ -214,7 +217,7 @@ def calculate_indices(ds,
             a: b for a, b in bandnames_dict.items() if a in ds.variables
         }
 
-    elif collection == 'sentinel2':
+    elif collection == 'ga_sentinel2_collection_1':
 
         # Dictionary mapping full data names to simpler 'red' alias names
         bandnames_dict = {
@@ -247,7 +250,8 @@ def calculate_indices(ds,
         raise ValueError(f"'{collection}' is not a valid option for "
                           "`collection`. Please specify either \n"
                           "'ga_landsat_collection_2', "
-                          "'ga_landsat_collection_3' or 'sentinel2'")
+                          "'ga_landsat_collection_3' or "
+                          "'ga_sentinel2_collection_1'")
         
     # Apply index function after normalising to 0.0-1.0 by dividing by 10K
     try:

--- a/Scripts/dea_bandindices.py
+++ b/Scripts/dea_bandindices.py
@@ -15,9 +15,9 @@ Last modified: September 2019
 
 # Define custom functions
 def calculate_indices(ds,
-                      index='NDVI',
-                      custom_varname=None,
-                      collection='LandsatCollection3'):
+                      index=None,
+                      collection=None,
+                      custom_varname=None):
     """
     Takes an xarray dataset containing spectral bands, calculates one of
     a set of remote sensing indices, and adds the resulting array as a 
@@ -31,7 +31,7 @@ def calculate_indices(ds,
         A two-dimensional or multi-dimensional array with containing the 
         spectral bands required to calculate the index. These bands are 
         used as inputs to calculate the selected water index.
-    index : str, optional
+    index : str
         A string giving the name of the index to calculate:
         'NDVI' (Normalised Difference Vegation Index, Rouse 1973)
         'EVI' (Enhanced Vegetation Index, Huete 2002),
@@ -54,14 +54,8 @@ def calculate_indices(ds,
         'TCB' (Tasseled Cap Brightness, Crist 1985),
         'CMR' (Clay Minerals Ratio, Drury 1987),
         'FMR' (Ferrous Minerals Ratio, Segal 1982),
-        'IOR' (Iron Oxide Ratio, Segal 1982)
-        Defaults to 'NDVI'.        
-    custom_varname : str, optional
-        By default, the function will return the original dataset with 
-        a new index variable named after `index` (e.g. 'NDVI'). To 
-        specify a custom name instead, you can supply e.g. 
-        `custom_varname='custom_name'`. 
-    collection : str, optional
+        'IOR' (Iron Oxide Ratio, Segal 1982)   
+    collection : str
         An optional string that tells the function what dataset or data 
         collection is being used to calculate the index. This is 
         necessary because Landsat Collection 2, Landsat Collection 3 and
@@ -69,6 +63,11 @@ def calculate_indices(ds,
         spectra. Valid options are 'LandsatCollection2', 
         'LandsatCollection3' and 'Sentinel2'; defaults to 
         'LandsatCollection2'.
+    custom_varname : str, optional
+        By default, the function will return the original dataset with 
+        a new index variable named after `index` (e.g. 'NDVI'). To 
+        specify a custom name instead, you can supply e.g. 
+        `custom_varname='custom_name'`. 
         
     Returns
     -------
@@ -167,17 +166,33 @@ def calculate_indices(ds,
     # Select a water index function based on 'water_index'      
     index_func = index_dict.get(index)
     
-    # If no function is returned due to an invalid option being provided,
-    # raise an error informing user to choose from the list of valid options
-    if index_func is None:
-        raise ValueError(f'The selected index {index} is not one of the '
-                          'valid remote sensing index options. \nPlease '
-                          'see the function documentation for a full list '
-                          'of valid options for `index`')
+    # If no index is provided or if no function is returned due to an 
+    # invalid option being provided, raise an error informing user to 
+    # choose from the list of valid options
+    if index is None:
+        
+        raise ValueError(f"No remote sensing `index` was provided. Please "
+                          "refer to the function \ndocumentation for a full "
+                          "list of valid options for `index` (e.g. 'NDVI')")
+        
+    elif index_func is None:
+        
+        raise ValueError(f"The selected index '{index}' is not one of the "
+                          "valid remote sensing index options. \nPlease "
+                          "refer to the function documentation for a full "
+                          "list of valid options for `index`")
 
     # Rename bands to a consistent format if either 'Collection3'
     # or 'Sentinel2' is specified by `source`
-    if collection == 'LandsatCollection3':
+    if collection is None:
+
+        raise ValueError("'No `collection` was provided. Please specify "
+                         "either 'ga_landsat_collection_2', "
+                         "'ga_landsat_collection_3' \nor 'sentinel2' to "
+                         "ensure the function calculates indices using the "
+                         "correct spectral bands")
+    
+    elif collection == 'ga_landsat_collection_3':
 
         # Dictionary mapping full data names to simpler 'red' alias names
         bandnames_dict = {
@@ -185,7 +200,7 @@ def calculate_indices(ds,
             'nbart_red': 'red',
             'nbart_green': 'green',
             'nbart_blue': 'blue',
-            'bart_swir_1': 'swir1',
+            'nbart_swir_1': 'swir1',
             'nbart_swir_2': 'swir2',
             'nbar_red': 'red',
             'nbar_green': 'green',
@@ -200,7 +215,7 @@ def calculate_indices(ds,
             a: b for a, b in bandnames_dict.items() if a in ds.variables
         }
 
-    elif collection == 'Sentinel2':
+    elif collection == 'sentinel2':
 
         # Dictionary mapping full data names to simpler 'red' alias names
         bandnames_dict = {
@@ -223,7 +238,7 @@ def calculate_indices(ds,
             a: b for a, b in bandnames_dict.items() if a in ds.variables
         }
 
-    elif collection == 'LandsatCollection2':
+    elif collection == 'ga_landsat_collection_2':
 
         # Pass an empty dict as no bands need renaming
         bands_to_rename = {}
@@ -232,8 +247,8 @@ def calculate_indices(ds,
     else:
         raise ValueError(f"'{collection}' is not a valid option for "
                           "`collection`. Please specify either \n"
-                          "'LandsatCollection2', 'LandsatCollection3' or "
-                          "'Sentinel2'")
+                          "'ga_landsat_collection_2', "
+                          "'ga_landsat_collection_3' or 'sentinel2'")
         
     # Apply index function after normalising to 0.0-1.0 by dividing by 10K
     try:
@@ -246,9 +261,8 @@ def calculate_indices(ds,
                          f'is equivelent to `nbart_nir_1` for Sentinel 2)')
 
     # Add as a new variable in dataset
-    ds[custom_varname or index] = index_array
+    output_band_name = custom_varname if custom_varname else index
+    ds[output_band_name] = index_array
 
     # Return input dataset with added water index variable
     return ds
-
-

--- a/Scripts/dea_bandindices.py
+++ b/Scripts/dea_bandindices.py
@@ -1,0 +1,255 @@
+## dea_bandindices.py
+'''
+Description: This file contains a set of python functions for computing remote sensing band indices on Digital Earth Australia data.
+
+License: The code in this notebook is licensed under the Apache License, Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth Australia data is licensed under the Creative Commons by Attribution 4.0 license (https://creativecommons.org/licenses/by/4.0/).
+
+Contact: If you need assistance, please post a question on the Open Data Cube Slack channel (http://slack.opendatacube.org/) or on the GIS Stack Exchange (https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions here: https://gis.stackexchange.com/questions/tagged/open-data-cube). 
+
+If you would like to report an issue with this script, you can file one on Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
+
+Last modified: September 2019
+
+'''
+
+
+# Define custom functions
+def calculate_indices(ds,
+                      index='NDVI',
+                      custom_varname=None,
+                      source='LandsatCollection3'):
+    """
+    Takes an xarray dataset containing spectral bands, calculates one of
+    a set of remote sensing indices, and adds the resulting array as a 
+    new variable in the original dataset.  
+    
+    Last modified: September 2019
+    
+    Parameters
+    ----------  
+    ds : xarray Dataset
+        A two-dimensional or multi-dimensional array with containing the 
+        spectral bands required to calculate the index. These bands are 
+        used as inputs to calculate the selected water index.
+    index : str, optional
+        A string giving the name of the index to calculate:
+        'NDVI' (Normalised Difference Vegation Index, Rouse 1973)
+        'EVI' (Enhanced Vegetation Index, Huete 2002),
+        'LAI' (Leaf Area Index, Boegh 2002),
+        'SAVI' (Soil Adjusted Vegetation Index, Huete 1988),
+        'NDMI' (Normalised Difference Moisture Index, Gao 1996),
+        'NBR' (Normalised Burn Ratio, Lopez Garcia 1991),
+        'BAI' (Burn Area Index, Martin 1998),
+        'NDBI' (Normalised Difference Built-Up Index, Zha 2003),
+        'NDSI' (Normalised Difference Snow Index, Hall 1995),
+        'NDWI' (Normalised Difference Water Index, McFeeters 1996), 
+        'MNDWI' (Modified Normalised Difference Water Index, Xu 1996), 
+        'AWEI_ns (Automated Water Extraction Index,
+                  no shadows, Feyisa 2014)',
+        'AWEI_sh' (Automated Water Extraction Index,
+                   shadows, Feyisa 2014), 
+        'WI' (Water Index, Fisher 2016),
+        'TCW' (Tasseled Cap Wetness, Crist 1985),
+        'TCG' (Tasseled Cap Greeness, Crist 1985),
+        'TCB' (Tasseled Cap Brightness, Crist 1985),
+        'CMR' (Clay Minerals Ratio, Drury 1987),
+        'FMR' (Ferrous Minerals Ratio, Segal 1982),
+        'IOR' (Iron Oxide Ratio, Segal 1982)
+        Defaults to 'NDVI'.        
+    custom_varname : str, optional
+        By default, the function will return the original dataset with 
+        a new index variable named after `index` (e.g. 'NDVI'). To 
+        specify a custom name instead, you can supply e.g. 
+        `custom_varname='custom_name'`. 
+    collection : str, optional
+        An optional string that tells the function what dataset or data 
+        collection is being used to calculate the index. This is 
+        necessary because Landsat Collection 2, Landsat Collection 3 and
+        Sentinel 2 use different names for bands covering a similar 
+        spectra. Valid options are 'LandsatCollection2', 
+        'LandsatCollection3' and 'Sentinel2'; defaults to 
+        'LandsatCollection2'.
+        
+    Returns
+    -------
+    ds : xarray Dataset
+        The original xarray Dataset inputted into the function, with a 
+        new varible containing the remote sensing index as a DataArray.
+    """
+
+    # Dictionary containing remote sensing index band recipes
+    index_dict = {
+                  # Normalised Difference Vegation Index, Rouse 1973
+                  'NDVI': lambda ds: (ds.nir - ds.red) /
+                                     (ds.nir + ds.red),
+
+                  # Enhanced Vegetation Index, Huete 2002
+                  'EVI': lambda ds: ((2.5 * (ds.nir - ds.red)) /
+                                     (ds.nir + 6 * ds.red -
+                                      7.5 * ds.blue + 1)),
+
+                  # Leaf Area Index, Boegh 2002
+                  'LAI': lambda ds: (3.618 * ((2.5 * (ds.nir - ds.red)) /
+                                     (ds.nir + 6 * ds.red -
+                                      7.5 * ds.blue + 1)) - 0.118),
+
+                  # Soil Adjusted Vegetation Index, Huete 1988
+                  'SAVI': lambda ds: ((1.5 * (ds.nir - ds.red)) /
+                                      (ds.nir + ds.red + 0.5)),
+
+                  # Normalised Difference Moisture Index, Gao 1996
+                  'NDMI': lambda ds: (ds.nir - ds.swir1) /
+                                     (ds.nir + ds.swir1),
+
+                  # Normalised Burn Ratio, Lopez Garcia 1991
+                  'NBR': lambda ds: (ds.nir - ds.swir1) /
+                                    (ds.nir + ds.swir1),
+
+                  # Burn Area Index, Martin 1998
+                  'BAI': lambda ds: (1.0 / ((0.10 - ds.red) ** 2 +
+                                            (0.06 - ds.nir) ** 2)),
+
+                  # Normalised Difference Built-Up Index, Zha 2003
+                  'NDBI': lambda ds: (ds.swir1 - ds.nir) /
+                                     (ds.swir1 + ds.nir),
+
+                  # Normalised Difference Snow Index, Hall 1995
+                  'NDSI': lambda ds: (ds.green - ds.swir1) /
+                                     (ds.green + ds.swir1),
+
+                  # Normalised Difference Water Index, McFeeters 1996
+                  'NDWI': lambda ds: (ds.green - ds.nir) /
+                                     (ds.green + ds.nir),
+
+                  # Modified Normalised Difference Water Index, Xu 2006
+                  'MNDWI': lambda ds: (ds.green - ds.swir1) /
+                                      (ds.green + ds.swir1),
+
+                  # Automated Water Extraction Index (no shadows), Feyisa 2014
+                  'AWEI_ns': lambda ds: (4 * (ds.green - ds.swir1) -
+                                        (2.5 * ds.nir * + 2.75 * ds.swir2)),
+
+                  # Automated Water Extraction Index (shadows), Feyisa 2014
+                  'AWEI_sh': lambda ds: (ds.blue + 2.5 * ds.green -
+                                         1.5 * (ds.nir + ds.swir1) -
+                                         2.5 * ds.swir2),
+
+                  # Water Index, Fisher 2016
+                  'WI': lambda ds: (1.7204 + 171 * ds.green + 3 * ds.red -
+                                    70 * ds.nir - 45 * ds.swir1 -
+                                    71 * ds.swir2),
+
+                  # Tasseled Cap Wetness, Crist 1985
+                  'TCW': lambda ds: (0.0315 * ds.blue + 0.2021 * ds.green +
+                                     0.3102 * ds.red + 0.1594 * ds.nir +
+                                    -0.6806 * ds.swir1 + -0.6109 * ds.swir2),
+
+                  # Tasseled Cap Greeness, Crist 1985
+                  'TCG': lambda ds: (-0.1603 * ds.blue + -0.2819 * ds.green +
+                                     -0.4934 * ds.red + 0.7940 * ds.nir +
+                                     -0.0002 * ds.swir1 + -0.1446 * ds.swir2),
+
+                  # Tasseled Cap Brightness, Crist 1985
+                  'TCB': lambda ds: (0.2043 * ds.blue + 0.4158 * ds.green +
+                                     0.5524 * ds.red + 0.5741 * ds.nir +
+                                     0.3124 * ds.swir1 + -0.2303 * ds.swir2),
+
+                  # Clay Minerals Ratio, Drury 1987
+                  'CMR': lambda ds: (ds.swir1 / ds.swir2),
+
+                  # Ferrous Minerals Ratio, Segal 1982
+                  'FMR': lambda ds: (ds.swir1 / ds.nir),
+
+                  # Iron Oxide Ratio, Segal 1982
+                  'IOR': lambda ds: (ds.red / ds.blue)
+    }
+
+    try:
+
+        # Select a water index function based on 'water_index'
+        index_func = index_dict[index]
+
+        # Rename bands to a consistent format if either 'Collection3'
+        # or 'Sentinel2' is specified by `source`
+        if source == 'LandsatCollection3':
+
+            # Dictionary mapping full data names to simpler 'red' alias names
+            bandnames_dict = {
+                'nbart_nir': 'nir',
+                'nbart_red': 'red',
+                'nbart_green': 'green',
+                'nbart_blue': 'blue',
+                'bart_swir_1': 'swir1',
+                'nbart_swir_2': 'swir2',
+                'nbar_red': 'red',
+                'nbar_green': 'green',
+                'nbar_blue': 'blue',
+                'nbar_nir': 'nir',
+                'nbar_swir_1': 'swir1',
+                'nbar_swir_2': 'swir2'
+            }
+
+            # Rename bands in dataset to use simple names (e.g. 'red')
+            bands_to_rename = {
+                a: b for a, b in bandnames_dict.items() if a in ds.variables
+            }
+
+        elif source == 'Sentinel2':
+
+            # Dictionary mapping full data names to simpler 'red' alias names
+            bandnames_dict = {
+                'nbart_red': 'red',
+                'nbart_green': 'green',
+                'nbart_blue': 'blue',
+                'nbart_nir_1': 'nir',
+                'nbart_swir_2': 'swir1',
+                'nbart_swir_3': 'swir2',
+                'nbar_red': 'red',
+                'nbar_green': 'green',
+                'nbar_blue': 'blue',
+                'nbar_nir': 'nir',
+                'nbar_swir_2': 'swir1',
+                'nbar_swir_3': 'swir2'
+            }
+
+            # Rename bands in dataset to use simple names (e.g. 'red')
+            bands_to_rename = {
+                a: b for a, b in bandnames_dict.items() if a in ds.variables
+            }
+
+        elif source == 'LandsatCollection2':
+
+            # Pass an empty dict as no bands need renaming
+            bands_to_rename = {}
+
+        # Apply water index function to data and add to input dataset. If a
+        # custom name is supplied for the output water index variable, use it.
+        if custom_varname:
+
+            # Apply function after normalising to 0.0-1.0 by dividing by 10K
+            ds[custom_varname] = index_func(
+                ds.rename(bands_to_rename) / 10000.0)
+
+        else:
+
+            # Apply function after normalising to 0.0-1.0 by dividing by 10K
+            ds[index] = index_func(ds.rename(bands_to_rename) / 10000.0)
+
+        # Return input dataset with added water index variable
+        return ds
+
+    except AttributeError as e:
+        raise Exception(
+            f'The band equivelent to {str(e).split(" ")[-1]} is missing from '
+            f'the input dataset. \nPlease verify that all bands required to '
+            f'compute {index} are present in `ds`.'
+        )
+
+    except KeyError as e:
+        raise Exception(
+            f'The selected index {e} is not one of the valid remote sensing '
+            f'index options. \n Please see the function documentation for a '
+            'full list of valid options for `index`'
+        )
+        
+

--- a/Scripts/dea_bandindices.py
+++ b/Scripts/dea_bandindices.py
@@ -56,13 +56,12 @@ def calculate_indices(ds,
         'FMR' (Ferrous Minerals Ratio, Segal 1982),
         'IOR' (Iron Oxide Ratio, Segal 1982)   
     collection : str
-        An optional string that tells the function what dataset or data 
+        An string that tells the function what dataset or data 
         collection is being used to calculate the index. This is 
         necessary because Landsat Collection 2, Landsat Collection 3 and
         Sentinel 2 use different names for bands covering a similar 
-        spectra. Valid options are 'LandsatCollection2', 
-        'LandsatCollection3' and 'Sentinel2'; defaults to 
-        'LandsatCollection2'.
+        spectra. Valid options are 'ga_landsat_collection_2', 
+        'ga_landsat_collection_3' and 'sentinel2'.
     custom_varname : str, optional
         By default, the function will return the original dataset with 
         a new index variable named after `index` (e.g. 'NDVI'). To 

--- a/Scripts/dea_coastaltools.py
+++ b/Scripts/dea_coastaltools.py
@@ -1,0 +1,13 @@
+## dea_coastaltools.py
+'''
+Description: This file contains a set of python functions for conducting coastal analyses on Digital Earth Australia data.
+
+License: The code in this notebook is licensed under the Apache License, Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth Australia data is licensed under the Creative Commons by Attribution 4.0 license (https://creativecommons.org/licenses/by/4.0/).
+
+Contact: If you need assistance, please post a question on the Open Data Cube Slack channel (http://slack.opendatacube.org/) or on the GIS Stack Exchange (https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions here: https://gis.stackexchange.com/questions/tagged/open-data-cube). 
+
+If you would like to report an issue with this script, you can file one on Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
+
+Last modified: September 2019
+
+'''

--- a/Scripts/dea_datahandling.py
+++ b/Scripts/dea_datahandling.py
@@ -19,7 +19,7 @@ from datacube.storage import masking
 
 
 def load_ard(dc,
-             products=['ga_ls5t_ard_3', 'ga_ls7e_ard_3', 'ga_ls8c_ard_3'],
+             products=None,
              min_gooddata=0.0,
              fmask_gooddata=[1, 4, 5],
              mask_pixel_quality=True,
@@ -57,8 +57,8 @@ def load_ard(dc,
     dc : datacube Datacube object
         The Datacube to connect to, i.e. `dc = datacube.Datacube()`.
         This allows you to also use development datacubes if required.    
-    products : list, optional
-        An optional product name to load data from. Options are 
+    products : list
+        A list of product names to load data from. Valid options are 
         ['ga_ls5t_ard_3', 'ga_ls7e_ard_3', 'ga_ls8c_ard_3'] for Landsat,
         and ['s2a_ard_granule', 's2b_ard_granule'] for Sentinel 2
     min_gooddata : float, optional
@@ -108,15 +108,14 @@ def load_ard(dc,
         function until you explicitly run `ds.compute()`. If used in 
         conjuction with `dask.distributed.Client()` this will allow for 
         automatic parallel computation.
-    **dcload_kwargs: dict
+    **dcload_kwargs : 
         A set of keyword arguments to `dc.load` that define the 
         spatiotemporal query used to extract data. This can include `x`,
         `y`, `time`, `resolution`, `resampling`, `group_by`, `crs`
         etc, and can either be listed directly in the `load_ard` call 
         (e.g. `x=(150, 151)`), or by passing in a query kwarg 
         (e.g. `**query`). For a full list of possible options, see: 
-        https://datacube-core.readthedocs.io/en/latest/dev/api/generate/datacube.Datacube.load.html        
-        
+        https://datacube-core.readthedocs.io/en/latest/dev/api/generate/datacube.Datacube.load.html          
         
     Returns
     -------
@@ -126,6 +125,14 @@ def load_ard(dc,
         pixels.   
         
     '''
+    
+    # Verify that products were provided
+    if not products:
+        raise ValueError("Please provide a list of product names "
+                         "to load data from. Valid options are: \n"
+                         "['ga_ls5t_ard_3', 'ga_ls7e_ard_3', 'ga_ls8c_ard_3'] " 
+                         "for Landsat, and ['s2a_ard_granule', "
+                         "'s2b_ard_granule'] for Sentinel 2'")
 
     # If `measurements` are specified but do not include fmask, add it
     if (('measurements' in dcload_kwargs) and 

--- a/Scripts/dea_datahandling.py
+++ b/Scripts/dea_datahandling.py
@@ -30,13 +30,14 @@ def load_ard(dc,
              lazy_load=False,
              **dcload_kwargs):
     '''
-    Loads Landsat Collection 3 or Sentinel 2 ARD data for multiple 
-    sensors (i.e. ls5t, ls7e and ls8c for Landsat; s2a and s2b for 
-    Sentinel 2), and returns a single masked xarray dataset containing 
-    only observations that contain greater than a given proportion of 
-    good quality pixels. This can be used to extract clean time series 
-    of observations that are not affected by cloud, for example as an 
-    input to the `animated_timeseries` function from `dea_plotting`.
+    Loads Landsat Collection 3 or Sentinel 2 Definitive and Near Real 
+    Time data for multiple sensors (i.e. ls5t, ls7e and ls8c for 
+    Landsat; s2a and s2b for Sentinel 2), and returns a single masked 
+    xarray dataset containing only observations that contain greater 
+    than a given proportion of good quality pixels. This can be used 
+    to extract clean time series of observations that are not affected 
+    by cloud, for example as an input to the `animated_timeseries` 
+    function from `dea_plotting`.
     
     The proportion of good quality pixels is calculated by summing the 
     pixels flagged as good quality in `fmask`. By default non-cloudy or 
@@ -60,7 +61,9 @@ def load_ard(dc,
     products : list
         A list of product names to load data from. Valid options are 
         ['ga_ls5t_ard_3', 'ga_ls7e_ard_3', 'ga_ls8c_ard_3'] for Landsat,
-        and ['s2a_ard_granule', 's2b_ard_granule'] for Sentinel 2
+        ['s2a_ard_granule', 's2b_ard_granule'] for Sentinel 2 Definitive, 
+        and ['s2a_nrt_granule', 's2b_nrt_granule'] for Sentinel 2 Near 
+        Real Time.
     min_gooddata : float, optional
         An optional float giving the minimum percentage of good quality 
         pixels required for a satellite observation to be loaded. 
@@ -131,8 +134,10 @@ def load_ard(dc,
         raise ValueError("Please provide a list of product names "
                          "to load data from. Valid options are: \n"
                          "['ga_ls5t_ard_3', 'ga_ls7e_ard_3', 'ga_ls8c_ard_3'] " 
-                         "for Landsat, and ['s2a_ard_granule', "
-                         "'s2b_ard_granule'] for Sentinel 2'")
+                         "for Landsat, ['s2a_ard_granule', "
+                         "'s2b_ard_granule'] \nfor Sentinel 2 Definitive, or "
+                         "['s2a_nrt_granule', 's2b_nrt_granule'] for Sentinel 2 "
+                         "Near Real Time")
 
     # If `measurements` are specified but do not include fmask, add it
     if (('measurements' in dcload_kwargs) and 

--- a/Scripts/dea_datahandling.py
+++ b/Scripts/dea_datahandling.py
@@ -1,0 +1,224 @@
+## dea_datahandling.py
+'''
+Description: This file contains a set of python functions for handling Digital Earth Australia data.
+
+License: The code in this notebook is licensed under the Apache License, Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth Australia data is licensed under the Creative Commons by Attribution 4.0 license (https://creativecommons.org/licenses/by/4.0/).
+
+Contact: If you need assistance, please post a question on the Open Data Cube Slack channel (http://slack.opendatacube.org/) or on the GIS Stack Exchange (https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions here: https://gis.stackexchange.com/questions/tagged/open-data-cube). 
+
+If you would like to report an issue with this script, you can file one on Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
+
+Last modified: September 2019
+
+'''
+
+# Import required packages
+import numpy as np
+import xarray as xr
+from datacube.storage import masking
+
+
+def load_ard(dc,
+             query,
+             products=['ga_ls5t_ard_3', 'ga_ls7e_ard_3', 'ga_ls8c_ard_3'],
+             bands=['nbart_red', 'nbart_green', 'nbart_blue'],
+             min_gooddata=0.0,
+             fmask_gooddata=[1, 4, 5],
+             mask_pixel_quality=True,
+             mask_invalid_data=True,
+             ls7_slc_off=False,
+             product_metadata=False,
+             dask_chunks={'time': 1},
+             lazy_load=False):
+    '''
+    Loads Landsat Collection 3 or Sentinel 2 ARD data for multiple 
+    sensors (i.e. ls5t, ls7e and ls8c for Landsat; s2a and s2b for 
+    Sentinel 2), and returns a single masked xarray dataset containing 
+    only observations that contain greater than a given proportion of 
+    good quality pixels. This can be used to extract clean time series 
+    of observations that are not affected by cloud, for example as an 
+    input to the `animated_timeseries` function from `dea_plotting`.
+    
+    The proportion of good quality pixels is calculated by summing the 
+    pixels flagged as good quality in `fmask`. By default non-cloudy or 
+    shadowed land, snow and water pixels are treated as good quality, 
+    but this can be customised using the `fmask_gooddata` parameter.
+    
+    MEMORY ISSUES: For large data extractions, it can be advisable to 
+    set both `mask_pixel_quality=False` and `mask_invalid_data=False`. 
+    These operations coerce all numeric values to float64 when NaN 
+    values are inserted into the array, potentially causing your data 
+    to use 4x as much memory. Be aware that the resulting arrays will 
+    contain invalid -999 values which may affect future analyses.
+    
+    Last modified: September 2019
+    
+    Parameters
+    ----------  
+    dc : datacube Datacube object
+        The Datacube to connect to, i.e. `dc = datacube.Datacube()`.
+        This allows you to also use development datacubes if required.    
+    query : dict
+        A dict containing the query bounds. Can include lat/lon, time 
+        etc. If no `time` query is given, the function defaults to all 
+        timesteps available to all sensors (e.g. 1987-2018)
+    products : list, optional
+        An optional product name to load data from. Options are 
+        ['ga_ls5t_ard_3', 'ga_ls7e_ard_3', 'ga_ls8c_ard_3'] for Landsat,
+        and ['s2a_ard_granule', 's2b_ard_granule'] for Sentinel 2
+    bands : list, optional
+        An optional list of strings containing the bands to be loaded; 
+        options default to ['nbart_red', 'nbart_green', 'nbart_blue'].
+    min_gooddata : float, optional
+        An optional float giving the minimum percentage of good quality 
+        pixels required for a satellite observation to be loaded. 
+        Defaults to 0.0 which will return all observations regardless of
+        pixel quality (set to e.g. 0.99 to return only observations with
+        more than 99% good quality pixels).
+    fmask_gooddata : list, optional
+        An optional list of fmask values to treat as good quality 
+        observations in the above `min_gooddata` calculation. The 
+        default is `[1, 4, 5]` which will return non-cloudy or shadowed 
+        land, snow and water pixels Choose from: 
+        `{'0': 'nodata', '1': 'valid', '2': 'cloud', 
+          '3': 'shadow', '4': 'snow', '5': 'water'}`.
+    mask_pixel_quality : bool, optional
+        An optional boolean indicating whether to apply the good data 
+        mask to all observations that were not filtered out for having 
+        less good quality pixels than `min_gooddata`. E.g. if 
+        `min_gooddata=0.99`, the filtered observations may still contain 
+        up to 1% poor quality pixels. The default of False simply 
+        returns the resulting observations without masking out these 
+        pixels; True masks them out and sets them to NaN using the good 
+        data mask. This will convert numeric values to float64 which can 
+        cause memory issues, set to False to prevent this.
+    mask_invalid_data : bool, optional
+        An optional boolean indicating whether invalid -999 nodata 
+        values should be replaced with NaN. Defaults to True. This will 
+        convert all numeric values to float64 which can cause memory 
+        issues, set to False to prevent this.
+    ls7_slc_off : bool, optional
+        An optional boolean indicating whether to include data from 
+        after the Landsat 7 SLC failure (i.e. SLC-off). Defaults to 
+        False, which removes all Landsat 7 observations > May 31 2003. 
+    product_metadata : bool, optional
+        An optional boolean indicating whether to return the dataset 
+        with a `product` variable that gives the name of the product 
+        that each observation in the time series came from (e.g. 
+        'ga_ls5t_ard_3'). Defaults to False.
+    dask_chunks : dict, optional
+        An optional dictionary containing the coords and sizes you wish 
+        to create dask chunks over. Usually used in combination with 
+        `lazy_load=True` (see below). For example: 
+        `dask_chunks = {'x': 500, 'y': 500}`
+    lazy_load : boolean, optional
+        Setting this variable to True will delay the computation of the 
+        function until you explicitly run `ds.compute()`. If used in 
+        conjuction with `dask.distributed.Client()` this will allow for 
+        automatic parallel computation.
+        
+    Returns
+    -------
+    combined_ds : xarray Dataset
+        An xarray dataset containing only satellite observations that 
+        contains greater than `min_gooddata` proportion of good quality 
+        pixels.   
+        
+    '''
+
+    # If `bands` does not include fmask, add it
+    new_bands = set(bands)
+    new_bands.add('fmask')
+
+    # Create a list to hold data for each product
+    product_data = []
+
+    # Iterate through each requested product
+    for product in products:
+
+        try:
+
+            # Load data including fmask band
+            print(f'Loading {product} data')
+            ds = dc.load(product=f'{product}',
+                         dask_chunks=dask_chunks,
+                         measurements=new_bands,
+                         group_by='solar_day',
+                         **query)
+            
+            # Keep a record of the original number of observations
+            total_obs = len(ds.time)
+
+            # Remove Landsat 7 SLC-off observations if ls7_slc_off=False
+            if not ls7_slc_off and product == 'ga_ls7e_ard_3':
+                print('    Ignoring SLC-off observations for ls7')
+                ds = ds.sel(time=ds.time < np.datetime64('2003-05-30'))
+
+            # Identify all pixels not affected by cloud/shadow/invalid
+            good_quality = np.isin(ds.fmask,
+                                   test_elements=fmask_gooddata)
+            good_quality = ds.fmask.where(good_quality).notnull()
+
+            # Compute good data for each observation as % of total pixels
+            data_perc = good_quality.sum(axis=1).sum(
+                axis=1) / (good_quality.shape[1] * good_quality.shape[2])
+
+            # Filter by data_perc to drop low quality observations
+            filtered = ds.sel(time=data_perc >= min_gooddata)
+            print(f'    Filtering to {len(filtered.time)} '
+                  f'out of {total_obs} observations')
+
+            # Optionally apply pixel quality mask to all observations that
+            # were not dropped in previous step
+            if mask_pixel_quality & (len(filtered.time) > 0):
+                print('    Applying pixel quality mask')
+                filtered = filtered.where(good_quality)
+
+            # Optionally add satellite name
+            if product_metadata:
+                filtered['product'] = xr.DataArray(
+                    [product] * len(filtered.time), [('time', filtered.time)])
+
+            # If any data was returned, add result to list
+            if len(filtered.time) > 0:
+                product_data.append(filtered.drop('fmask'))
+
+        # If  AttributeError due to there being no `fmask` variable in
+        # the dataset, skip this product and move on to the next
+        except AttributeError:
+            print(f'    No data for {product}')
+
+        # If a KeyError occurs, raise an error to check that all
+        # requested bands are found in the product
+        except KeyError as e:
+            raise Exception(f'Band {e} does not exist in this product. '
+                            f'Verify that values passed to `bands` exist '
+                            f'in {products}')
+
+    # If any data was returned above, combine into one xarray
+    if (len(product_data) > 0):
+
+        # Concatenate results and sort by time
+        print(f'Combining and sorting data')
+        combined_ds = xr.concat(product_data, dim='time').sortby('time')
+
+        # Optionally filter to replace no data values with nans
+        if mask_invalid_data:
+            print('    Masking out invalid values')
+            combined_ds = masking.mask_invalid_data(combined_ds)
+
+        # If `lazy_load` is True, return data as a dask array without
+        # actually loading it in
+        if lazy_load:
+            print(f'    Returning {len(combined_ds.time)} observations'
+                  ' as a dask array')
+            return combined_ds
+
+        else:
+            print(f'    Returning {len(combined_ds.time)} observations ')
+            return combined_ds.compute()
+
+    # If no data was returned:
+    else:
+        print('No data returned for query')
+        return None

--- a/Scripts/dea_plotting.py
+++ b/Scripts/dea_plotting.py
@@ -1,0 +1,299 @@
+## dea_plotting.py
+'''
+Description: This file contains a set of python functions for plotting Digital Earth Australia data.
+
+License: The code in this notebook is licensed under the Apache License, Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth Australia data is licensed under the Creative Commons by Attribution 4.0 license (https://creativecommons.org/licenses/by/4.0/).
+
+Contact: If you need assistance, please post a question on the Open Data Cube Slack channel (http://slack.opendatacube.org/) or on the GIS Stack Exchange (https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions here: https://gis.stackexchange.com/questions/tagged/open-data-cube). 
+
+If you would like to report an issue with this script, you can file one on Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
+
+Last modified: September 2019
+
+'''
+
+# Import required packages
+import folium  
+import math
+import numpy as np
+from pyproj import Proj, transform
+
+
+def rgb(ds,
+        bands=['nbart_red', 'nbart_green', 'nbart_blue'],
+        index=None,
+        index_dim='time',
+        robust=True,
+        percentile_stretch=None,
+        col_wrap=4,
+        size=6,
+        aspect=None,
+        savefig_path=None,
+        savefig_kwargs={},
+        **kwargs):
+    
+    """
+    Takes an xarray dataset and plots RGB images using three imagery 
+    bands (e.g ['nbart_red', 'nbart_green', 'nbart_blue']). The `index` 
+    parameter allows easily selecting individual or multiple images for 
+    RGB plotting. Images can be saved to file by specifying an output 
+    path using `savefig_path`.
+    
+    This function was designed to work as an easier-to-use wrapper 
+    around xarray's `.plot.imshow()` functionality.
+    
+    Last modified: August 2019
+    
+    Parameters
+    ----------  
+    ds : xarray Dataset
+        A two-dimensional or multi-dimensional array to plot as an RGB 
+        image. If the array has more than two dimensions (e.g. multiple 
+        observations along a 'time' dimension), either use `index` to 
+        select one (`index=0`) or multiple observations 
+        (`index=[0, 1]`), or create a custom faceted plot using e.g. 
+        `col="time"`.       
+    bands : list of strings, optional
+        A list of three strings giving the band names to plot. Defaults 
+        to '['nbart_red', 'nbart_green', 'nbart_blue']'.
+    index : integer or list of integers, optional
+        `index` can be used to select one (`index=0`) or multiple 
+        observations (`index=[0, 1]`) from the input dataset for 
+        plotting. If multiple images are requested these will be plotted
+        as a faceted plot.
+    index_dim : string, optional
+        The dimension along which observations should be plotted if 
+        multiple observations are requested using `index`. Defaults to 
+        `time`.
+    robust : bool, optional
+        Produces an enhanced image where the colormap range is computed 
+        with 2nd and 98th percentiles instead of the extreme values. 
+        Defaults to True.
+    percentile_stretch : tuple of floats
+        An tuple of two floats (between 0.00 and 1.00) that can be used 
+        to clip the colormap range to manually specified percentiles to 
+        get more control over the brightness and contrast of the image. 
+        The default is None; '(0.02, 0.98)' is equivelent to 
+        `robust=True`. If this parameter is used, `robust` will have no 
+        effect.
+    col_wrap : integer, optional
+        The number of columns allowed in faceted plots. Defaults to 4.
+    size : integer, optional
+        The height (in inches) of each plot. Defaults to 6.
+    aspect : integer, optional
+        Aspect ratio of each facet in the plot, so that aspect * size 
+        gives width of each facet in inches. Defaults to None, which 
+        will calculate the aspect based on the x and y dimensions of 
+        the input data.
+    savefig_path : string, optional
+        Path to export image file for the RGB plot. Defaults to None, 
+        which does not export an image file.
+    savefig_kwargs : dict, optional
+        A dict of keyword arguments to pass to 
+        `matplotlib.pyplot.savefig` when exporting an image file. For 
+        all available options, see: 
+        https://matplotlib.org/api/_as_gen/matplotlib.pyplot.savefig.html        
+    **kwargs : optional
+        Additional keyword arguments to pass to `xarray.plot.imshow()`. 
+        For more options, see:
+        http://xarray.pydata.org/en/stable/generated/xarray.plot.imshow.html  
+        
+    Returns
+    -------
+    An RGB plot of one or multiple observations, and optionally an image
+    file written to file.
+    
+    """
+
+    # Compute image aspect based on first index
+    if not aspect:
+        data_shape = ds.isel(**{index_dim: 0}).to_array().shape
+        aspect = data_shape[2] / data_shape[1]
+
+    # If no value is supplied for `index` (the default), plot using default 
+    # values and arguments passed via `**kwargs`
+    if index is None:
+
+        if len(ds.dims) > 2 and 'col' not in kwargs:
+            raise Exception(
+                f'The input dataset `ds` has more than two dimensions: '
+                '{list(ds.dims.keys())}. Please select a single observation '
+                'using e.g. `index=0`, or enable faceted plotting by adding '
+                'the arguments e.g. `col="time", col_wrap=4` to the function ' 
+                'call'
+            )
+
+        # Select bands and convert to DataArray
+        da = ds[bands].to_array()
+
+        # If percentile_stretch == True, clip plotting to percentile vmin, vmax
+        if percentile_stretch:
+            vmin, vmax = da.compute().quantile(percentile_stretch).values
+            kwargs.update({'vmin': vmin, 'vmax': vmax})
+
+        img = da.plot.imshow(robust=robust,
+                             col_wrap=col_wrap,
+                             size=size,
+                             aspect=aspect,
+                             **kwargs)
+
+    # If values provided for `index`, extract corresponding observations and 
+    # plot as either single image or facet plot
+    else:
+
+        # If a float is supplied instead of an integer index, raise exception
+        if isinstance(index, float):
+            raise Exception(
+                f'Please supply `index` as either an integer or a list of '
+                'integers'
+            )
+
+        # If col argument is supplied as well as `index`, raise exception
+        if 'col' in kwargs:
+            raise Exception(
+                f'Cannot supply both `index` and `col`; please remove one and '
+                'try again'
+            )
+
+        # Convert index to generic type list so that number of indices supplied
+        # can be computed
+        index = index if isinstance(index, list) else [index]
+
+        # Select bands and observations and convert to DataArray
+        da = ds[bands].isel(**{index_dim: index}).to_array()
+
+        # If percentile_stretch == True, clip plotting to percentile vmin, vmax
+        if percentile_stretch:
+            vmin, vmax = da.compute().quantile(percentile_stretch).values
+            kwargs.update({'vmin': vmin, 'vmax': vmax})
+
+        # If multiple index values are supplied, plot as a faceted plot
+        if len(index) > 1:
+
+            img = da.plot.imshow(robust=robust,
+                                 col=index_dim,
+                                 col_wrap=col_wrap,
+                                 size=size,
+                                 aspect=aspect,
+                                 **kwargs)
+
+        # If only one index is supplied, squeeze out index_dim and plot as a 
+        # single panel
+        else:
+
+            img = da.squeeze(dim=index_dim).plot.imshow(robust=robust,
+                                                        size=size,
+                                                        aspect=aspect,
+                                                        **kwargs)
+
+    # If an export path is provided, save image to file. Individual and 
+    # faceted plots have a different API (figure vs fig) so we get around this 
+    # using a try statement:
+    if savefig_path:
+
+        print(f'Exporting image to {savefig_path}')
+
+        try:
+            img.fig.savefig(savefig_path, **savefig_kwargs)
+        except:
+            img.figure.savefig(savefig_path, **savefig_kwargs)
+
+            
+def display_map(x, y, crs='EPSG:4326', margin=-0.5, zoom_bias=0):
+    """ 
+    Given a set of x and y coordinates, this function generates an 
+    interactive map with a bounded rectangle overlayed on Google Maps 
+    imagery.        
+    
+    Last modified: September 2019
+    
+    Modified from function written by Otto Wagner available here: 
+    https://github.com/ceos-seo/data_cube_utilities/tree/master/data_cube_utilities
+    
+    Parameters
+    ----------  
+    x : (float, float)
+        A tuple of x coordinates in (min, max) format. 
+    y : (float, float)
+        A tuple of y coordinates in (min, max) format.
+    crs : string, optional
+        A string giving the EPSG CRS code of the supplied coordinates. 
+        The default is 'EPSG:4326'.
+    margin : float
+        A numeric value giving the number of degrees lat-long to pad 
+        the edges of the rectangular overlay polygon. A larger value 
+        results more space between the edge of the plot and the sides 
+        of the polygon. Defaults to -0.5.
+    zoom_bias : float or int
+        A numeric value allowing you to increase or decrease the zoom 
+        level by one step. Defaults to 0; set to greater than 0 to zoom 
+        in, and less than 0 to zoom out.
+        
+    Returns
+    -------
+    folium.Map : A map centered on the supplied coordinate bounds. A 
+    rectangle is drawn on this map detailing the perimeter of the x, y 
+    bounds.  A zoom level is calculated such that the resulting 
+    viewport is the closest it can possibly get to the centered 
+    bounding rectangle without clipping it. 
+    """
+
+    # Convert each corner coordinates to lat-lon
+    all_x = (x[0], x[1], x[0], x[1])
+    all_y = (y[0], y[0], y[1], y[1])
+    all_longitude, all_latitude = transform(Proj(init=crs),
+                                            Proj(init='EPSG:4326'), 
+                                            all_x, all_y)
+
+    # Calculate zoom level based on coordinates
+    lat_zoom_level = _degree_to_zoom_level(min(all_latitude),
+                                           max(all_latitude),
+                                           margin=margin) + zoom_bias
+    lon_zoom_level = _degree_to_zoom_level(min(all_longitude), 
+                                           max(all_longitude), 
+                                           margin=margin) + zoom_bias
+    zoom_level = min(lat_zoom_level, lon_zoom_level)
+
+    # Identify centre point for plotting
+    center = [np.mean(all_latitude), np.mean(all_longitude)]
+
+    # Create map
+    interactive_map = folium.Map(
+        location=center,
+        zoom_start=zoom_level,
+        tiles="http://mt1.google.com/vt/lyrs=y&z={z}&x={x}&y={y}",
+        attr="Google")
+
+    # Create bounding box coordinates to overlay on map
+    line_segments = [(all_latitude[0], all_longitude[0]),
+                     (all_latitude[1], all_longitude[1]),
+                     (all_latitude[3], all_longitude[3]),
+                     (all_latitude[2], all_longitude[2]),
+                     (all_latitude[0], all_longitude[0])]
+
+    # Add bounding box as an overlay
+    interactive_map.add_child(
+        folium.features.PolyLine(locations=line_segments,
+                                 color='red',
+                                 opacity=0.8))
+
+    # Add clickable lat-lon popup box
+    interactive_map.add_child(folium.features.LatLngPopup())
+
+    return interactive_map
+
+
+def _degree_to_zoom_level(l1, l2, margin=0.0):
+    
+    """
+    Helper function to set zoom level for `display_map`
+    """
+    
+    degree = abs(l1 - l2) * (1 + margin)
+    zoom_level_int = 0
+    if degree != 0:
+        zoom_level_float = math.log(360 / degree) / math.log(2)
+        zoom_level_int = int(zoom_level_float)
+    else:
+        zoom_level_int = 18
+    return zoom_level_int

--- a/Scripts/dea_spatialtools.py
+++ b/Scripts/dea_spatialtools.py
@@ -1,0 +1,13 @@
+## dea_spatialtools.py
+'''
+Description: This file contains a set of python functions for conducting spatial analyses on Digital Earth Australia data.
+
+License: The code in this notebook is licensed under the Apache License, Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth Australia data is licensed under the Creative Commons by Attribution 4.0 license (https://creativecommons.org/licenses/by/4.0/).
+
+Contact: If you need assistance, please post a question on the Open Data Cube Slack channel (http://slack.opendatacube.org/) or on the GIS Stack Exchange (https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions here: https://gis.stackexchange.com/questions/tagged/open-data-cube). 
+
+If you would like to report an issue with this script, you can file one on Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
+
+Last modified: September 2019
+
+'''


### PR DESCRIPTION
### Proposed changes
Committing first set of scripts for the `develop` branch, including the following functions:
- `load_ard`: a replacement for `load_clearlandsat` and `load_clearsentinel2` which combines multiple sensors, masks out cloud and optionally drops cloudy scenes. Should make it possible to load both Collection 3 Landsat and Sentinel 2 with the one function
- `rgb`: for RGB plotting
- `display_map`: for previewing a query before you load data
- `calculate_indices`: updated to include more indices, and to work on both Sentinel 2 and Landsat Collection 3

### Checklist
- [x] ~~Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)~~
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] ~~Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)~~
- [x] ~~Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated~~
- [x] ~~Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)~~
- [x] ~~If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with~~


