### PR TITLE
Add additional suggested urban indices to calculate_indices

### DIFF
--- a/Scripts/dea_bandindices.py
+++ b/Scripts/dea_bandindices.py
@@ -76,7 +76,7 @@ def calculate_indices(ds,
         `custom_varname='custom_name'`. Defaults to None, which uses
         `index` to name the variable. 
     normalise : bool, optional
-        Some coefficient-based indices (e.g. WI, BAEI, AWEI_sh, AWEI_sh, 
+        Some coefficient-based indices (e.g. WI, BAEI, AWEI_nh, AWEI_sh, 
         TCW, TCG, TCB) produce different results if surface reflectance 
         values are not scaled between 0.0 and 1.0 prior to calculating 
         the index. Set `normalise=True` to scale values first by 


### PR DESCRIPTION
Added additional urban indices recommended by Peter Tan to `calculate_indices`
Added a warning in the function to inform user if they are using a coefficient formula on un-normalized surface reflectance values (e.g. 0-10,000 vs 0.0-1.0), as this may produce weird results for certain indices