### PR TITLE
fix confusing typo in exporting geotiffs notebook

### DIFF
--- a/Frequently_used_code/Exporting_geotiffs.ipynb
+++ b/Frequently_used_code/Exporting_geotiffs.ipynb
@@ -42,7 +42,7 @@
    "source": [
     "### Technical details\n",
     "* **Products used:** [`ga_ls8c_ard_3`](https://explorer.sandbox.dea.ga.gov.au/ga_ls8c_ard_3/)\n",
-    "* **Analyses used:** `datacube.helpers.write_geotiff` `dea_spatialtools.array_to_geotiff`"
+    "* **Analyses used:** `datacube.helpers.write_geotiff` `dea_datahandling.array_to_geotiff`"
    ]
   },
   {
@@ -338,7 +338,7 @@
     "**Contact:** If you need assistance, please post a question on the [Open Data Cube Slack channel](http://slack.opendatacube.org/) or on the [GIS Stack Exchange](https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions [here](https://gis.stackexchange.com/questions/tagged/open-data-cube)).\n",
     "If you would like to report an issue with this notebook, you can file one on [Github](https://github.com/GeoscienceAustralia/dea-notebooks).\n",
     "\n",
-    "**Last modified:** September 2019\n",
+    "**Last modified:** October 2019\n",
     "\n",
     "**Compatible `datacube` version:** "
    ]
@@ -394,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Existing notebook has a typo where it refers to the `dea_spatialtools` script. I've changed it to `dea_datahandling` which is where the function `array_to_geotiff` lives.

