### PR TITLE
Add exception handling for `subpixel_contours` when some or all contours fail 

### DIFF
--- a/Scripts/dea_spatialtools.py
+++ b/Scripts/dea_spatialtools.py
@@ -315,7 +315,8 @@ def subpixel_contours(da,
                       attribute_df=None,
                       output_path=None,
                       min_vertices=2,
-                      dim='time'):
+                      dim='time',
+                      errors='ignore'):
     
     """
     Uses `skimage.measure.find_contours` to extract multiple z-value 
@@ -330,7 +331,7 @@ def subpixel_contours(da,
     `attribute_df` parameter can be used to pass custom attributes 
     to the output contour features.
     
-    Last modified: April 2020
+    Last modified: June 2020
     
     Parameters
     ----------  
@@ -380,6 +381,11 @@ def subpixel_contours(da,
         operating in 'single z-value, multiple arrays' mode. The default
         is 'time', which extracts contours for each array along the time
         dimension.
+    errors : string, optional
+        If 'raise', then any failed contours will raise an exception.
+        If 'ignore' (the default), a list of failed contours will be 
+        printed. If no contours are returned, an exception will always 
+        be raised.
         
     Returns
     -------
@@ -497,7 +503,16 @@ def subpixel_contours(da,
     empty_contours = contours_gdf.geometry.is_empty
     failed = ', '.join(map(str, contours_gdf[empty_contours][dim].to_list()))
     contours_gdf = contours_gdf[~empty_contours]
-    if empty_contours.any():  
+    
+    # Raise exception if no data is returned, or if any contours fail 
+    # when `errors='raise'. Otherwise, print failed contours
+    if empty_contours.all():
+        raise Exception("Failed to generate any valid contours; verify that "
+                        "values passed to `z_values` are valid and present "
+                        "in `da`")
+    elif empty_contours.any() and errors == 'raise':  
+        raise Exception(f'Failed to generate contours: {failed}')
+    elif empty_contours.any() and errors == 'ignore':  
         print(f'Failed to generate contours: {failed}')
 
     # If asked to write out file, test if geojson or shapefile

--- a/Scripts/dea_spatialtools.py
+++ b/Scripts/dea_spatialtools.py
@@ -383,8 +383,8 @@ def subpixel_contours(da,
         dimension.
     errors : string, optional
         If 'raise', then any failed contours will raise an exception.
-        If 'ignore' (the default), a list of failed contours will be 
-        printed. If no contours are returned, an exception will always 
+        If 'ignore' (the default), a list of failed contours will be
+        printed. If no contours are returned, an exception will always
         be raised.
         
     Returns
@@ -503,16 +503,16 @@ def subpixel_contours(da,
     empty_contours = contours_gdf.geometry.is_empty
     failed = ', '.join(map(str, contours_gdf[empty_contours][dim].to_list()))
     contours_gdf = contours_gdf[~empty_contours]
-    
-    # Raise exception if no data is returned, or if any contours fail 
+
+    # Raise exception if no data is returned, or if any contours fail
     # when `errors='raise'. Otherwise, print failed contours
     if empty_contours.all():
         raise Exception("Failed to generate any valid contours; verify that "
                         "values passed to `z_values` are valid and present "
                         "in `da`")
-    elif empty_contours.any() and errors == 'raise':  
+    elif empty_contours.any() and errors == 'raise':
         raise Exception(f'Failed to generate contours: {failed}')
-    elif empty_contours.any() and errors == 'ignore':  
+    elif empty_contours.any() and errors == 'ignore':
         print(f'Failed to generate contours: {failed}')
 
     # If asked to write out file, test if geojson or shapefile


### PR DESCRIPTION
### Proposed changes
Issue #590 gives an example where `subpixel_contours` does not raise an exception when no valid contours are returned, despite an exception being raised when a `output_path` is supplied. 

This PR updates the function to do two things:

1. Always raise an exception if _all_ contours fail
2. _Optionally_ raise an exception if _any_ contours fail

Option 2 is controlled by a new `errors` parameter, which either prints failed contours to the console, or raises an error:

```
    errors : string, optional
        If 'raise', then any failed contours will raise an exception.
        If 'ignore' (the default), a list of failed contours will be 
        printed. If no contours are returned, an exception will always 
        be raised.
```

### Closes issues (optional)
- Closes Issue #590