### PR TITLE
Fixes issue #377

### DIFF
--- a/10_Scripts/DEADataHandling.py
+++ b/10_Scripts/DEADataHandling.py
@@ -493,9 +493,9 @@ def load_clearlandsat(dc, query, sensors=('ls5', 'ls7', 'ls8'), product='nbart',
             # from automatically casting to float64, using 2x the memory
             # We also need to manually reset attributes due to a possible
             # bug in recent xarray version
-            combined_ds = (combined_ds.astype(np.float32)
-                           .assign_attrs(crs=combined_ds.crs))
-            combined_ds = masking.mask_invalid_data(combined_ds)    
+            sensor_ds = (sensor_ds.astype(np.float32)
+                           .assign_attrs(crs=sensor_ds.crs))
+            sensor_ds = masking.mask_invalid_data(sensor_ds)    
         
         return sensor_ds
     


### PR DESCRIPTION
_Note: checklist below only relevant if committing to the [`develop`](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop) branch:_

### Proposed changes
Changes variable name in the case on single sensor for the load_clearlandsat() function.

### Closes issues (optional)
- Closes Issue #377

### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


