### PR TITLE
Fix possible bug in subpixel_contours

### DIFF
--- a/Scripts/dea_spatialtools.py
+++ b/Scripts/dea_spatialtools.py
@@ -488,7 +488,7 @@ def subpixel_contours(da,
     # Convert output contours to a geopandas.GeoDataFrame
     contours_gdf = gpd.GeoDataFrame(data=attribute_df, 
                                     geometry=list(contour_arrays.values()),
-                                    crs={'init': str(crs)})   
+                                    crs=crs)   
 
     # Define affine and use to convert array coords to geographic coords.
     # We need to add 0.5 x pixel size to the x and y to obtain the centre 

--- a/Scripts/dea_spatialtools.py
+++ b/Scripts/dea_spatialtools.py
@@ -440,7 +440,8 @@ def subpixel_contours(da,
                             "6886890.0)`")
 
     # If z_values is supplied is not a list, convert to list:
-    z_values = z_values if isinstance(z_values, list) else [z_values]
+    z_values = z_values if (isinstance(z_values, list) or 
+                            isinstance(z_values, np.ndarray)) else [z_values]
 
     # Test number of dimensions in supplied data array
     if len(da.shape) == 2:


### PR DESCRIPTION
`crs` is defined in the function a few lines above as a crs object.
Later on it then takes this as a string and tries to feed it into the `{'init:(crs)}` format, but this errors because the crs is not just an EPSG number.
