### PR TITLE
Minor style updates and fixes for readthedocs issues

### DIFF
--- a/DEA_notebooks_template.ipynb
+++ b/DEA_notebooks_template.ipynb
@@ -5,20 +5,33 @@
    "metadata": {},
    "source": [
     "### General advice (delete this cell before submitting for review)\n",
-    "> - When choosing a location for your analysis, **select an area that has data on both the `NCI` and `DEA Sandbox`** to allow your code to be run on both environments. \n",
+    "\n",
+    "> * When choosing a location for your analysis, **select an area that has data on both the NCI and DEA Sandbox** to allow your code to be run on both environments. \n",
     "For example, you can check this for Landsat using the [DEA Explorer](https://explorer.sandbox.dea.ga.gov.au/ga_ls5t_ard_3/1990) (use the drop-down menu to view all products).\n",
     "As of September 2019, the `DEA Sandbox` has a single year of continental Landsat data for 2015-16, and the full 1987-onward time-series for three locations (Perth WA, Brisbane QLD, and western NSW).\n",
-    "> - When adding **Products used**, embed the hyperlink to that specific product on the DEA Explorer using the `[text link](product url)` syntax.\n",
-    "> - When writing in Markdown cells, start each sentence on a **new line**.\n",
+    "> * When adding **Products used**, embed the hyperlink to that specific product on the DEA Explorer using the `[product_name](product url)` syntax.\n",
+    "> * When writing in Markdown cells, start each sentence on a **new line**.\n",
     "This makes it easy to see changes through git commits.\n",
-    "> - Use Australian English in markdown cells and code comments.\n",
-    "> - Use the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. To make sure all code in the notebook is consistent, you can use the `jupyterlab_code_formatter` tool: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended). This will reformat the code in the cell to a consistent style.\n",
-    "> - For additional guidance, refer to the style conventions and layouts in approved `develop` branch notebooks. \n",
+    "> * Use Australian English in markdown cells and code comments.\n",
+    "> * Check the [known issues](https://github.com/GeoscienceAustralia/dea-docs/wiki/Known-issues) for formatting regarding the conversion of notebooks to DEA docs using Sphinx.\n",
+    "Things to be aware of:\n",
+    "    * Sphinx is highly sensitive to bulleted lists:\n",
+    "        * Ensure that there is an empty line between any preceding text and the list\n",
+    "        * Only use the `*` bullet (`-` is not recognised)\n",
+    "        * Sublists must be indented by 4 spaces\n",
+    "    * Two kinds of formatting cannot be used simultaneously:\n",
+    "        * Hyperlinked code: \\[\\`code_format\\`](hyperlink) fails\n",
+    "        * Bolded code: \\*\\*\\`code_format\\`\\*\\* fails\n",
+    "    * Headers must appear in heirachical order (`#`, `##`, `###`, `####`) and there can only be one title (`#`).\n",
+    "> * Use the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. To make sure all code in the notebook is consistent, you can use the `jupyterlab_code_formatter` tool: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended). This will reformat the code in the cell to a consistent style.\n",
+    "> * For additional guidance, refer to the style conventions and layouts in approved `develop` branch notebooks. \n",
     "Examples include\n",
-    "    - [Frequently_used_code/Using_load_ard.ipynb](./Frequently_used_code/Using_load_ard.ipynb)\n",
-    "    - [Real_world_examples/Coastal_erosion.ipynb](./Real_world_examples/Coastal_erosion.ipynb)\n",
-    "    - [Scripts/dea_datahandling.py](./Scripts/dea_datahandling.py)\n",
-    "> - In the final notebook cell, include a set of relevant tags which are used to build the DEA User Guide's [Tag Index](https://docs.dea.ga.gov.au/genindex.html). \n",
+    "    * [Frequently_used_code/Using_load_ard.ipynb](./Frequently_used_code/Using_load_ard.ipynb)\n",
+    "    * [Real_world_examples/Coastal_erosion.ipynb](./Real_world_examples/Coastal_erosion.ipynb)\n",
+    "    * [Scripts/dea_datahandling.py](./Scripts/dea_datahandling.py)\n",
+    "> * The DEA Image placed in the title cell will display as long as the notebook is contained in one of the standard directories.\n",
+    "It does not work in the highest level directory (hence why it doesn't display in the original template notebook).\n",
+    "> * In the final notebook cell, include a set of relevant tags which are used to build the DEA User Guide's [Tag Index](https://docs.dea.ga.gov.au/genindex.html). \n",
     "Use all lower-case (unless the tag is an acronym), separate words with spaces (unless it is the name of an imported module), and [re-use existing tags](https://github.com/GeoscienceAustralia/dea-notebooks/wiki/List-of-tags).\n",
     "Ensure the tags cell below is in `Raw` format, rather than `Markdown` or `Code`.\n"
    ]
@@ -245,7 +258,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "**Tags**: :index:`NCI compatible`, :index:`sandbox compatible`, :index:`sentinel 2`, :index:` landsat 8`, :index:`dea_plotting`, :index:`rgb`, :index:`NDVI`, :index:`time series`"
+    "**Tags**: :index:`NCI compatible`, :index:`sandbox compatible`, :index:`sentinel 2`, :index:`landsat 8`, :index:`dea_plotting`, :index:`rgb`, :index:`NDVI`, :index:`time series`"
    ]
   }
  ],

--- a/DEA_notebooks_template.ipynb
+++ b/DEA_notebooks_template.ipynb
@@ -27,22 +27,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Descriptive title that follows notebook filename\n",
+    "# Descriptive title that follows notebook filename <img align=\"right\" src=\"../Supplementary_data/dea_logo.jpg\">\n",
+    "\n",
     "* **Compatability:** Notebook currently compatible with the `NCI`|`DEA Sandbox` environment only\n",
     "* **Products used:** \n",
-    "[`s2a_ard_granule`](https://explorer.sandbox.dea.ga.gov.au/s2a_ard_granule), \n",
-    "[`s2b_ard_granule`](https://explorer.sandbox.dea.ga.gov.au/s2b_ard_granule),\n",
-    "[`ga_ls5t_ard_3`](https://explorer.sandbox.dea.ga.gov.au/ga_ls5t_ard_3),\n",
-    "[`ga_ls7e_ard_3`](https://explorer.sandbox.dea.ga.gov.au/ga_ls7e_ard_3),\n",
-    "[`ga_ls8c_ard_3`](https://explorer.sandbox.dea.ga.gov.au/ga_ls8c_ard_3)\n",
-    "* **Special requirements:** An _optional_ description of any special requirements, e.g. If running on the [NCI](https://nci.org.au/), ensure that `module load otps` is run prior to launching this notebook"
+    "[s2a_ard_granule](https://explorer.sandbox.dea.ga.gov.au/s2a_ard_granule), \n",
+    "[s2b_ard_granule](https://explorer.sandbox.dea.ga.gov.au/s2b_ard_granule),\n",
+    "[ga_ls5t_ard_3](https://explorer.sandbox.dea.ga.gov.au/ga_ls5t_ard_3),\n",
+    "[ga_ls7e_ard_3](https://explorer.sandbox.dea.ga.gov.au/ga_ls7e_ard_3),\n",
+    "[ga_ls8c_ard_3](https://explorer.sandbox.dea.ga.gov.au/ga_ls8c_ard_3)\n",
+    "* **Special requirements:** An _optional_ description of any special requirements, e.g. If running on the [NCI](https://nci.org.au/), ensure that `module load otps` is run prior to launching this notebook\n",
+    "* **Prerequisites:** An _optional_ list of any notebooks that should be run or content that should be understood prior to launching this notebook\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Background\n",
+    "## Background\n",
     "An *optional* overview of the scientific, economic or environmental management issue or challenge being addressed by Digital Earth Australia. \n",
     "For `Beginners_Guide` or `Frequently_Used_Code` notebooks, this may include information about why the particular technique or approach is useful or required. \n",
     "If you need to cite a scientific paper or link to a website, use a persistent DOI link if possible and link in-text (e.g. [Dhu et al. 2017](https://doi.org/10.1080/20964471.2017.1402490))."
@@ -52,12 +54,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Description\n",
+    "## Description\n",
     "A _compulsory_ description of the notebook, including a brief overview of how Digital Earth Australia helps to address the problem set out above.\n",
     "It can be good to include a run-down of the tools/methods that will be demonstrated in the notebook:\n",
+    "\n",
     "1. First we do this\n",
     "2. Then we do this\n",
-    "3. Finally we do this\n"
+    "3. Finally we do this\n",
+    "\n",
+    "***"
    ]
   },
   {
@@ -65,6 +70,7 @@
    "metadata": {},
    "source": [
     "## Getting started\n",
+    "\n",
     "Provide any particular instructions that the user might need, e.g. To run this analysis, run all the cells in the notebook, starting with the \"Load packages\" cell. "
    ]
   },
@@ -73,6 +79,8 @@
    "metadata": {},
    "source": [
     "### Load packages\n",
+    "Import Python packages that are used for the analysis.\n",
+    "\n",
     "Use standard import commands; some are shown below. \n",
     "Begin with any `iPython` magic commands, followed by standard Python packages, then any additional functionality you need from the `Scripts` directory."
    ]
@@ -101,8 +109,9 @@
    "metadata": {},
    "source": [
     "### Connect to the datacube\n",
-    "Give your datacube app a unique name. \n",
-    "Ideally, this will be the same as the notebook file name."
+    "\n",
+    "Connect to the datacube so we can access DEA data.\n",
+    "The `app` parameter is a unique name for the analysis which is based on the notebook file name."
    ]
   },
   {
@@ -121,6 +130,7 @@
     "### Analysis parameters\n",
     "\n",
     "An *optional* section to inform the user of any parameters they'll need to configure to run the notebook:\n",
+    "\n",
     "* `param_name_1`: Simple description (e.g. `example_value`). Advice about appropriate values to choose for this parameter.\n",
     "* `param_name_2`: Simple description (e.g. `example_value`). Advice about appropriate values to choose for this parameter.\n"
    ]
@@ -197,13 +207,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Additional information"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "***\n",
+    "\n",
+    "## Additional information\n",
+    "\n",
     "**License:** The code in this notebook is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). \n",
     "Digital Earth Australia data is licensed under the [Creative Commons by Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) license.\n",
     "\n",
@@ -212,7 +219,7 @@
     "\n",
     "**Last modified:** October 2019\n",
     "\n",
-    "**Compatible `datacube` version:** "
+    "**Compatible datacube version:** "
    ]
   },
   {


### PR DESCRIPTION
### Proposed changes
Made some minor style updates for compatability with the new beginners guide notebooks.

Also fixed up some issues that are affecting correct rendering on the readthedocs page (headings order, spaces between bullet points and text, multiple formatting types).

Finally, re-wrote some of the instructional code so that it makes sense even if the text is left in the notebook rather than removed (as happens reasonably regularly.

### Checklist (replace `[ ]` with `[x]` to check off)
- [x] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [x] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [x] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


