### PR TITLE
Fix dask dashboard link

### DIFF
--- a/Scripts/dea_dask.py
+++ b/Scripts/dea_dask.py
@@ -33,6 +33,8 @@ from datacube.utils.dask import start_local_dask
 from datacube.utils.rio import configure_s3_access
 
 _HAVE_PROXY = bool(find_spec('jupyter_server_proxy'))
+_IS_AWS = ('AWS_ACCESS_KEY_ID' in os.environ or
+           'AWS_DEFAULT_REGION' in os.environ)
 
 
 def create_local_dask_cluster(spare_mem='3Gb', display_client=True):
@@ -69,7 +71,7 @@ def create_local_dask_cluster(spare_mem='3Gb', display_client=True):
     # Start up a local cluster
     client = start_local_dask(mem_safety_margin=spare_mem)
 
-    if 'AWS_ACCESS_KEY_ID' in os.environ:
+    if _IS_AWS:
         # Configure GDAL for s3 access
         configure_s3_access(aws_unsigned=True,
                             client=client)

--- a/Scripts/dea_dask.py
+++ b/Scripts/dea_dask.py
@@ -1,25 +1,25 @@
 ## dea_dask.py
 '''
-Description: A set of python functions for simplifying the creation of a 
+Description: A set of python functions for simplifying the creation of a
 local dask cluster.
 
 License: The code in this notebook is licensed under the Apache License,
-Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth 
-Australia data is licensed under the Creative Commons by Attribution 4.0 
+Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth
+Australia data is licensed under the Creative Commons by Attribution 4.0
 license (https://creativecommons.org/licenses/by/4.0/).
 
-Contact: If you need assistance, please post a question on the Open Data 
-Cube Slack channel (http://slack.opendatacube.org/) or on the GIS Stack 
-Exchange (https://gis.stackexchange.com/questions/ask?tags=open-data-cube) 
-using the `open-data-cube` tag (you can view previously asked questions 
-here: https://gis.stackexchange.com/questions/tagged/open-data-cube). 
+Contact: If you need assistance, please post a question on the Open Data
+Cube Slack channel (http://slack.opendatacube.org/) or on the GIS Stack
+Exchange (https://gis.stackexchange.com/questions/ask?tags=open-data-cube)
+using the `open-data-cube` tag (you can view previously asked questions
+here: https://gis.stackexchange.com/questions/tagged/open-data-cube).
 
-If you would like to report an issue with this script, you can file one on 
+If you would like to report an issue with this script, you can file one on
 Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 
 Functions included:
     create_local_dask_cluster
-    
+
 Last modified: March 2020
 
 '''
@@ -35,17 +35,17 @@ def create_local_dask_cluster(spare_mem='3Gb', display_client=True):
     """
     Using the datacube utils function `start_local_dask`, generate
     a local dask cluster. Automatically detects if on AWS or NCI.
-    
+
     Example use :
-        
+
         import sys
         sys.path.append("../Scripts")
         from dea_dask import create_local_dask_cluster
-        
+
         create_local_dask_cluster(spare_mem='4Gb')
-    
+
     Parameters
-    ----------  
+    ----------
     spare_mem : String, optional
         The amount of memory, in Gb, to leave for the notebook to run.
         This memory will not be used by the cluster. e.g '3Gb'
@@ -53,35 +53,35 @@ def create_local_dask_cluster(spare_mem='3Gb', display_client=True):
         An optional boolean indicating whether to display a summary of
         the dask client, including a link to monitor progress of the
         analysis. Set to False to hide this display.
-    
+
     """
 
     if 'AWS_ACCESS_KEY_ID' in os.environ:
-        
+
         # Close previous client if any
         client = locals().get('client', None)
         if client is not None:
             client.close()
             del client
-        
+
         # Configure dashboard link to go over proxy
         dask.config.set({"distributed.dashboard.link":
                      os.environ.get('JUPYTERHUB_SERVICE_PREFIX', '/')+"proxy/{port}/status"})
-                
+
         # Start up a local cluster
         client = start_local_dask(mem_safety_margin=spare_mem)
 
         ## Configure GDAL for s3 access
-        configure_s3_access(aws_unsigned=True,  
+        configure_s3_access(aws_unsigned=True,
                             client=client);
-    else:        
-        
+    else:
+
         # Close previous client if any
         client = locals().get('client', None)
         if client is not None:
             client.close()
             del client
-            
+
         # Start up a local cluster on NCI
         client = start_local_dask(mem_safety_margin=spare_mem)
 


### PR DESCRIPTION
### Proposed changes
- Enable dashboard link via proxy if `jupyter-server-proxy` is install regardless of the `AWS_`  environment variables. This should also be useful for people on NCI who access via ssh port forwarding.
- White space cleanups
- Remove `client` deletion from `locals()` this is always no-op in a function

### Closes issues (optional)
- Closes Issue #554 

### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


