### PR TITLE
Adding temporary info to `develop` readme pages

### DIFF
--- a/DEA_datasets/README.rst
+++ b/DEA_datasets/README.rst
@@ -1,4 +1,14 @@
 DEA datasets
 ============
 
-These notebooks are designed to introduce you to the datasets available through Digital Earth Australia.
+These notebooks are designed to introduce the datasets available through Digital Earth Australia.
+
+These notebooks should include:
+
+* Background information about the product and why it is necessary (this can be harvested from DEA's Content Management Interface: https://cmi.ga.gov.au/node)
+
+* A simple example of how to load the data
+
+* Information on any special features of the data (e.g. important attributes or bands) and any important steps that must be considered to conduct valid analyses (e.g. PQ fusers, group_by etc)
+
+* Where possible, aim at beginner to intermediate users who may not be familar with technical remote sensing terminology

--- a/Frequently_used_code/README.rst
+++ b/Frequently_used_code/README.rst
@@ -2,3 +2,11 @@ Frequently used code
 ====================
 
 These notebooks feature code-snippets that are applicable to many analyses.
+
+These notebooks should:
+
+* Be as short as possible
+
+* Include simple, reproducible examples of commonly used tasks
+
+* The end goal is to create a `recipe book` of useful code that users can copy-paste into their analyses

--- a/Real_world_examples/README.rst
+++ b/Real_world_examples/README.rst
@@ -2,3 +2,9 @@ Real-world examples
 ===================
 
 These notebooks feature demonstrations of how Digital Earth Australia can be used to address various problems.
+
+These notebooks should:
+
+* Be based around a specific scientific/management/business goal/problem, and with a useful end product/output (e.g. framed around a use case/narrative)
+
+* Present more complex workflows often involving multiple analysis steps and/or multiple datasets (ideally using techniques available in `Frequently_used_code` notebooks)


### PR DESCRIPTION
Adding some temporary information to the readme pages for each directory on `develop` to guide the creation of notebooks during the `dea-notebook` refresh