### PR TITLE
Restore lazy load to load_ard

### DIFF
--- a/Scripts/dea_datahandling.py
+++ b/Scripts/dea_datahandling.py
@@ -265,8 +265,19 @@ def load_ard(dc,
             # Load data including fmask band
             print(f'Loading {product} data')
             try:
-                ds = dc.load(product=f'{product}',
-                             **dcload_kwargs)
+                
+                # If dask_chunks is specified, load data using query
+                if lazy_load:
+                    ds = dc.load(product=f'{product}',
+                                 **dcload_kwargs)
+                
+                # If no dask chunks specified, add this param so that
+                # we can lazy load data before filtering by good data
+                else:
+                    ds = dc.load(product=f'{product}',
+                                 dask_chunks={},
+                                 **dcload_kwargs) 
+                
             except KeyError as e:
                 raise ValueError(f'Band {e} does not exist in this product. '
                                  f'Verify all requested `measurements` exist '


### PR DESCRIPTION
### Proposed changes
This update restores lazy loading functionality to `load_ard`, so that datasets are filtered/observations dropped based on `min_gooddata` before the data is loaded into memory, not after.

This greatly reduces the load time of any notebook that uses the `min_gooddata` parameter to load non-cloudy observations.

### Closes issues (optional)
- Closes Issue #520 
