### PR TITLE
Add missing Imagery_on_web_map.ipynb notebook to index

### DIFF
--- a/Frequently_used_code/README.rst
+++ b/Frequently_used_code/README.rst
@@ -15,6 +15,7 @@ A recipe book of simple code examples demonstrating how to perform common geospa
    Exporting_NetCDFs.ipynb
    Geomedian_composites.ipynb
    Image_segmentation.ipynb
+   Imagery_on_web_map.ipynb
    Integrating_external_data.ipynb
    Masking_data.ipynb
    Opening_GeoTIFFs_NetCDFs.ipynb


### PR DESCRIPTION
Kirill's notebook was missing from the index and not rendered in the docs
Imagery_on_web_map.ipynb
