### PR TITLE
Update to notebook template after refresh sprint

### DIFF
--- a/DEA_notebooks_template.ipynb
+++ b/DEA_notebooks_template.ipynb
@@ -6,12 +6,18 @@
    "source": [
     "### General advice (delete this cell before submitting for review)\n",
     "> - When choosing a location for your analysis, **select an area that has data on both the `NCI` and `DEA Sandbox`** to allow your code to be run on both environments. \n",
-    "For example, you can check this for Landsat using the [DEA Explorer](https://explorer.sandbox.dea.ga.gov.au/ga_ls5t_ard_3/1990) (use the drop-down menu to view all products). \n",
+    "For example, you can check this for Landsat using the [DEA Explorer](https://explorer.sandbox.dea.ga.gov.au/ga_ls5t_ard_3/1990) (use the drop-down menu to view all products).\n",
     "As of September 2019, the `DEA Sandbox` has a single year of continental Landsat data for 2015-16, and the full 1987-onward time-series for three locations (Perth WA, Brisbane QLD, and western NSW).\n",
-    "> - When writing in Markdown cells, start each sentence is on a **new line**.\n",
+    "> - When adding **Products used**, embed the hyperlink to that specific product on the DEA Explorer using the `[text link](product url)` syntax.\n",
+    "> - When writing in Markdown cells, start each sentence on a **new line**.\n",
     "This makes it easy to see changes through git commits.\n",
     "> - Use Australian English in markdown cells and code comments.\n",
     "> - Use the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. To make sure all code in the notebook is consistent, you can use the `jupyterlab_code_formatter` tool: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended). This will reformat the code in the cell to a consistent style.\n",
+    "> - For additional guidance, refer to the style conventions and layouts in approved `develop` branch notebooks. \n",
+    "Examples include\n",
+    "    - [Frequently_used_code/Using_load_ard.ipynb](./Frequently_used_code/Using_load_ard.ipynb)\n",
+    "    - [Real_world_examples/Coastal_erosion.ipynb](./Real_world_examples/Coastal_erosion.ipynb)\n",
+    "    - [Scripts/dea_datahandling.py](./Scripts/dea_datahandling.py)\n",
     "> - In the final notebook cell, include a set of relevant tags which are used to build the DEA User Guide's [Tag Index](https://docs.dea.ga.gov.au/genindex.html). \n",
     "Use all lower-case (unless the tag is an acronym), separate words with spaces (unless it is the name of an imported module), and [re-use existing tags](https://github.com/GeoscienceAustralia/dea-notebooks/wiki/List-of-tags).\n",
     "Ensure the tags cell below is in `Raw` format, rather than `Markdown` or `Code`.\n"
@@ -253,6 +259,13 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.8"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/DEA_notebooks_template.ipynb
+++ b/DEA_notebooks_template.ipynb
@@ -4,32 +4,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Descriptive title that follows notebook filename"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Notebook currently compatible with the `NCI`|`DEA Sandbox` environment only**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### General advice (delete this cell before submitting for review)\n",
-    "\n",
-    "- When choosing a location for your analysis, **select an area that has data on both the `NCI` and `DEA Sandbox`** to allow your code to be run on both environments. \n",
+    "> - When choosing a location for your analysis, **select an area that has data on both the `NCI` and `DEA Sandbox`** to allow your code to be run on both environments. \n",
     "For example, you can check this for Landsat using the [DEA Explorer](https://explorer.sandbox.dea.ga.gov.au/ga_ls5t_ard_3/1990) (use the drop-down menu to view all products). \n",
     "As of September 2019, the `DEA Sandbox` has a single year of continental Landsat data for 2015-16, and the full 1987-onward time-series for three locations (Perth WA, Brisbane QLD, and western NSW).\n",
-    "- When writing in Markdown cells, start each sentence is on a **new line**.\n",
+    "> - When writing in Markdown cells, start each sentence is on a **new line**.\n",
     "This makes it easy to see changes through git commits.\n",
-    "- Use Australian English in markdown cells and code comments.\n",
-    "- Use the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. To make sure all code in the notebook is consistent, you can use the `jupyterlab_code_formatter` tool: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended). This will reformat the code in the cell to a consistent style.\n",
-    "- In the final notebook cell, include a set of relevant tags which are used to build the DEA User Guide's [Tag Index](https://docs.dea.ga.gov.au/genindex.html). \n",
-    "Use all lower-case, seperate words with spaces, and where possible re-use existing tags.\n",
+    "> - Use Australian English in markdown cells and code comments.\n",
+    "> - Use the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. To make sure all code in the notebook is consistent, you can use the `jupyterlab_code_formatter` tool: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended). This will reformat the code in the cell to a consistent style.\n",
+    "> - In the final notebook cell, include a set of relevant tags which are used to build the DEA User Guide's [Tag Index](https://docs.dea.ga.gov.au/genindex.html). \n",
+    "Use all lower-case (unless the tag is an acronym), separate words with spaces (unless it is the name of an imported module), and [re-use existing tags](https://github.com/GeoscienceAustralia/dea-notebooks/wiki/List-of-tags).\n",
     "Ensure the tags cell below is in `Raw` format, rather than `Markdown` or `Code`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Descriptive title that follows notebook filename\n",
+    "* **Compatability:** Notebook currently compatible with the `NCI`|`DEA Sandbox` environment only\n",
+    "* **Products used:** \n",
+    "[`s2a_ard_granule`](https://explorer.sandbox.dea.ga.gov.au/s2a_ard_granule), \n",
+    "[`s2b_ard_granule`](https://explorer.sandbox.dea.ga.gov.au/s2b_ard_granule),\n",
+    "[`ga_ls5t_ard_3`](https://explorer.sandbox.dea.ga.gov.au/ga_ls5t_ard_3),\n",
+    "[`ga_ls7e_ard_3`](https://explorer.sandbox.dea.ga.gov.au/ga_ls7e_ard_3),\n",
+    "[`ga_ls8c_ard_3`](https://explorer.sandbox.dea.ga.gov.au/ga_ls8c_ard_3)\n",
+    "* **Special requirements:** An _optional_ description of any special requirements, e.g. If running on the [NCI](https://nci.org.au/), ensure that `module load otps` is run prior to launching this notebook"
    ]
   },
   {
@@ -47,17 +47,11 @@
    "metadata": {},
    "source": [
     "### Description\n",
-    "A _compulsory_ description of the notebook, including a brief overview of how Digital Earth Australia helps to address the problem set out above, and a run-down of the tools/methods being demonstrated below.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Technical details\n",
-    "* **Products used:** `product_name`, `product_name`, `product_name`\n",
-    "* **Analyses used:** NDWI water index, geomedian compositing, pixel drill\n",
-    "* **Special requirements:** An _optional_ description of any special requirements, e.g. If running on the [NCI](https://nci.org.au/), ensure that `module load otps` is run prior to launching this notebook"
+    "A _compulsory_ description of the notebook, including a brief overview of how Digital Earth Australia helps to address the problem set out above.\n",
+    "It can be good to include a run-down of the tools/methods that will be demonstrated in the notebook:\n",
+    "1. First we do this\n",
+    "2. Then we do this\n",
+    "3. Finally we do this\n"
    ]
   },
   {
@@ -79,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +86,8 @@
     "import sys\n",
     "import xarray as xr\n",
     "\n",
-    "sys.path.append(\"../Scripts\")"
+    "sys.path.append('../Scripts')\n",
+    "from dea_plotting import rgb\n"
    ]
   },
   {
@@ -100,16 +95,17 @@
    "metadata": {},
    "source": [
     "### Connect to the datacube\n",
-    "Give your datacube app a unique name that is consistent with the purpose of the notebook."
+    "Give your datacube app a unique name. \n",
+    "Ideally, this will be the same as the notebook file name."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dc = datacube.Datacube(app=\"DEA_notebooks_template\")"
+    "dc = datacube.Datacube(app='DEA_notebooks_template')"
    ]
   },
   {
@@ -125,12 +121,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "param_name_1 = \"example_value\"\n",
-    "param_name_2 = \"example_value\""
+    "param_name_1 = 'example_value'\n",
+    "param_name_2 = 'example_value'"
    ]
   },
   {
@@ -138,19 +134,16 @@
    "metadata": {},
    "source": [
     "## Heading 1\n",
-    "Use headings to break up key steps/stages of the notebook."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Use markdown text for detailed, descriptive text explaining what the code below does and why it is needed."
+    "Use headings to break up key steps/stages of the notebook.\n",
+    "\n",
+    "Use markdown text for detailed, descriptive text explaining what the code below does and why it is needed.\n",
+    "\n",
+    "> **Note:** Use this markdown format (sparingly) to draw particular attention to an important point or caveat"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,24 +204,16 @@
     "**Contact:** If you need assistance, please post a question on the [Open Data Cube Slack channel](http://slack.opendatacube.org/) or on the [GIS Stack Exchange](https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions [here](https://gis.stackexchange.com/questions/tagged/open-data-cube)).\n",
     "If you would like to report an issue with this notebook, you can file one on [Github](https://github.com/GeoscienceAustralia/dea-notebooks).\n",
     "\n",
-    "**Last modified:** September 2019\n",
+    "**Last modified:** October 2019\n",
     "\n",
     "**Compatible `datacube` version:** "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.7+43.gc873f3ea\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(datacube.__version__)"
    ]
@@ -247,7 +232,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "**Tags**: :index:`sandbox_compatible`, :index:`nci_compatible`, :index:`template`, :index:`dc.load`, :index:`plotting`, :index:`landsat8`, :index:`pixeldrill`"
+    "**Tags**: :index:`NCI compatible`, :index:`sandbox compatible`, :index:`sentinel 2`, :index:` landsat 8`, :index:`dea_plotting`, :index:`rgb`, :index:`NDVI`, :index:`time series`"
    ]
   }
  ],


### PR DESCRIPTION
I've made some minor updates to the notebook template based on my experiences using it over the past few weeks. These are completely optional, I just wanted to start the discussion with a pull request so we have something to work from!

1. I've moved the Guidance cell to the very top of the notebook so it's easier to delete
2. I've got rid of the `Analyses used` bullet point, as I found this a bit redundant. Details on analyses included in the notebook could instead be included as a numbered list in the `Description` section (like most notebooks already do).
3. In addition to the above, moved the `Products used` and `Special requirements` bullet points right up to the top next to the `Compatible with...` statement. That way all the important stuff is at the top.
4. Updated the tags to reflect the guide here (https://github.com/GeoscienceAustralia/dea-notebooks/wiki/List-of-tags)

Feel free to edit this branch directly or comment with anything you think should be updated! 

If we settle on any changes, I'm happy to go through the new notebooks and update them to match the revisions before we swap `develop` to `master`.
