### PR TITLE
Fix image segmentation notebook

### DIFF
--- a/Frequently_used_code/Image_segmentation.ipynb
+++ b/Frequently_used_code/Image_segmentation.ipynb
@@ -357,8 +357,8 @@
     "# Name of the segmented .kea file that will be output \n",
     "segmented_kea_file = 'meanNDVI_segmented.kea'\n",
     "\n",
-    "# Name of the segmented GeoTIFF attributed with the zonal mean of input file\n",
-    "segments_zonal_mean = 'segments_zonal_mean_shepherdSeg.tif'\n"
+    "# Name of the segmented .kea file attributed with the zonal mean of input file\n",
+    "segments_zonal_mean = 'segments_zonal_mean_shepherdSeg.kea'\n"
    ]
   },
   {


### PR DESCRIPTION
### Proposed changes

Fix error in `Image_segmentation.ipynb` one of the output files was named with `.tif` but was populated by `rsgislib` with KEA format, `rsgislib` would then fail to open the file it produced to add statistics and overviews to it. Changing file name to end on `.kea` fixes the problem. 

This was tested in the sandbox using custom docker with `rsgislib` installed, this docker is not yet available to sandbox users.