### PR TITLE
Add link to wiki getting started guides to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,10 +50,12 @@ The ``dea-notebooks`` repository uses 'branches' to manage individuals' notebook
 
 * `Working branches <https://github.com/GeoscienceAustralia/dea-notebooks/branches>`_: All other branches in the repository are working spaces for users of ``dea-notebooks``. They have a unique name (typically named after the user, e.g. ``ClaireK``, ``BexDunn``). The notebooks on these branches can be works-in-progress and do not need to be pretty or complete. By using a working branch, it is easy to use scripts and algorithms from ``dea-notebooks`` in your own work, or share and collaborate on a working version of a notebook or code.
 
-Getting started with DEA notebooks
+Getting started with DEA Notebooks
 ----------------------------------
 
-There are two main options for interacting with ``dea-notebooks``:
+To get started with using ``dea-notebooks``, `visit the DEA Notebooks Wiki page <https://github.com/GeoscienceAustralia/dea-notebooks/wiki>`_. This page includes guides for getting started on both the `DEA Sandbox <https://github.com/GeoscienceAustralia/dea-notebooks/wiki#getting-started-on-the-dea-sandbox>`_ and `NCI environments <https://github.com/GeoscienceAustralia/dea-notebooks/wiki#getting-started-on-the-nci>`_.
+
+Once you're set up, there are two main options for interacting with ``dea-notebooks`` and contributing back to the repository:
 
 * **DEA notebooks using git**: Git is a version-control software designed to help track changes to files and collaborate with multiple users on a project. Using ``git`` is the recommended workflow for working with ``dea-notebooks`` as it makes it easy to stay up to date with the latest versions of functions and code, and makes it impossible to lose your work. 
 


### PR DESCRIPTION
Added link to wiki to `develop` readme to make it easier for users to find guides for getting started with the Sandbox/NCI.