### PR TITLE
Fix #539 by simplifying multiple z-value, single array mode in `subpixel_contours`

### DIFF
--- a/Scripts/dea_spatialtools.py
+++ b/Scripts/dea_spatialtools.py
@@ -26,7 +26,7 @@ Functions included:
     largest_region
     transform_geojson_wgs_to_epsg
 
-Last modified: February 2020
+Last modified: April 2020
 
 '''
 
@@ -447,11 +447,9 @@ def subpixel_contours(da,
 
         print(f'Operating in multiple z-value, single array mode')
         dim = 'z_value'
-        da = da.expand_dims({'z_value': z_values})
-
         contour_arrays = {str(i)[0:10]: 
-                          contours_to_multiline(da_i, i, min_vertices) 
-                          for i, da_i in da.groupby(dim)}        
+                          contours_to_multiline(da, i, min_vertices) 
+                          for i in z_values}    
 
     else:
 


### PR DESCRIPTION
### Proposed changes
Issue #539 occurred when `subpixel_contours` was applied to an xarray dataset loaded using `xr.open_rasterio`. The problem is related to the current overly complex way `multiple z-value, single array mode` is implemented in `subpixel_contours`:

- Currently, a 2D array is converted to 3D by adding a new `z_value` dimension. This needlessly duplicates the data, and causes strange interactions with `scikit-image` as found in #539.
- This fix simplifies the approach to simply iterate through the list of `z_values`, rather than expand any dimensions. This fixes the  `ValueError: buffer source array is read-only` error.

### Closes issues (optional)
- Closes Issue #539

