### PR TITLE
Use datacube.utils.geom tools in transform_geojson_wgs_to_epsg

### DIFF
--- a/Scripts/dea_spatialtools.py
+++ b/Scripts/dea_spatialtools.py
@@ -42,6 +42,8 @@ from skimage.measure import label
 from skimage.measure import find_contours
 from shapely.geometry import LineString, MultiLineString, shape
 from datacube.helpers import write_geotiff
+from datacube.utils.geometry import CRS, Geometry
+
 
 def xr_vectorize(da, 
                  attribute_col='attribute', 
@@ -703,7 +705,6 @@ def transform_geojson_wgs_to_epsg(geojson, EPSG):
         a geojson dictionary containing a 'coordinates' key, in the desired CRS
 
     """
-    from datacube.utils.geometry import CRS, Geometry
     gg = Geometry(geojson['geometry'], CRS('epsg:4326'))
     gg = gg.to_crs(CRS(f'epsg:{EPSG}'))
     return gg.__geo_interface__

--- a/Scripts/dea_spatialtools.py
+++ b/Scripts/dea_spatialtools.py
@@ -31,8 +31,6 @@ Last modified: February 2020
 '''
 
 # Import required packages
-import osr
-import ogr
 import collections
 import numpy as np
 import xarray as xr
@@ -689,36 +687,23 @@ def largest_region(bool_array, **kwargs):
 
 
 def transform_geojson_wgs_to_epsg(geojson, EPSG):
-    
     """
     Takes a geojson dictionary and converts it from WGS84 (EPSG:4326) to desired EPSG
-    
+
     Parameters
     ----------
     geojson: dict
         a geojson dictionary containing a 'geometry' key, in WGS84 coordinates
     EPSG: int
         numeric code for the EPSG coordinate referecnce system to transform into
-        
+
     Returns
     -------
     transformed_geojson: dict
         a geojson dictionary containing a 'coordinates' key, in the desired CRS
-        
+
     """
-
-    geojson_geom = geojson['geometry']
-    polygon = ogr.CreateGeometryFromJson(str(geojson_geom))
-
-    source = osr.SpatialReference()
-    source.ImportFromEPSG(4326)
-
-    target = osr.SpatialReference()
-    target.ImportFromEPSG(EPSG)
-
-    transform = osr.CoordinateTransformation(source, target)
-    polygon.Transform(transform)
-    
-    transformed_geojson = eval(polygon.ExportToJson())
-
-    return transformed_geojson
+    from datacube.utils.geometry import CRS, Geometry
+    gg = Geometry(geojson['geometry'], CRS('epsg:4326'))
+    gg = gg.to_crs(CRS(f'epsg:{EPSG}'))
+    return gg.__geo_interface__


### PR DESCRIPTION
### Proposed changes

Call to `datacube.utils.geometry` routines for transforming geometries from one projection to another.

### Closes issues (optional)
- Closes Issue #522 

### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with
