### PR TITLE
Retire DEA Notebooks refresh header text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,5 @@
 .. Notebook Gallery Instructions:
 
-**9 January 2020 update:** *This repository was recently upgraded to a new directory structure and set of improved and easier to use Jupyter notebooks and scripts. To access an archive of the previous version of the repository,* `visit the master_archive branch <https://github.com/GeoscienceAustralia/dea-notebooks/tree/master_archive>`_. *Please note that notebooks and code in the* ``master_archive`` *branch are no longer maintained or supported.*
-
-
 .. image:: Supplementary_data/dea_logo_wide.jpg
   :width: 900
   :alt: Digital Earth Australia logo


### PR DESCRIPTION
### Proposed changes
It's now been six months since the DEA Notebooks refresh, I think this text at the top of the repository readme file can be removed
