### PR TITLE
Fix indent error in `dea_datahandling`

### DIFF
--- a/Scripts/dea_datahandling.py
+++ b/Scripts/dea_datahandling.py
@@ -460,8 +460,8 @@ def download_unzip(url,
     if remove_zip:        
         os.remove(zip_name)
 
-  
-  def wofs_fuser(dest, src):
+
+def wofs_fuser(dest, src):
     """
     Fuse two WOfS water measurements represented as `ndarray`s.
     


### PR DESCRIPTION
The previous addition of `wofs_fuser` broke `dea_datahandling` because of an incorrect indent. My fault for not testing this!