### PR TITLE
Add largest_region function to dea_spatialtools

### DIFF
--- a/Scripts/dea_spatialtools.py
+++ b/Scripts/dea_spatialtools.py
@@ -491,7 +491,7 @@ def largest_region(bool_array, **kwargs):
         
     '''
     
-    # First, break boolean array into unique, descrete regions/blobs
+    # First, break boolean array into unique, discrete regions/blobs
     blobs_labels = label(bool_array, background=0, **kwargs)
     
     # Count the size of each blob, excluding the background class (0)


### PR DESCRIPTION
### Proposed changes
Have added a new function to identify the largest connected area of pixels within an xarray dataset. This can be used for e.g. selecting the largest waterbody in an array, for example for separating ocean pixels from inland pixels.


