### PR TITLE
Added ENSO influence waterbodies notebook

### DIFF
--- a/Scientific_workflows/DEAWaterbodies/DEAWaterbodiesToolkit/ENSOInfluence.ipynb
+++ b/Scientific_workflows/DEAWaterbodies/DEAWaterbodiesToolkit/ENSOInfluence.ipynb
@@ -1,0 +1,705 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Estimate ENSO Influence <img align=\"right\" src=\"../../../Supplementary_data/dea_logo.jpg\">\n",
+    "\n",
+    "* **Compatability:** Notebook currently compatible with both the `NCI` and `DEA Sandbox` environments\n",
+    "* **Products used:** [DEA Waterbodies](https://cmi.ga.gov.au/data-products/dea/456/waterboards) time series data (available online)\n",
+    "\n",
+    "## Background\n",
+    "\n",
+    "The El Niño-Southern Oscillation (ENSO) is the climate driver associated with Pacific Ocean El Niño and La Niña events (ENSO phases). These events affect climate and rainfall patterns in eastern Australia. Different waterbodies are affected differently: some waterbodies, such as Kati Thanda, may only fill during La Niña; others, such as Lake Burley Griffin, are unchanged whether an ENSO phase is active or not.\n",
+    "\n",
+    "\n",
+    "### Digital Earth Australia use case \n",
+    "The [DEA Waterbodies](https://cmi.ga.gov.au/data-products/dea/456/waterboards) product uses Geoscience Australia’s archive of over 30 years of Landsat satellite imagery to identify where almost 300,000 waterbodies are in the Australian landscape and tells us how the wet surface area within those waterbodies changes over time.\n",
+    "These data can be analysed to obtain insights into the duration and temporal dynamics of inundation for any mapped waterbody in Australia.\n",
+    "\n",
+    "## Description\n",
+    "\n",
+    "This notebook estimates the influence of ENSO on a DEA Waterbody using a few different metrics. This analysis should work for any time series stored in a similar format.\n",
+    "\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting started\n",
+    "\n",
+    "Run the first cell, which loads all modules needed for this notebook. Then edit the configuration to match what you want the notebook to output."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import scipy.stats\n",
+    "import xarray\n",
+    "from matplotlib import pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configuration\n",
+    "\n",
+    "To generate statistics for a waterbody with a given geohash, specify the geohash here:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geohash = \"r4ctk0hzm\"  # Kati Thanda"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, specify the path to the waterbodies CSVs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "waterbody_csv_path = \"https://data.dea.ga.gov.au/projects/WaterBodies/timeseries\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Southern Oscillation Index\n",
+    "\n",
+    "The Southern Oscillation Index (SOI) tracks ENSO based on pressure differences between Tahiti and Darwin. The United States National Oceanic and Atmospheric Administration has an easily-accessed record of the SOI, which we load here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "--2020-09-30 11:20:38--  https://stateoftheocean.osmc.noaa.gov/atm/data/soi.nc\n",
+      "Resolving stateoftheocean.osmc.noaa.gov... 161.55.85.40\n",
+      "Connecting to stateoftheocean.osmc.noaa.gov|161.55.85.40|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 28572 (28K) [application/x-netcdf]\n",
+      "Saving to: `soi.nc.1'\n",
+      "\n",
+      "     0K .......... .......... .......                         100%  187K=0.1s\n",
+      "\n",
+      "2020-09-30 11:20:39 (187 KB/s) - `soi.nc.1' saved [28572/28572]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "wget https://stateoftheocean.osmc.noaa.gov/atm/data/soi.nc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "soi = (\n",
+    "    xarray.open_dataset(\"soi.nc\").SOI * 10\n",
+    ")  # multiply by 10 to match standard convention.\n",
+    "soi = pd.DataFrame({\"SOI\": soi.to_pandas()}).resample(\"1D\").mean().interpolate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load DEA Waterbodies data\n",
+    "\n",
+    "The DEA Waterbodies time series are stored as CSV files. \n",
+    "Each waterbody is labelled by a geohash, e.g. Weereewa is `r3f225n9h`. \n",
+    "They are stored online (on Amazon S3) in a folder named after the first four characters of the geohash, and the filename is the geohash, e.g. Weereewa is at `https://data.dea.ga.gov.au/projects/WaterBodies/timeseries/r3f2/r3f225n9h.csv`. \n",
+    "Each CSV has three columns: `Observation Date`, `Wet pixel percentage`, `Wet pixel count (n = ?)` where ? is the total number of observations. \n",
+    "An example is:\n",
+    "\n",
+    "    Observation Date,Wet pixel percentage,Wet pixel count (n = 230894)\n",
+    "    1987-05-29T23:14:29Z,,\n",
+    "    1987-07-16T23:15:29Z,,\n",
+    "    1987-09-02T23:16:50Z,,\n",
+    "    1987-09-18T23:17:13Z,19.9,45926\n",
+    "    \n",
+    "First we will read the CSV containing the surface area vs time observations data directly from the URL path using `pandas`.\n",
+    "We will rename the `Observation Date, Wet pixel percentage, Wet pixel count (n = ?)` columns to more consistent and easier to access names:\n",
+    "```\n",
+    "    date, pc_wet, px_wet\n",
+    " ```\n",
+    "    \n",
+    "We also ensure that the 'date' column is parsed as a `datetime`, and convert the data percentages to decimals:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set path to the CSV file\n",
+    "csv_path = f\"{waterbody_csv_path}/{geohash[:4]}/{geohash}.csv\"\n",
+    "\n",
+    "# Load the data using `pandas`:\n",
+    "time_series = pd.read_csv(\n",
+    "    csv_path,\n",
+    "    header=0,\n",
+    "    names=[\"date\", \"pc_wet\", \"px_wet\"],\n",
+    "    parse_dates=[\"date\"],\n",
+    "    index_col=\"date\",\n",
+    ")\n",
+    "time_series.index = time_series.index.astype(\"datetime64[ns]\")\n",
+    "\n",
+    "# Convert percentages into a float between 0 and 1.\n",
+    "time_series.pc_wet /= 100\n",
+    "\n",
+    "# Drop null values.\n",
+    "time_series = time_series[pd.notnull(time_series.px_wet)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpolate data to daily values\n",
+    "\n",
+    "DEA Waterbodies data is stored with one row per satellite observation. \n",
+    "To make our data easier to analyse by time, we can use interpolation the data to estimate the percentage coverage of water for every individual day in our time series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_series = time_series.resample(\"1D\").mean().interpolate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7f48a455b198>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAEGCAYAAABiq/5QAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9aZQc13kleF8suWfWXoUqoAoACZBAwaYoCVxkmaZE2ZbkpTk6tlqSt7FOyzJty7LbM2Or3e7pObbbHo9nxrbGWlqWl9M+tii15EWyaam1ryZFUgslEoAIAgSxA7WhtsyM7c2PiBf5IjLWzMiMzETcc3jAqsrKiqrM+OLG/e53P0IpRYYMGTJkuHkgpH0AGTJkyJChv8gKf4YMGTLcZMgKf4YMGTLcZMgKf4YMGTLcZMgKf4YMGTLcZJDS+sHT09P0wIEDaf34DBkyZBhKPPnkkyuU0pluniO1wn/gwAE88cQTaf34DBkyZBhKEELOdfscmdSTIUOGDDcZssKfIUOGDDcZssKfIUOGDDcZssKfIUOGDDcZssKfIUOGDDcZQgs/IeQvCCHXCCHf9vk6IYS8kxBymhDyFCHkJckfZoYMGTJkSApRGP9fAXhNwNdfC+Cw9d9bAbyn+8PKkCFDhgy9Qmjhp5R+AcBawEMeBPDfqIlHAYwTQuaTOkAenz11DR958kIvnjpDhgwZbhokMcC1F8B57uML1ucuux9ICHkrzLsCLC0txf5Bb/7LxwEAP3zHPAqy2MGhZsiQIUOGJJq7xONznttdKKXvo5Qep5Qen5mJN3HML4zZbKixvjdDhgwZMrSQROG/AGCR+3gfgEsJPK8DW03N/v/NuhbwyAwZMmTIEIQkCv9HAfyM5e65F8ANSmmbzNMtVraa9v/fqGeMP0OGDBk6RajGTwj5AIBXAJgmhFwA8J8ByABAKX0vgEcA/BCA0wB2Aby5Fwe6sq3Y/59JPRkyZMjQOUILP6X0TSFfpwB+KbEj8sHqdovxb2aMP0OGDBk6xtBM7q7whb+RafwZMmTI0CmGqPBzUk/G+DNkyJChYwxR4W9ispxDXhKywp8hQ4YMXWCoCv90JYdaUe5Jc/e/fv45fOCrLyT+vBkyZMgwaBiawr+6rWC6kketIPXEzvn7/3IS/+HvvpX482bwx9qOggPv+Gd84ukraR9Khgw3FYam8K9sNzFVyWOsKGcDXF3i8o162ocAADh1ZQsA8JdfPpvykWTIcHNhaAq/yfh7J/XcLHjkW5fxst//DL5yeiXtQwG1kj2oZ8BHhgwZeoWhKPwNVcdWU7OkHjmb3O0CT124AQD42gvrKR8J7EQngXjFPWXIkKFXGIrCzzz805WcJfX0rvBrutGz5x4ElHJmqmld1VM+khayup8hQ38xFIV/1fLwT1fyqBUlbDY0UErx03/+GP7ok99J9GeN+nCYXfiV9C9wmcKTIUM6SCKPv+dgjH/Kknp0g2KrqeGxM2uoFeREf9bGroLJci7R5xwkSIJJr+tq+hc4wxL3M8afIUN/MWSM32zuAsB3rmxB0Q00tWQli40R7x80NZPp7yrpSz2abhV+z5UOGTJk6BWGovBftzV+084JtJqUrJAlhVFvHA9S4VesfkrG+DNk6C+GovCvbDdRyUsoyKIt7XzrolX41YQL/+5oF/6G1dQdhNgLdcQb6RkyDCqGovCvbiuYqpi6e61otiWeurABAGgmUDx0o9VmHHXG37AulBsDcIHLCn+GDOlgKAq/mdOTBwCb8T93fQcA0EzAlsgXoEEoiL1Ew+qJrO0qIY/sPZSEZboMGTJEwxAVfpPxM42fIYnioXGMf6OefkHsJZo241ccC+zTgMKauyEiv6ob+E//8G1cudHox2FlyDDyGIrCb0o9JuOvFpwO1CSau/zQ1shLPRbjV3WK7Wa6lk7Veu3CertffPY6/vrRc/itf8hC9DJkSAIDX/g13cDarmJLPZLYOmSBIBE7p6pzGv+ISz28NJa2rKVGdPVkrYD0cWmjjgvru2kfRoaEMPCFf31XBaWwpR4eB6bLibh6NOMmYvzc32ttJ11ZK6pM1xr0ynyfaeHXP/wUfvPvv532YWRICANf+Fc4D78bt81WE3H1aDqv8Y924W9qOvKS+bKvp9zgZYzfCGk1sF6EkNX91HB2ZQc7KUuDGZLDUBf+W2bKUDSj6yYla+4WZCF1+aPXaKgG5scKANIv/Ky5GxaMxy4M2YRvOtANiqubDfvOK8PwY+ALP4trmPKQeipWo7fbBi8rPFPlPDbraupul16ioeqYHysCANZ3BkPj5++4vMAKjjDw79bRxMp2E5pBYYTdmmUYGgx8SJsX4/+XX7kPN+oqnr60CcAs/AVZ7PhnsObudDWPixt11FUdpdzA/2k6QkPTMVPNQyADwPitC7YSwvhpxvhTxcUNc2NbVvdHBwPPoVa2FeREATXOxnl0voZ7b5mytepunT2suTtj3VWMcoO3qRoo5USMFeXUC7/N+I2Qwm/9m/V208HlDXN+gp9w/4evX8Q7P/1sWoeUoUsMQeFvYqqS83R02IW/S2cPY/xTZfOuYpR1/oaqoyCLmCjnUpd6GNNXtWAq2WruZpU/DbAdzbzG/6sf/Ab+34R3YWToH4ai8Hs1dgEgb8k7YVJBEFa3m/ix93wFADBdNRn/SBd+zUBeFjBRyg0A4zcLiRrC+I3M1ZMqWlLP6Gk9r3v3l+3z/2bCwAvZfECbG0kw/qubTfv/FydKAEZX6jEMCkUzUJBETJRy9gmdFtjkblhYG7suZD7+dOAl9TCougFZHHj+6Iuvv7CR9iGkgoF/xYIYfy4BjZ/py//bq2/Hyw9NAwBujGheD3M/mYxfxnraA1wxXT1Z3U8HlyyphxF+4yZKsx1VDHThp5RGY/xd2DmZ3HBsoYbxkhkAN6pvZnaBLEgiJsum1JOmdZUx/TDGz44w0/jTwSXG+K33Cn9+jOq5MuqIVPgJIa8hhJwihJwmhLzD4+tjhJCPEUK+SQh5mhDy5iQObrOhQdENzPhp/JKp8Te6iGZmHn5ZFFDJSxAFMrIaP4trKMgixks5NDUD9QRirTuFYks9UZu7PT+kkcaffOpZ/PbHnon1PU1Nty3V7M6LbcQDssI/rAgt/IQQEcC7ALwWwDKANxFCll0P+yUAz1BKXwTgFQD+H0JI1xvLg6Z2AaAoJ1D4rdtWSSAghGCsKI9sbAP7OxUsqQcws5DSQlTGz5SFjPF3hz/61HfwF18+G+t7WBS2KBC717KyxRX+ESVJo44ojP9uAKcppWcopQqAhwE86HoMBVAlZvetAmANQNfBHkFTuwBQyZu96e1m54WfFR2W+jlelEeWxbBI5rxk2jkBpKrzZxr/4OOyVfj31AqejH+zMZrnyqgjSuHfC+A89/EF63M8/hTAUQCXAHwLwK9QSttoHCHkrYSQJwghT1y/fj30B4cx/nLeZPzdhEexoiOLZlUZK8kjy2KattRj2jmBdKd3mX9f0YPzllpfyip/v8HI12wtb7t6VrZb75m6kp5UmKFzRCn8Xmeb+yx9NYBvAFgAcCeAPyWE1Nq+idL3UUqPU0qPz8zMhP7gVavw+zH+ss34uyj81v2rZAXBjI0y47elHhGTZVPqSTOamZd4vKyCDJnGnx4YMZgq523Gv8Ix/m5k1gzpIUrhvwBgkft4H0xmz+PNAP6OmjgN4CyAI90e3PVtBYQAkyV/V48kkK4Yv+pi/ONFeWTXLza0FuMfL6U/rMYP3gU1eDONPz1s2IU/Z78O17ea9grURrY3eSgRpfA/DuAwIeSg1bB9I4CPuh7zAoBXAQAhZA7A7QDOdHtwK9tNTJZyjq1bPAghKOel7qQew6Xxl3Ij7OppafzjxcFi/EHTu6wBnzH+/mNtR0UpJ6IgC5zU08S+CTPhNWP8w4nQyV1KqUYIeRuATwAQAfwFpfRpQshD1tffC+B3APwVIeRbMKWh36CUrnR7cKtWTk8QKnmpy+Zuy9UDALWijK2GBt2gEEes0jQ5xi9ZwXcbKWr8/AYuNYA56gZb0Thar0daoJRG/ltu7CqYKOUgCMQh9cxW83hWFBwb3TIMDyJFNlBKHwHwiOtz7+X+/xKAH0z20Mwmkl9jl6HSLeO3pZ6WqwcANuuq7XwZFfCMHwAmyzmspWrnpCjlROwqus3qvdBi/Fnh7xR8D0UzqC1thmF9V8F4SYZAiD2xu7Kl4OieGvKykDH+IcVAT+6ajD+48JfzInaUJKQey9VTHN3p3SbX3AWYrJWunZPtPQjav6vrmZ2zW/AFOs6k+/quiolSzvTxUzOuYWW7iZlqHgVZ7DoSPUM6GOjCbzL+YNZdzkvYaiTQ3BWYxm8W/lEc4mK35XnZ/F0ny7nUNH5KKVTdsC25QYyfRQVkdb9z8BPazRgsfcNi/ISYr8ONugrNoJiu5FGQM6lnWDGwhb+h6thuaj2Xeph+LDJXDyv8KUcW9wJ8Vg9g/q5pNbI1g4LS1vR10PQukylGLxS4f+D99h0xfkvqsWdrqnkUJDGTeoYUA1v4W8Nb4Yy/u8Jv/iuS0Zd6GqoBgbSsq5Ol9Bg/K/RsFiOo8LO7gVHMg+8XOpF6dINis2H2ukSruXudOy8L8ugU/pttn/AAF36zIEVh/N0McLkXeY8VR3f9Itu+xRwdE+Uc6qqeysnLpnZLOcb4A6QexvhvrnMzUTiknoi6/I26CkqBiZIMQkyN/7qV0zMzYlKPfpO9uQa38G+xqd0ozV2943hh91o/m/GPoJe/oel2lDWAVGMb2PBW2WruakGMX88Yf7fgpZ6gRjoP9r5gUg/AFX6rudsYkeZu0OT4KGJgC//qTnSpRzdox5n8rN6wwp+TBJRy4kg2d5uqYTt6ALQSOlPYvcsKP2P8QeszWR8mK/ydo96B1MP6XKad0/zcta0mZNFMsc1L4sgw/iBzwShiYAt/HKkH6Dyvx2uf63gxvaZnL9HQXIW/nB7jZwNbJebqCZJ6KGP8vT+uUYVD449YrBkhYANcAHB1s4Gpch6EEBRkIZZDaJARdMc5ihjgwt9EJS85CpUXmFTQaYPXoBSEOKdCayMa1NZQnVLPpFX402jwqi6pJ5KrJ2P8HaMTjX+Nk3rYHfHVzQamq+b7ZpSauxnjHxBE8fAD3Sd0GpS2TYSOl+SR3LvbUHXkuQsp22x2jVus0S+0pB5W+AMmd5nGf3ORskRRV1p/vNhST1kGi8u6ttm03zcFWRiZkLZM4x8QrGyFT+0CLalnp8O8HoO2rJwMoxrN3NQMFDjGP16SkRMFXNtq9P1YWKFvuXrCGf/N5rxIEp0w/vVdFZJAUM1LTsbPCv8I+fh5xv8HHz+JP/rkd1I8mt5jYAv/6k4zEuOvFLqUegzaFgUwXhzNhM6mZedkIIRgpprHtc0UGL9b44+Qzpk1dztHJxp/a2qX2IV/R9ExXWWM3yz8oyDB8Rr/ez73HP7k08+meDS9x8AW/igBbQBQsQrHVsJSzyi6ehqqgYLsfMlna/mUGL/T1cN8/V7IfPzdw2HnjNjIXN9R7b0NfFLtNCf1GDT68w0yMo1/AKDpBtZ3lUhSTznfbXMXbfHLtaIMRTNG5jaWwfTxO5vlc9VCOozfrfEHMH49Y/xdo96Jq2dXsZcg8acIuxNnd4+jYOnMNP4BwNquAkqBmRjN3U4Lv+4l9dh5PaPF+ps+jP/qZgqMX3O5egKahC2pp/fHNaqoq7r9vo6q8W/sqvb3CFzln7GkHmYUGAVLZ5CdeBQxkIV/Zcta9xaF8ee6c/VQ2r5wZVTzehqa3maPnasVsNnQ+n53wxh/MRchnTMb4OoaDUVHJS+BkOiunnVrCQvg3IVgu3oso8CoMH5NN/C7//RM2ofSFwxk4W9N7YYXflEgKMpiV1JPm8ZfZPtoR8vS2VDbCz9jb/2We1ohbeGTu1rm4+8adVVHKSciLwmRCj+l1GT8ZZME8c63lsZvST0jENugGgZOX9/G+790Nu1D6QsGsvBHTeZkKHexflGntG2X6yhm8lNKzeau5HzJ52oFAOh7g5c1c1tZPeHN3czH3znqqo6iLCIviZGkmV1Fh6IbNuPnuRG7I25p/MNf+HWD4moKva60MJCFf3U7utQDmM6eThk/9XD1jKLUwxh13sX4J+2gtv7+rq3jEUBItFjmzMffOeqKebeXl4RILhw2zc3ynHg5lOn9rF80ClKPptNUel1pYSAL//XtJnLWMvAo6CaT3zDapZ6x0ugldNrbt1yMn62c7HdWCSv0eVGELAiBk7tGilLP+bVdPPKty33/uUmjoRko5kTkZSGSq4cZG9x2znKuRRxGjfFfywp/uljZUjBVyTnyc4JQ7iKT30vqqeQkCGS0GL973y4DW8qi9tkywwa4ZIlAFknERSx9OTQHXvfuL+MX/+ZrQ99faCg6CpIl9UTQ+PlIZqCVZTXJya9sk9uuMvyFXzWMTOpJG+bUbjSZB7DWL3a4cN2g1GFVA8xb2bGijI0RyuthjN9d+CVrA01ajF8WBUiiEPjz0/Txs5TYoDuSYUBd1VHMiciJQiQ7Z6vwO5u7TBoEgH0TRQDA86s7SR9u36HrFFcyxp8uVrajxTUwmFJPZ6yDerh6APMWd5R8/Oxkd0s97Ba+3z5mxfp5kkAgi4L9sRcGwcc/7NOpdcvRlZejuXrcUg87RViiK2DGei+MFfDMpc3kD7jP0DKpJ32sbkeb2mWo5MVAqefj376CDz95wVNO0I12qQcYvWhmP8YvW7GL/R5ZV3UDOUkAIabUE8z4za+lKbcM+5BSQ2Gunmga/zq3hAUAthvm+TVRdhKy5YUanrk8/IX/ZnP1ROue9hGUUqxGzOlhqOQl+43phbd/4OtQdAMr2008dP+tjq95ST2AuYwljQUlvQLzWrsnd+3mbp+9kopmIGdddGRRiJTOmeYAV6cb3gYFptQjIC9F2y63sauiWpBsYsCy+afaCv8YPnPyGuqKbg/jDSMUXbcXyd8MGDjGv1nXoOhGbKmnruq+eRuMtXz74o22r3mFtAGjF83c8GvuWhp/vzVsVTfsxrIkksDm8iD4+IfZuaLqBjSDcow/msY/wen5zDXnJmTL8zUYFDh5ZbhZ/9XN5k2V1zNwjH8lxtQug53Jr2ioFeS2rzOmeH693v41A55Sz3hptNYvNn3snGKKdk7GJnOiEDGrJ2P8naDOXfTzshhp2fr6rmo3dgHgLffdght1FT/zsgOOxx1bqAEAnrm8iRcvTSR30H3GpY322jDKGDjGv7IVv/CHBbWxK/n5td22r/kx/vGijM2GanvIhx0tqcft6mFST7/tnBQ56yIkiSQkqycr/N2gYdktW66eKM1dxW7sAuYd8G8/+F1tcs6+iSKqBQlPD3mDNyv8KWPFntqNJ/UA4YV/bUdpe4xf4a8VZVAKbAX0DoYJdnNX8mnupiD1RNX4B8HVM8xSD2P8RdvVE1Xqab97doMQguX52tA7ey5u3DyOHmAAC3+cgDYGtozFL69HNyj2WJk059edrN+ggODxV2BsZ1S8/C2Nv93OSUg6zV120TEnd7Pmbq/gKPxRXT3cEpYwLC/UcPLK5lBr5BfX29WAUcbAFf6VrSYIQSS2wcCCvnwZP6XYP1UCALyw6i78tG3nLmBKPcDoTO+ywu9exAIgNDKhF1B1A7Jk/t1liQT+fH0AGP8w2znZ9q1CzprcDennKJqB7abmaO4GYXm+hoZq4OzK8A5ybTY0VCNGxIwCIhV+QshrCCGnCCGnCSHv8HnMKwgh3yCEPE0I+XynB7SyY279kcTo1yQm9fh5+XWD4uB0GUB7g9dcxOLh6hmxZSyMsebl9r+rKAT76HsBhWvuSkK0yd00ffyNEWL8imYE/i3ZXe5EORr5OrYwBgB4+lK7a26YMD9WSPsQ+obQ6koIEQG8C8BrASwDeBMhZNn1mHEA7wbwbyilxwC8vtMDWtmKF9cAcK6egMI/XcmjnBPbGrzm5G779zDGPyrRzE1VByHtrh4gvLnaC7g1/uDJ3fQWsTBOMMyMv+Fw9Zh/8yDpyj21G4ZDsxXIIhm6QS73xW/PWDGlI+k/otDquwGcppSeoZQqAB4G8KDrMT8B4O8opS8AAKX0WqcHtLLdjNXYBYKbu5RSe6/u4mQJF9o0/vYNXMDoRTM3NAN5a1LWDVkU0hngkljhD5vcTc/Hz/5aQ63xK63F9uxiG/T7rFuRzJMRC39OEnB4tjp0DV43j5ivZYyfx14A57mPL1if43EbgAlCyOcIIU8SQn7G64kIIW8lhDxBCHni+vXrnj9sdSfe1C7QYvxezV1WNFjhf8HF+P2knhor/CMyvdtQ2xetM0gCScHVQ1vN3ciunjQYv/neGB1Xj7UnN8DZs24z/uh9tmMLprNnmFJM3e+nPZnU44BXNrL71ZUAvBTADwN4NYD/RAi5re2bKH0fpfQ4pfT4zMyM5w9b2YrP+AuyAIF4M362vEMUCBYnSji/Vne8Of2knoIsoiiLI8P4vRatM5iFN+XJXZ+fbxjUZmZp1BT23hhqxs9LPdZdVpCzh60cdefyBGF5oYbVHQXXtoYn9sD9dsoKvxMXACxyH+8DcMnjMR+nlO5QSlcAfAHAi+IeTF3RsaPosRk/IcQ3k9/J+IuoqzpWd1os3k/qAUy5Z1Sau16L1hlEgdhBaP2CohvIWXcguQDGz2/dSmMDF/uRw1z42QAX27kLBKeNMsYfx1m3PG9N8A6R3ON+O83V4tWdYUaUwv84gMOEkIOEkByANwL4qOsx/wjgPkKIRAgpAbgHwIm4B7PVNN9wUTdv8aiGFX5iMn4ADrlH9xngAqzYhhFh/A1VbxveYgjLyukFTB9/i/H7NZd5b3i/pR7DoPZxDXNzly1KKVg7d4Fwxp+TBBR9iIIXjnLRDcMC9/tptpoxfhuUUg3A2wB8AmYx/xCl9GlCyEOEkIesx5wA8HEATwH4KoD3U0q/Hfdg2Ekex8rJ4Ld+kRFZUSBYsrz8vLPH8MnjB0YrmrmhGp5WTsD08aeR1eOY3PVh1PwFod+En2fFw8z466qOnCRAFAjn6vG/kG02NNQKUuQNeABQK8hYmiwNtaVz7iZq7kai1pTSRwA84vrce10f/yGAP+zmYHh2Hhd+Ug9zq4gCsTcGXeC8/IZPHj9gWjrPrY7GRF9TC2b8qTd3faQmXU+P8TsL//Ay/oaq2+w9H8HVw1+U42DYohvc7yd35PQoY6Amd3l2HhcVH8bPdGFBICjlJExXci7GHyz13AyMXxL6L/WofGRDQHOXt5n2vfBzxTFKzMGgoq5whT+Cj1/TjY7uuo8t1PD86m7H+6/7DffbyWsvx6hioAo/z87jopwXPdcvsrrBUijdlk4zqyeguTtCWT1+zV1JFFJq7rYmd3WDeiahOjT+Ptdevjg2hpjxs327ADiN3//3UQ1qL+iJg2VL5z8xJDr/8BhPk8dAFX6DY+dxESr1WKx+caLkCGoLlHpKOTRUY6g93AxNa4DLC5IQnJWTNCilZuG3igu7AHjJPbrDepsx/k5Q56UeKYLUo3Uo9SwMl7MnzdC/tDFQhZ818qROpR7Fv7kr2Iy/iEsbDbuZGST1sCGuzRGQe5oBjF8W+9vc1S1vfiurx3/hO/ucKJC+h7Q5Cv8wN3eVdsYftIxF65Dx76kVMFGSh6bws7r/wJFZPPL2+9I9mD5joAo/u633K8RB8HP1MMZvSz0TJegGxeUbZv62385dYLTyehqa/wBXv7N62N2FLLWau+bnPRi/dVyySPru4+eL4zDf9TkYfwSNn9+OFgeEEBxbGMPTl4fD2cPuIL/30LR9t3KzYCALf6eMX9Vpm/vCLR8tTTotnUF2zvERSugM9PH3ObKBuWVyXHMX8N77q9mFX+i/1KOb7yVJIEPP+AttUk+Axq8b9i7muFheqOE7V7YDIzgGBeztdBP1dG0MZOHvqLlr3cq6G7y6R3MXaC1kMaUe7+cclaA2SqmZ1ePr6ulvSBtj0nEYf04U+i71sGJfLUjDb+e0zo9cBI1f0zuTegDT0qnoBp67vt3R9/cT7O0UZ15hVDBQhZ+x885cPd4JnaygMVY/P1aAKBCcX6vbP9NvbmC8aG3hGvKgNs0wE0oHxcev2oyfTe76r3/UOcaflp2zWpDt1ZXDCFPqaS22B4Kb1Z1KPQC3fL2HOv+1zWTWJNpqwM1X9wer8PONvLhgCZ3uHbnu2QBJFLAwXrAtnYbhf8UfFcbP57F7IWiAqhdghV92Sz1erh5W+CXS98X3rPDXisPN+OuqjpK1pU4SBUu6CpJ6qP2axMXB6TLyktCz5euffOYq7v69T+ML3/FO940D2qL8XT/XsGGgCr89bNVhcxdAm7OHPSffN+AtnUFST7UggZBRKPzWonUfqUfss8bfXvj9pR52x2Zq/H06QAusF1HNy0Ot8e8qTkcX28LlB80wIHWo8UuigCN7epfN//UX1gEAT13Y6Pq5WM/o5iv7g1b47ayeDhh/wXv9IhtMEtyFn5d6fCq/IJCRSOgM2rcLWItQ+simFc3S7V0af5DUkxOFvrt6mBxSLUhD6+rRDQpFMxyBa3lZDHH1ULv/0gmWF8bwzOXeZPMzTpjEU7On6IRoDjsGsvB38kL4rV9kJJLX8Rcni1jZbmJX0aAHSD2AKfcMO+MP2rcLhO+8TRpuVw+70HtFBbMLUl4S+r4ekh1PrWgy/mFaMsLALljFXOu1z0tCBFdP58VweaGGG3UVFzfq4Q+OCWLx8yReCfZy3oR1f7AKv+Ehy0RFWHOXZ/XM2XNh3VzKEvTjxovDH80cpvGn1dxlTD8XgfEXZBGq3t/iq3CuHkq97aaDDn77FkNOEkJdPZ02d4HeZvNHZfwbu4q9QtIPWXN3QNBVczfnvX7RK/htkfPyB0k9wGhEMzN2NzDNXWbnZK4egfn4/Zu7BVkEpc7snl6Dd/UAw5nXU1faX/u8JIS6ejq1cwLAkT1VENKbbP6oR3Xnb38SL/6dTwY+xu7t+jzrMN7hRcVAFX6jq+Yu8/F7N3dFl8YPmAtZdMM/sgEw83qGfe+u3dz10W373dy1pR6m8UvhPn7GWPvai2BSj9U/Gsa8npbUw5wDvvIAACAASURBVBd+MVzq6YLxl/MSDk6Xe2rppAmIPbZLzOf07/fcSD8xUIVf66K5K4kC8pLgofG3Sz3TlRyKsmjt3w3W+EZB6mEned6P8Qtmc7dfDMce4GKuHoEVfv/JXeZICloZmDSYHFKzGP8wWjp3ubWLDHlJCPw7dmPnZFier/XE0sn6cUkWZT/iN8ohbgNV+Ltp7gJmg7fd1WP+yzd3CTH3755f34UeMMAFmM3dzbradw95kgizc7IBqn7JKKzAtxg/C2nzYvzm5xhj7eudiZVSGSXfZlBR9+jv5OVgqUczOsvj57G8UMPFjTpuJOyIs0/VBIqyEWLnHOG6P5iFv5PmLuAd1OYXA2FaOncDQ9oAM6/HoMDWkCyX8ILd3A2Y3AX6J6O4m7vMM/5/fOzptgtsy9UjOr63H1A0c2cA+9nDaOn0au6aUo/335FSajL+LjuexxbGACSv8/fC1eM3spAx/j6hm6wegGXyu7N6fAr/pFX4jWCpZxSimVuM30/q8dfYewFFdzZ3mavn6mazrVDwzV0gOE44aSi6uau2MMSMv6G0a/w50d/OyYfidQPm7El6B28vfPz+zd3uf8agYqAKfzdZPQBQyYvYbjoLdKu563zs4mQJO4oORTcCpR47mnkAh7gMg0ZiobbGH9DcBfop9Tibu3xPx30MaTZ3m6ol9dhbq4av8HsyftnfzsmktG6lnplqHjPVfA8Yv4lEmrtM6vE5/ZP4GYOKgSr8WgKMvz2dkzV3nb/qorV4HQjuKYyXrKC2AVzB+H//j1M48p8+Hlr8Qxl/QCxyL8BYe84V2QCgbTrX3dztq9RjrYdkGv9Q2jk9pR5/jV81nHdj3eDYQvLL15ksm8T1vzXA5dfc7f5nDCoGqvAbXTZ3vTV+8183q2defiB41eMgB7W9/4tnAQCrIYMqrciG4OZuv6KZ/ULagHZWbTP+XHoaf2GYGb+H1JOXRF9Xj+pyXHWD5fkaTl/b7okbKhGpJ6S5m2n8fUI3qxcBc4jL7ephFxNRDCj8QXbOAV7Gwk7ela1m4OMamqlV+13gglYf9gL2Bi4Pxl9X3ZPXFuO3m7tpunqGkPH7DnAFa/zdDHAxLC/UoBkUz15NLps/yXiFsKyeEa77g1X4bTtnp4W/0M74bfnI9eJW8hImy6aME3SHMciMn+F6SOFvqv6L1oHWSd635q57cpcrMsx3zqDrzpyhfks9eVloba0aRsav6pBF4ri4Bmn87ruxbmA7e3rg509Cfw/L6skmd/uEbrJ6AEvqUXSHJdCOevb4TZnOH9RTKMgi8pIw0IV/ZTuk8Gv+i9aBlp2yX81dRTeZNNNW+TV/7sKvuZq7/Sz8Tc3V3B1Gxq+2v/Y5UYRmUM+5idbdWPfUev9kCaWcmGiD1yZpCbxVw7J6RrjuD1bh77a5W7FiG3a521jDlo/af1Um94TdPo6X5IHbwrXVaF2Iwgp/Q/VftA70v7mraoajsPB3eHVX4WcnZ0FOSeoZdjsnt2idIR8wBc0uBp3m8fMQBIKj87VELZ3snZKE/t56imxyN1Uk0dwFnHk9flIP0Cr8YT9vEKOZL99orZ9b2Q5v7voNbwGtk7yfzV2/vHdfxm9P7va3uZsf9gEuRXc0dgEESldKglIPYDZ4T1zeSmzyPUkff5idM3P19AldN3fz7ctY/Jq7QCusLcjHD5i7dwetuXtxvZV1fj1U6jF8s/gBXuPvl9TjH/tbd29Q093N3f7bOWWRgJDhZPy7igfjt/6W3ow/OakHMC2d203N3njXLZKc3GXwbe5mPv7+wOiyuVvOxWX8psYfdoMxVho8xs+WXCxNlsJdPREZf980fks794If42+FtPVxgEvT7V5EISDmYJBRV+MxfnbX1+0AF8PyApvgTUbnT3RyNzicM9P4+wXNoB2zfaAl9TgYf0Bzd2mIpZ5LG3XIIsHyfC2Cxh/S3GVZPX1i06rFpL2wq7ZHbgikNeWr6Qb+9rEX8OzVrZ4fJ9P4ARZsNnxST5DG79WsZmsxk2L8t81VIQokMWdPK50zucndLKsnZeghgWlhaK1fbL2h9aDm7kQJb3/gEL7/6Fzg844P4N7dSxt17BkrYLaWD7VzRm7u9jGywa+w7HrsU5AEwWagqm7gN//+W/jBP/5Cz4/TUfglwZ6AjoIbuyq+9OxKrw4tMuoehZ/dbXndwfDL7ZNAQRZxaKaSmLMnyWVZWVZPCAghryGEnCKEnCaEvCPgcXcRQnRCyI93cjBG14zffIPzeT2a3TBuf7wgEPzaD96OpalS+xc5jBVl1FV9oOx8FzfqWBgrYrqSx2ZDCzy2hqb7LloHuOZuHxm/u7CULTmizcdvmBvS3M6jfpyUpiRlHldBDl5e4sb/+uFv4qf+/DFc22yEP7iHqCs6Cm6pR/a3p2qu4boksJxgdEOSA1zhzd3Rrfyhry4hRATwLgCvBbAM4E2EkGWfx/0BgE90ejCaEZyNH4ZWc9dp5xRI8EL1MLDp3UGSey5tNLB33Cz8ALAa4OxpqlGbu/1K56RtUs/Tv/0avHhp3M6WYdB0kwwwr38/dXY2wAWwBeXRf/Y16y7s3FoyTc1O0VANj+ZuuKunGwLmxvJ8DVc2G1gNkSTjIInhqrCsnhGu+5EY/90ATlNKz1BKFQAPA3jQ43G/DOAjAK51ejCG0Z3U42fn7NaTPGYFtQ1KNLOmG7iy2cDeiSJmqmbhD9L5wwa4psrmc1wPsYUmBUXTPRllKSd6MH4Dokhs+2e/LJWGYebSM1kkL4mxfva+cdM4wLuv0sCuovkXfi+ppweM/5jV4E1C7mH9uKg1OfgCkS1iCcJeAOe5jy9Yn7NBCNkL4HUA3hv0RISQtxJCniCEPHH9+vW2r3fb3C3lRBDiLPzmopWOnxJAK7ZhUHT+q1tN6AbFwngR0xXzohRU+BuqEejqma3mIYskcpG6sL6LXaXzxTR8QeVRlCVPV49IWlJPvwq/ey9wISDmwAt7ralw5r5KC3VVd6xdBMBNIgdp/Mkx/qNWNn8Scg8j51FlmKC2FftatnrRG15/Ffdf5I8B/AalNPCspJS+j1J6nFJ6fGZmpu3rYduwQg+UEJRdQW16Aox/0DL5L1nFZIGTela2/Nl6Q9UDpR5BIFgYL0YuUt/7B5/Fm/7ssRhH7IRfc7eUE9t9/Ezjt15D92Rvr8AKf15qMf44hZ8ttr+QIuM39zUYbXd7wa6eZJu7ADBRzmFhrJCIpTPu5sUgi3JYVs8oF34pwmMuAFjkPt4H4JLrMccBPGxpZdMAfogQolFK/yHOwTA9txtUXNHMzA7YDQYtqI0V/r3jLanHb4hL0w1oBg1k/ACwb6KICxGGbFgf4JvnN+IcsgOK1t7cBfykHvM9IQgEokDaegC9gr0zgHP1rMeI7WAZUedT1PjZhcrt4w929SSXzsljeaGWjLMnptQTVLzDF7GMLqJc1h8HcJgQcpAQkgPwRgAf5R9AKT1IKT1AKT0A4MMAfjFu0QcsO2eXbftyXmyzc3aa/cNgRzMPSOG/aDP+AgqyiEpe8rV0spM7yM4JmBeRKFLPdqN1Ue20wab4+PiLObGN0esGtaeupT4W/qZrWYzp6onO+Fmf/IUUC7/XEhYAgcvjtYQjGxiWF8Zw5vp213ds7FROlPH72jlHt/SHvrqUUg3A22C6dU4A+BCl9GlCyEOEkIeSPBjDoF0zjUreJfVQ2rZ9Ky6qBRmEDA7jv7hex0RJRsmaVJ6u5Hw1fnvRekBzFwD2TZRwbasZqqFvcYW/UxlD1b0nd0s5Ebuq7jjh+OZ8ThT6p/F7MP44dk7GJi9u1PuaL8TDt/Dbi2U8pB7W3E0gpI3H8nwNBgVOdTl4Z0c2RCzK7o1uPFgkw82Y1RNF6gGl9BEAj7g+59nIpZT+bKcH062dE2jfwqXrtG3fblyIAkE1L+HGgCR0XtqoY2G8tTpyppr3L/yaU6v2w17r+S7faODgdNn3cZtcKuiJy5uOhTZRoWreWT2lnATdoGhqLV2av2OTYw5RdYO2wi/H+9mMaeoGxeUbjY7+Tt2C9UvafPyBrh6L8UvJSj3HFlrL1+9cHO/6+SIz/oCIDxrS3B1hwj9Yk7vdNncBs/C3Mf4Epj7GS7mBkXqYh59hupL3TehsRmb85vOF6fw84+9UszXTOdtfE8ZMeTlAMwz79ZME0r/mrkvqyUtirMgGXmJIS+evK+bvUPKxcyoehV9NMJaZx76JIqoFqWtnT9zgtEDGfxM3dweq8CfW3FWczV2vZM64GKS8HjfjNwu/n9QTUeOfiOY75/cAdHoSm4tY2i9EZY99Cg7GLwp9W3iu6ObPcWT1xND4+aKRls5vSz0uxk8IQc5nIC3JRSzun7k8332Dl11Po14AguKgwxaxZIW/TzB61dxNhPF3ntezq2j4Xz70TayHLEWPght1FVtNrY3xb+yqngyOFcp8COPfUytAFEiobs8Y/x37xnDiSoeFX/Nh/FbPou66cLO+jyz2j/E3bYlMtP9takZ0bdmgGCvKkASSeuH3utvz61lohgFJIF1NuvtheaGGk5e3ukuBtf7+UZ8iWONnaP2ut860ZM4RrvuDVfj1BJq75bzkcJ6Yzd1kGH+nk7t/+9gL+MjXLuCdn3m26+PgPfwM01VziGt1p531s2ZomMYviQL21AqhXn7G+O85OInza3WH5h8Vvs1duT2vR3Mx/n5FNrg1/rhbuAxqHu/eiWJ6hV/xbu4C/hEUqt79OeiHYwtjqKs6zq7sdPwcrBYn4erxsnN+/Fe/D+/+yZfE+hnDiIEq/JrRPeOv5CQoumGfuGZzN5nC36nGz95gSdx52B7+CSfjB7yHuFp2zmDGD0Tz8jPGf/fBKQDAycvxXBq6Qe2i6EbJI6iN+fgB83v6rfHzA1xAjMJvmKaCpckSzqc0xNXwkXoA/wgKVTcSd/QwLM93H91AY0s9QU9m/sPXHFkU7Nc8k3r6BCMBdu7O60liNgAwpZ4bdbUjby9z8yVxAeI9/AxBeT12czdkgAswLyahGn9TQ0EW8KJ9YwCAZ2LuU1UDfOKsQNV9GX8fB7j0djsnEH3hOjMV7Jsopdbc3Q1h/F7SoKZT37WY3eLQbAWy2F02P21V/kiIZOd0fT5uHtAwYqAKv5YAO3evX0xiNgAwGb9uUIdjKCpaCx+SKfw5UcC0FawGADMV/+ndqM1dwPTyX9lsBKZ0btZVVAsyZqp5TJVzsdlb0yWh8GBzCW7G72ju9muAS3W7evwTLb3AAgeXJktY21EcTfF+wa+5C5g9H2+px0g0mZNHThJw21y1q+Xr1PVvGAKlHuvXdxPDuHlAw4iBKvxGAtZLm/FbDcIkZgMAc+8u0FleDw1xD8TBpY0GFsYLjouILfV4Fv5ozV3ATJQ0KHDlhn+G/FZDQ7UgmS6NBXORdhywi0rOJ6sHgCMAzmT85ttUEkn/NP62kDb/DHsvsN4S2/J2fq3/ck/DZ4ALYItlvKQe/33ISWB53szm73Qqln1b9JC28OauuzywxvZNPbnbT2iJNHfNNzmTepKYDQDMvbtAZ9O7ug+z6ARuKydgMrpyTgzW+CPcvjMvf9Bi7M2GyfgBM3Xx1NWtWJOpUaQenvEbLo2/X/Ca3AUQeYiLucnswp/QsvE4qCu6Y4kND7/mrmb4b0dLAssLNazuKKFb4/wQt7mrBQxw+WX1+MVCXN1s4P1fPDMSF4SBKvxGAs3dasG5jCWJ2QCgu6A23Wb8CUg96+2FHwCmq3kfqSfaABcQzcu/1dBQs/7Gy/M1KJqBMzFcGqq907X9rVf2kHrcrh4evTwB2yd34zF+RjgWJ62LaQo6P1u76GXN9MseUnUjsUXrXmAN3k6TOuO+5oGM3yerh33sVol+8W++ht/95xOx3u+DioEq/OZ+1cFt7gLdSj3dHYeqG7i61fAu/JU8VjxYVEvjDy/882NFEBKcwbPVUO2Layc56+7BKB4FWQAhbh+/wTF+599PDWBz3cKWelhIW0yNnzH+saKMakFKxdJZV/0X8OQl7+XxvZZ6jna5lCVmbzdkZiCY8bsvGhtWZEvG+BOGpicQ2ZDrTXOXafxrHl75MIRNCEbFlRsNUNra7sRjxmd6t6HpkEUSqWmekwTMVYO9/FsNDdW8eRG8ZaaMnCTEOomVAMZPCEFRFiMz/l6uimy67ZxyPDunbpjNfGLJPakUfkVHMed9igc1d3sp9dQKMpYmSx07e5gTJ6rGH+Tq8VvE0tL4XT/b/rh3f59+YaAKfxLN3YqL8ScxGwCYlsl9E0V85GsXY1/xbY2/y8rvNbzFMF31TuhsqkbgonU3wrz8rLkLmIX49rkqTsQo/HZz1ycEjCV0MrhdPTy87IhJwVy0LthFoKXxx5B6rF9xaTIdS2dd0T0bu4A/409KGg3C8nytY2ePfepFPAWDIhv8snrYx+7z3K8ZPIwYqMKvJZCr45Z6kpgNAEwP/kP334pvnN/AV55bjfW97A3U7XF4efgZpit5rO+qbSy4oemRrJwMeyf8N3GpuoG6qtvNXQA4Ol+N5dIIau4C7Zn8usvH7/VcvYCiOXcGFGIyfv59x4a4gopQL1BXdTsGww2/VZIm4+9tWTi2UMPzq7sdWaNbdT96dIYf/O7EGVF0f2tSku0gYKAKv5GA9TInCciJAraYxt/lHl8eP/7SfZir5fGnnzkd6/ts90CXPz+Q8VuWzjVXHlBD1WMz/ssbDc8Thk3t1oqtYrI8H8+loYQU/pIsOeyc/OvnbjoqvSz8uu4o/LEHuLg7zX2TJSiagWsdOlk6hdnc9ZF6giZ3e1z4ly2d/2QHOr+t8fcoqwfgXD2uiws7JYa/7A9Y4U+iuQuwoLZW4U/qCl2QRfzcfbfgX8+s4onn1yJ/H6tP3fK9ixsNTFdyng07VvjdBbipGvEY/3gJmkFxdbPdy8/6G5PlnP051uB9OuJJ7HbLuFHMeWn8rUUsPHrZ3G2qzjyhuHZON+MH+p/S2VBDpB6f1Yu91PiBVuHvpMHLinHUwh8U2cAYvJ/U08b42c+O9qMHGoNV+BNo7gJsGYtZPJJYvcjjJ+5ZwmQ5hz/9bHTWzxh/V6mE8PbwM8xYQW1uS2dTi8f499q5/O1yz6qV+T/FTQ3bLo2IzTpWrL1C2gC2cN0vq6ePUo/uJ/VEZ/zs7rU1xNXfwm82d71f+4IsQjNo2wyGGdLW27Kwp1bAZDmHpy92zvijNne1gMrvt4jFb4CLPVW35/EgYLAKf0JLU/j1i0kX/lJOwr/73oP43Knr+PbFaA2qpAr/xY06FsZ8Cn/F1P3dls5GTMbPhrgubrQXKSYj8Yy/VpCxOFmM3OAN0/jdC9c13bBfvzapp9fNXS+pJ3JkA8CyzvaOmzbZfjP+XSXYzgm09yx67eoBksnmj3omBU/uhmT1+HxrZudMGEktTeHXLyYVy8zjp1+2H9WCFFnr16yCr3VR+CmlgYyfRTO7N3E1ArzcXmA5/xc8IgbWdtsLPwAc3RP9JG4Vfj9XT7vG7+vq6XVzl/t5kihAFEjkRTD8+y4nCZivFfrO+MOkHqC98Gt90PgBU+45dXUr9l1bp446L/hm9bCvuxk/I3Dc53t519lLDF7hT4DxOwp/wowfMFnum7/nAD7+9BV8J8LyaHY73Y2r40Zdxa6iO+KYeZRyEko5sc3Sabp6ohf+gixiupL3dPasWReVibLs+PzyQg1nV3YcBdsPQSFtQDvj5/s+sut1VHvJ+F1SD2AOccUZ4OILymIKXv66qtv5R274TSKrOk187aIX2NT3c9e3Y32fvYErgTx+P3smO1/cSbC2zGS9Bf7pqUs4/B//Bc8P4STvQBV+LaEiXcmLTqmnB/arN7/8IEo5Ee+OoPUzXbsbxs80970eVk4GrxWMpo8/3su8d6LorfHvKKjmpbaewdH5GigFTl0JvwiqrolYNwLtnFIfm7tae+H3G3rygttG3O8hLkqpHdngBXuxjNp/qQdoLV+PO8jVcvUkENLm8zW/KX338NhHnrwAAJHI36BhoAq/kVDhL+d619xlmCjn8FP37sdHv3kp9IrPJAk9cCtEMJiVc95H4weA6UquzdUTl/EDps7vyfh3FExWcm2fj7Ngg7H0QI1f1e2TUgsIaeu1j999wfRbV+gFN+FYmizh2lazf7HSmgFKgYIf47cu3m7pynT19L4sHJwuIy8J8Qt/TGdNIONnzV1XffDL5XI3ltkdQa82lvUSA1X4k7JzVgpS4gNcXnjLfQchiQLe+/nnAh/Hil03dYrFTNeKsu9jvBh/3OYuYEZCXPQYOFrbUdr0fcC8UFQLUqQGr73M21fqkaAbFIpuwDAoKIVt53Qz0V5GNHsV/oIsxkrn5MPRlqZMZ0/YhrOkEBTJDPg3q1XN6Eshk0QBR/ZUYzd4E2X8Ps3dgiyiKIt2Nk/rucx/2cWEvRe2GvEH0dLGYBV+Ixk7ZyUvYUfRQClNTD7ywmy1gDfetYiPfO1CYL6NmgDjZ6mWQRfGmWres7kbx84JmIVc0Y22i8jajoLJUnvhJ4TgqJWzHgYlpLnLClVd0W1pjBHQ/mb16O1STwzGbxKO1sf7Jvrr5Q/avgX4TyKrhvc+5F5geWEMT8fM5mePjLxsPXBy1/zXa85nvCR7BDIyqcf8iF1cs8LfJZJs7hrUvBXrldTD8PP33wpKgfcFsH5W7LrR+FUjuCkKsNgGxeHNbmoG8jEZv+3ld13M/Bg/YMo9J69shTaw7QGuAKkHMAuXbhd+axGLu7nbQeF/7vo2/vEbF0Mfp3gshPcbevKCQdGm8QPAC6v9KfxB27cA/+whrYfL1t1YXqjhRl3FpYDFP22g8ULags45v6wewHvHtuEj9WymsF2tWwxM4aeUtp0snaLMrV/sVXOXYe94ET/2kn14+PHzuLbl/QZmbL2bVW5soUQQ45+u5kFpy29vGBSKZkTat8uDsVO+wUsp9dX4AbPw7yo6zoUwWtY89MqIB5zLWJhtTuJske7nioufev9j+JWHvxG6tN3t4wf8Yw684N4tMV3JoSiLfVu8Xg9h/F7L49kdcj9cPQDXG4qh89tZPUmEtPnEMgOM8TvvntmdCXtOdkewWc8Yf8dosbtkXD0AsN3Qes74AeAXXnErVN3An3/xrOfXbcbfhQuFFbmgqcqZinN6196+FbO5y7z8/EKW7aYGRTcw5cf4I7o0wrJgWKx2XdGh6873RBLpnKxwnwpxYngWfp9gMy+450f6Hc/cCGH8tquHk67sqeoeLVt34+h8FYQgVlJn3MndKLHM7kUsADBRynm4elrP2VB1u/mbMf4uwF6gpFw9ALDT1Hva3GU4MF3Gj75oAX/96Dms77SvP2xp/F0wfut7g6x27rye1vateC9zOS9hoiQ7GpGtqd285/ccmq1AEkhogzds0QeTenYUzR63Z9KD+25H6eBCun+qDAChx2kOcDmLZl4SYy9i4bE4WezbEFc9tLlrMX7u97H/3j0+XxhKOQkHp8sxGX+8u+dA6dEnqwewGL+Pq4dSZybWZgdb+dLG4BT+RBl/S+rpZXOXxy+98hB2FR1/+ZXn275mF/6upB52UgZr/EBrepdZ9eI2d4H2eOZW4fd2FRVkEbfOVEJdGl7+eB6ModYdGr+fjz8+42d/o9DC7zHAlZeFyJO7hodRgQ1x9WPkn0k9vpENFhngfx/bQNDH3cZxoxtsnd0AVreb+PoL64GP77S5O1bM4cau6nit+OgVPsRwM2vudg77JE+ouQuYhZ/S/uRn3zZXxauPzeGvvny27dYviQEuxm6DGP9MlRV+S+qx1y7Gf5n3jZccGn8Y4wdMuSeK1BPkGilxe3c113tCdl30OpncZXdBQYXfMChUnXpM7sZg/B65U0uTJewqelt0di8QtbnL/z62gaCPvvTlhRourNcj77LmpZ6f+Yuv4nXv/kpb0ByPoJtCO53T42vjJRmKbjimyMH97Kub5jk2V8uPLuMnhLyGEHKKEHKaEPIOj6//JCHkKeu/rxBCXhT3QJJk/KzwsxekX7eub3vlYWw2NPz1v55zfJ5p0XoXGr+mm7tn/ZqigPl7F2XRDmpjbC6uxg9YjH+9bp8cqzssmdNb4wdMzfbKZiOwsIVNhrZcPVo74xd5zbwzxs9iJU5e3vJl3qwn0zbAFUfjN9oHg/oZzxzW3PWyc9oGgj4y/mMLYwCiN3h5qYdNil8OcAUFN3dNeBHDCTa9yxV1xvgNSm0jx6HZymhq/IQQEcC7ALwWwDKANxFCll0POwvgfkrpHQB+B8D74h5IL6Qe9oIkMRsQBd+9bwz33zaDP//SWUduTSJST8TdwfwKxkY3jH+iiLraYqdeyZxuLM+bJ3EQmw5r7tpSj9qSetjvzUs9siig2VHht7zXTc13qbxv4fdZV+gFt48fMKUeoE+FP0TjZ3ddvEspLDm1F4gz9Q2AY92tO9xzLossf0GP0tz1ovxj1o5t3tljzxAYwNXNJmSRYGmyPLKunrsBnKaUnqGUKgAeBvAg/wBK6VcopUxsexTAvrgHkizjN9/sN/rM+AHglx84hLUdBR/46nn7c0oCzV1VN9qkDi+Y07uWxq92ofEzZ4+l86/tKMhLgm/oF2AyfiC48CtatOauQ+phk7vc758TBVuTjoOGqtvM26/YMPmjTeqJkdXjtQBocaJ/ufxhUo8gEORE5x1MWHJqLzBTzWOmmo/B+E0YlGKWFf41Z2QKX+uDIxuCm7sAcINz9rDn1SnFtc0GZqsFjBXl0WT8APYCOM99fMH6nB/+HYB/8foCIeSthJAnCCFPXL9+3fG1ZshgTxwwVw+7Evejuctw/MAk7r1lEu/7wnO2VY5p0d1o/FEHa/jYhpadsxPG7/Tyr26bw1tBUtNUJY+5WvBJ7NU05cFmDvgBLjurh1vQLoukQ6lHx52L4yDE/wLFLtReA1wsSiIMptn5HwAAIABJREFUbh8/YBbhmWoe5z0ir5NGQ9FBSPtdCw9Tumq3c/bLx89wbCH68nXKyS0svqSN8XP/Hymrx2dyFwDW+cJvb/+iuLrVwFwtj1pRgqIZfctgSgpRXmGvM93zr0kIeSXMwv8bXl+nlL6PUnqcUnp8ZmbG8TXGgvb5xA7HgSAQlHJiS+rp83Lkt73yMK5uNvFhK72PnVDdxDJrhhFJe52u5NvsnJ26eoCWl399139ql0eYS0PVgpu7gkBQlEXUOTunvYiFZ/yS0FHhrys6pio5HJgq+xd+n+ho9neMsgfAbw9Ev7z8LJkz6EKdl8TUGT9gvmdOX9uOFIfBRyOzO7Nzq27Gz0k9UQa4PL42YUWTbNRbUk8rqwe4ttnEXK2AWsG8QAwb649S+C8AWOQ+3gfgkvtBhJA7ALwfwIOU0tW4B/K8ddXeP12O+62eqOSlltTT5zfyyw9N4c7Fcbznc89B1Q0usqHzbBlFo2159F6YqeaxZsU2tHz88Qv/WFFGtSDZXv7VgLgGHkdDTmJVNxzM3QvlvOiMbLCKF3/BkEUh9gAXpRS7VkE8Ol/FicveQ1x+hZ/dOUVhd37zI/0q/LuKfyQzQ14SHL9La1akv4x/eaEGzaB49mp4Nj8v9eyq5h19EOMP8vsH2zk9opkdrp4GZqt5+65j2HT+KK/w4wAOE0IOEkJyAN4I4KP8AwghSwD+DsBPU0q/08mBnFvdsTcVJYFKXrJdPf1m/IQQ/PIDh3BhvY6/+9oF+/PdDXAZvomWPGYqOTO2YVexGVHcPH6GveNFTuNvBjp6GMJO4rDmLtBauG5r/GK71JMThdgbuBTdgG5QlHIiju6p4YW1XWx5MDW/PCGvmAM/GIb3+25xoojLN+o9XRsJmIw/7ILvdim1psP7e77Ecfbwdk7WqHfPRkTX+M1/vcpDQRZRkAWHzZRdRHYVDZsNDbO1AmoFp5FkWBBaESilGoC3AfgEgBMAPkQpfZoQ8hAh5CHrYf87gCkA7yaEfIMQ8kTcA3l+dQdLk6XEHDhljvH3U+NneODILI7O1/DOT7cWtXRV+PVokdX2ENeWYrPuThg/YOr8TONf21YCPfwMRy2Xhp+M0gyRegCgJJvrFw2Xxs9LPbIYX+ppKObjiznJPk6vJRqKbv7dvNI5gWh7d3UPVw9gOnsM2tqv0Cs0VP9F6wzuuYQ0XD0AsH+yhFJOjOTsaVkqzT4GYN7dXOeSZI2Irh4akuo/Xsw5JvHZo5l9dK5W4Bj/iBV+AKCUPkIpvY1Seiul9L9Yn3svpfS91v+/hVI6QSm90/rveNwDObe6iwNWZnkSKOdF+8VIo/ATQvC2Vx5yTL927eqJovFzQ1zd2DkBayHLeh0NVceOovtO7fI4MFVGUfY/iU2pJybjFzykHonE3sDFpIFSTsRRli3kIff4rYdkF9Ao07t+4YDMUXS+x7n8dcV/7SKDu7mrRRgS7AUEIXqsN4NhyXaLk2Yvyi/1NNDHHyD1AO2xDeyCcsUu/HlO4++P1POhJ86HPygCBmJyl1KK51d37ByVJFDJS/aL0ct0ziC85rv24NaZ1u/Ulasnqo+/whf+7hj/3vEitpoanreaZ1EYvygQHJmv+p7Eqk7DGb+1frHl6rFimUWn1BOX8TNpoJQTsTBm3qZ73ZkwGcbdFI/K+Fmx8bp7ZQtZeq3zR5J6XDuE02L8gOnseebyZqgBgkk6lJqv55E95gWc1/mdUk/4c/mVh/GS7GnnZIx/tlpAregcFu01mGGkWwxE4TdX0hkJM37J3rub1mo0USD4xVccsj/ulvFHsdlNs4TOrSYamg6BdD7HwBxWT10wrXZRmruAKfecuOy9YCPKTtdSG+M3Py+7mrtxN3Dx+TVseUxw4W+f3AXaF5S7YQcOelSUuWoBOVHoQ+E3Qpu75lxC+nZOwHT2bDe10Dsh9o5SdQOKZuC2uQoIgSMOnJdwOm3uAqbUw7t6GC7fMO/inYy/P4W/mxrCYyAKP9tZmyTjZ7ENQP+buzwevHMBv/XDR3H3wckEpJ7w36OSl1CQBaxsN9FUDbvIdQJm6fyWVfinfLL43Vier2GzoXluJVO0KM1dyZrcZXbO9tWLndg5ecYPmBeoUx7LY0KlnhDGrwcwfkEg2DfR+5TOuqJFcvU4IhuMdOycQPRYb1bH2Ws5VpSxMFbEC5ylk6/1QU46u7nr8/Xxkuzw8TNcvtFAThIwVpRRkEXkJKFvrp6RKvzsNu1AwlIPQxoaP4MkCnjLfbdgrlaI7ULhoYXEGTMQQuzp3U4WrfNgQ1xPXdgA0PI2h+FowIKNsAEuACjJopXVY37M7lj4C1gnzV02zcoKv9/yGD9XD/s+LycQD8Yy/QjH4mSp50Nc9QjNXfdimTSlntvmqhAFEtrgZWx+25Jxi7KI/VMl2w5uPqaFQKknYBELAIyX2hM6AXPV4lwtb78fa4X+Te+OVOF/fnUHkkCwMJ6MlRNoTe8C6RZ+huX5Gs6t7uLM9XCvshdUg0YOz2LTuw3VQKGLpRoTJRlFWcRTFy3GH1HqObKnak3GtjdOw9I5gVZzV3cNcPHoJLKhrrBiYb43/BxI9uSu62/HsnbCtozpLonKjX54+euKEU3jd9g5ndlI/URBFnFopoKnIzJ+9hoVcxL2Tzn/nry8E9QzsBexBDR3Fd2wCQOPuWqrVtUKUt80/pEr/IuTpURTAVleD5Bec5fHj71kL0SB4ENPdNac0XQj0gAX0JrebURo8AWBEFOWoNQsvmyoJQzlvISDU2U8c7l9DD9sEYv5/WZzVw1YNyknIPUcnqtA9Fge4zfAVSvImCrnbGnSD0xd8GP8S5Ml3KirjsZh0mio4a4ed/ZQmowfiBbr7S57pZyIpcky1nYU+07M0dwNCkak1JftA8C49X7/k0892/ZazdZaRodqUe6bq2e0Cv9KslZOwCX1pNTc5TFbK+CBI7P48JMXOooaiLMEe6aaw8q2Err0JAqYzj9RkmPNWJiNUyfj1w0K3Qgv/KWcBM2gNtPy+rmySGI3d92FvyCLuGW6PbrBr/AD5ra1syGFP2ybHLMg9srSSSm1IxuC0Da5a9s5Uyr88zVc2WxglfPku+Gu40zqAThnD/eYMMYf1P9jeT3/9Qtn8Mefds6lzqbF+BNa4pN64aeU4lzCVk7A2dyNu2y8V3jjXYtY2W7iMyevxf5eNWJWD2Ay/rWdJnYVrSvGD7ScPVEdPQzLC+ZkLK99qj4SihusYDGW5SUNdWLntF09HBP2ukD5hbQBZh/KHRHghhFa+Hub0qnq5gU2TOOvFMwmOnO/pTW5y3BsgUlv/vuQ3Xp7Mdde+HlXT9gAV9BvOs71tNzn0RyXMFDrUULnrqLZ71mGbvK+eKRe+Fe2Fewoek8Zf6cDTEnj/ttmMFfL44OPxx/CUGNIPTPVPAxqug+6/d33jpuvS9w7BxbRfJI7iRU9mmuEMfI1KwudL2AvPzSFX/uB27pr7srOwn9xo+64lQ9Kij04XcKVzUbbCcnD9vEHNHeB3nn5w9YuMtx7yxQoBT71zFUALY0/Svx3L8B6LkFJne46XsqJNmlk8cxxIhuiMH7A+Z4BTCsnQ60g98TV87a//Tre/vDXHZ/rZhaIR+oVkSXrJRXOxlAp8IV/MBi/JAp4/UsX8blT12wvcFREdfUArSGuC+v1xBh/UKHzgtdSFjVAQuHBCj0bl+d/h795y714+6sOW3bOmJO7io6cKDjunOwdAldax2laTomnxHTAep8+v+ov94RJPbWCjImS3LvCH7KEheH4/gkcnq3gN//+W3j0zKq9wjANOycATJRzWBgrBDp73DELRVlEJS9hqpyzp3djhbQFavwtxr/VdBZ2h9RTlBJn/A1Vx5dOr7TdFY6Mxv98D6ycgNPVMyiFHwD+7fFFGBT47zGbvKoez9UDmAWs04A2Bqbxh3nX3Zir5TFZzjmadWpEDZnt3WXrHr2cSZ2kc9YVrU3+WPZw9ph/N+/3DHufBjV4o+yPXuyhs6e1hCX47yyJAv7m5+7BwngRP/uXX8WjZ81Q3TRdcMsLY4EN3jaN33o9l6ZKttTDF3stgByEST0TXESJu7nrZvxJZ/J/8/wGFM1o6x2MTOE/t7oDUSD2xqekMIhSD2C+QV9+aAoffPx8ZL2uruhY3Wnaq+bCMF3x1ybjgr0ucaUeczK22sakgSiFv8X4ZZF4XvByIoGiG757c72w65FfM1PNY6qccxT+pqb7/r6M8Z8NYPy2qyeggC5OlnxXP3aLsH27PGarBTz81nuxf7KML59eRU4UOh74SwLLCzU8d33b9w6z3dVjnuf7uQsp/5YIYvxhUk9eEvHc7/0QFieLbcvgZ10aP5Ds9O5jZ9cAoO3njkxz9/nVXewdL3btPnGDt3N2soikl3jDXUu4uFHHl59bifT4Z69tgVJg2ZIlwjDNXSC6bWzPVvP4999/G/7sZ14a+3uX52s4eWXLlhD8/PFuFDmN3+/42cUjjua56+F0aUU3cL2IgATRSl7CdCUfzPhtqcf/WJYmS7iwvpsYg+PRYvxSyCNNTFfy+MBb78XR+ZqdPZMWludrMChwyiM1FfB29QDm1P+lG3U0Nd0hB528suVLDmiInRMw737KOamtANc4KdmOZk5Q53/MuvvaUXT7/AFGjPHvT7ixC7hcPQPE+AHgB5fnMF6S8XDEJi9rkLJAqjBU85JdXLv93Qkh+JXvP4xDs9EuOjyOztegaAbOWEXSdvWEaMhMplvbUZD3Ya0s4TNOg7eueE+zHp2v4tRV5wUq6OJ0cLqE51f8ZRo9pLkLmIVf1SmubDaiHn5kNCJq/Dwmyzl85Bdeho/8wvckfjxxcCwkuoEv6oS03t/7p0qgFOZENG0914X1Op695j00Gcb4GfilTq2f3fq+pBm/ohl48ty6/bvxMwIjUfgppTi7spO4vg84A7YGxc7JUJBFvO7Fe/E/nr6CtZ32ECg3TlzZRFEW7UjfMBBCMGPp/H6Fsx9YXnDq51EHhJgcs7Gr+urUjJHHmd71iypmFyjmz1dC5h8OTJWDpZ6QyAagFc/sFyfcDXZjSD08SjkpcVt1XOybKKJakDyH/wA4tB5+teR+O/V0x37Iq47MAgA+fcLbPm3QwN6ujbJH4edhB7Ul5OX/1sUNNFQD33d4pu15R6Lwb+yq2GpoPWH8/BU5qeUuSeINdy1C1aljQ5cfTl7ewu17qrF+D6bzdxPZ0C1unakgJwo2e4ta+HlW7iv1sIhkPXpDbVfVPeUPO1vIukAFST2AqfNf32ra/nc3WpENARr/RO+8/FGbu4MIQgiW52u+0Q182eMvbEuTlqVzddeWg+bHizi2UMNnTl71ea5olZ/f5ueFMRbNnND07qNnTH3/B5bnADh1/pEo/MwS1wvGP+g4sqeGOxfH8cHHzwc2KCmlOHllE0f2xJNa2O1nmoxfFgUcnqvYBdUv9dINnpX7DSExuSiOpbOuaG1+bMC8QMkisXX+cKmHFRlv1h9F6pkfL0AUSE+mdxsRffyDiuWFGk5e3vIscnyzln9vTFdyKOdEnFvdtR9DYLL+J8+tOzZpMcSReng756zLZJE043/s7Bpum6vYRgJeQhqtwj+dPOMfBrzp7kU8e20bX3thw/cx17aaWN9VYxf+qtVwSvvkX7Y2K1FKI9s5eZYf1txVY1g6vVw9gHkhOjRbxckrrQtUmNQDwFfnD5vcBczjXxgv9MTSGdXHP6g4tjCGuqp7zkpQl9TDQAjB0lQZ51ZbUg8hwANH52BQ4PPfue7xXOHNXcDZL3zjXYv457ff5/h6khq/pht48vk13HNwyr6gOBj/KLh6nl/ZBSGt+N+bDT9yxwLKOREffPwF38cwffzIfLTGLgOzs4Y1UnuNo/M1rO4ouL7VbA1whRR+QSD2SZ33aU7nOmzuFnzuII7OV+2/ddj8AyMqfkNcjJSFjV30KqWzFT+drkOnUyzbE7ztcg9f9tykZv9kCee4xesEBHfsHcN0JYdPe8SkUERj/FXOwXPvLVNttuq8JCAnJpPJ/+1Lm9hRdNxzy6Qdisiel1I6Goz/3OoOFsaKqbPStFDOS/jRFy3gY9+87JvxfuoKc/TEZfzmm8YrUrafsBdsXN5safxS+MnGmLkfa2WMP05QW13VPaUewCw2VzebWNtRQgt/KSdhtpr3DWuLIvUAps7fE43fknq6Hd5LC4dmTenNy9nDy6Jux9r+qRIurNXtOQoQk0S88vZZfP7UtTaSYNDgAS4GvtB73cURQhKb3n3sjGnjvPvgZGuto/W8STp/U5Z6dnvS2GX4v37sDrzjtUd69vxJ4A13LaKu6vinpy57fv3klS3MjxUcgVFRwBj/dp/iYv1wdE+r8CsxYn+LXIKmF2xXT0TGzxIr/aKK+Wz+oAEuhgPTZV8vfxSpBzCHuFa2Fewqyb5G5r5dYSBNDVGQkwTcNlf1jG7ga597PmdpqgRFN3DJikNhv/2rjs5is6HhyXPrzuei/ln8PGZDCj/A8noSKPxn13DLTBmz1QKKsghZJLbUk+TMR+qM/0DCGT08/u1di3jo/lt79vxJ4M7Fcdw+V/X19J+4HL+xCwB7xszJwrRP/rGSjL3jRTxzadN3s5UXWtHJ3o+1Nf6Izd2GaoBS/6Em9jc+YV2gwo7x4FTZV+qJEtkAtCydSW/jqivhkcyDDrM3dKPd+MB96L6jccdpsDuu7z08A1kkbam4BvXfvsWDT+L0K/xJZPLrBsXjZ019H7DuJLgLykgUft2gWN9VE0/lHDYQQvCGuxbxzfMbnrnwz13fjq3vA8DrX7oP/+G1R/Dz35f+hW95wVxqzop0lCltpk/7Sz3M1RON8TNW7cf4pyp5zFbz5p1JhD0GB6bLWNlWPCU6O50z5KK71KOUzihZ/IOO5YUaVrbN3hAPfoDLfTfI/p4s/4sV9Upewr23THnEoUeTevilK15LgYBkMvlPXN7EVlPDvbdM2p8bK8otxp9QYxdIsfAz9pf2wMgg4HUv3oucKLTFNZ9Z2Yaq044YvyQK+Pn7bw3NZO8Hjs7XcHZlx9Yqo0g9pTCpxyrMUfcYRxlqYtENUQr/Qdbg9XD26BEGuIDeFn6/Jvaw4NiCme76tIsM8bXP3fhfGC9CFolts+X//A8cmcXpa9sOC25UOycLPQQCpJ4EMvkftfR9xvgB552EHjONNgipFf6mdcLejB5+NybKObz6u/bg779+0ZHwx6IajnbA+AcJLH/l29bu3iixv6xA+xV+dvGImtBpxxgEFMSj8zWcvrZlxTcHF86gsLawnbsM4yUZlbyUeIO34WNbHSYcsXKp3A1eR+F3afyiQLBvorV4nXB8/gFripdn/UZEOydPVCSfXQVJZPI/dnYN+6dKtkwLmJvv1nbMu56RYvxRYwhGHW+8axE36io+8fQV+3MnrmwiJwr2wNCwgtnzvnHenFeIIvUwmSSM8UeXepxrF71wdL4KVaeRVlbuZ5OiHg3eKJENgCnzLU4m7+wZBamnVpCxNFlqK/z8AJeXa2n/VMnW+Pk///6pMg7NVhyFPyrj5+HP+Ltz9RgGxePPr+Geg5OOzy9NlnBuxbSoaka8GPIgpFr499QKAyFFDAJedssUFieLePirLbnn1JUt3DpbSW0HalLYN1FENS/ZMcRRNjyx0yu8uRtT6gl4vy1zd1ZREkTnxwo+jN/8N0qu/dJkMXGpZ1fRR8IivTxfa3P2BPn4AdPL72dhftWRWTx6ZtWO2ojTK2V3qX5rKbvN5D91dQsbu6pD5gHMKfGtpobVHQUJ1v0UpR5N76mVc9ggCARvOL6Ifz2zajOWk5e3cLQDfX/QIAjElqskwXuzVdv3WEwstLkbMaStrrLmrv9Q08Hpsl3wo3jgD0x5Wzqj+vgBk9GdX9+NtVcgDI0RYPyAma75/OqOIxOJBrh6AGCJk47df/8HjsxC1Sm+9Kw5xUsRTeoBgKly3vM5Gdj07laHzh7m37/nFifjtze+reyMDuPP9H0nfvylixAI8KEnzmN9R8GVzYatdQ472IrDqHcv7PxKqrnLTshyAOOXRAG3z5nHGcVyemC6pScD5takf/zGxcg+fsD08jdUA9e3m6GPjYq66h0/PWxYXqiBUuCkg/X7u3oAk/EzuGv0S/dPoFaQ7LTOOFLPlBV66PdwO5O/Q7nnsbNr2DtebEsxOGjVyDMrO6PB+DWDYv9NmtHjhz1jBbzy9ln89ycv2OPqUTP4Bx1sgjfqPld2QvoVz1zM5u6lDTP3fj5k0xu7QPlFRfA4MFXG2o6CG3UV200ND77ry/iVh79h68hRCz+QbErnKPj4AefUN0MY4+dVBOIya0qigFfcPovPnroGw6CRs3oA0+4LtK9gZGCM/yf+7FGsxryIU0rx1bNrbWwfMGVSSSCjw/iBzNHjhTfctYjrW0285/OnAWCEGL95Euci7kZgJ6Tf6jzG+KNGUlxY38WE5aKJdJyRGH/rNvx3PvaM/fkPP2lGbUeVeoBkLZ3m5O7wF/49tULb3mbH5K7HxXkxgPED5hTvyraCpy7eiJzVAwBvumsRAHyNFixQ7epmE3/55ecjPSfD6WvbWN1RcK9L3wfMi9XSZAlnV3YC10jGRaTCTwh5DSHkFCHkNCHkHR5fJ4SQd1pff4oQ8pIoz5tp/O145ZFZzFTz+PLpVUyVc/ZClWHHbXNViAKJHBoXdkKWchLmanmc9tmuxPC7//QMXvsnX8S3L21GCgNsXaDCTw1WBN7/pbP44BPn8dD9t+ITv/p99vdGYfx7x4sgBPai8CTQCIimGCawbH4n4+ekHg8SwV/wvP769982A4EAnzlxNfIiFgB47XfP48zv/ZBv0sAYt7KyqcVr8H7xWXMF68tubS/8gEkwzq7sIEYeYShC4/sIISKAdwH4AQAXADxOCPkopfQZ7mGvBXDY+u8eAO+x/g1ENrzVDlkU8OMv3Yf3fO45jJfkVBdfJ4mCLOLWmXLkULUwxg8A3713HJ965ioe+usnMT9ewPxYAXvGiua/tQLmagW8/0tn7cf/5D1LoT/3JUsT+Ln7DuJ7D0+HPpax9Y998xKOztfw73/gMPKSiP/8o8v4vX8+gYmSHPocBVnE7XNVfOCrL+CNdy05PNydQNUNqDodCakHMOWev/rK81B1A7IohLp6ANP7vr6rejL+8VIOx/dP4lMnrpkpqzFOryBTAmP8ABzTxpRSbOyquLhRx6WNuv3vyraCH7ljHq86OofPfec6bpkpO+5WeBycLuNfn1uNlUQbhii5rXcDOE0pPQMAhJCHATwIgC/8DwL4b9S8HD9KCBknhMxTSr2Tx2Dqc2G33Tcr3nB8Ee/53HNYCNGjhw33HZ7BmevBDJ3hba88hGcubeIVt836PubNLz+Ahqrj9PVtfPHZ69hRgpnWr786PLAvJwn4jz+8HOkY+cLzx2+40x4o+sl79uMNxxchRWxk//Eb78SPvfsr+KF3fhHjJRmUmhc8g1K7oWd/TM1i0nqM+S+lgGYY9oW1PCLn1rEFcy3mfX/wWTQ1Heucxu53V3PHvnErf9+7UD9wdBb/57+cxDOXN+1mfrcY4y7yH/3mJfzrmVXIooDVbaVNjsxLAko5EX//9YvYO17E5Rt1/Oz3HPR97oPTZdRVHT/y/30pkWMFohX+vQD4LIELaGfzXo/ZC8BR+AkhbwXwVgBYWgpnXzcrDkyX8Rc/exzfZY2tjwp+64ePRr6DOTxXxSd/7f7Ax7z80DRefshk5pRSbDU1XLnRwOUbDVy5UcflGw1c22piY1fBv3nRXsfJmRT+8MfvQCkn4XaX7TZq0QfMBv77/+e78DePnQNgylyEOP8VuI8J97H9ORBIIkFBElDKS/ifXrw30d8zLbzitlm8/qX7YFBzlaSqURyeq2BtR8H33Tbj+T1/+Po78O7PPofjByY8v/4T9yxBEggU3cBLlrwfExd5ScRXf/NVOHFlC4+eWcXKVhOaQTFZzmF+rIB9E0UsjBexd7yIyXIOqk7xV185i2cubaJWnMWbX37A97l/5I55nFvdQVMzoBsUv5fA8ZIw/zAh5PUAXk0pfYv18U8DuJtS+svcY/4ZwO9TSr9kffxpAL9OKX3S73mP///tnW2MXFUdxn9P6YsChQqIQUqkHwjJiqHSjaCCEhI0ErUlSEJCKIhRm9QETYyBoIlRE8UPRmONTY1tMfEl8YWwIIQAkTRRIuxCCy2llAYNYKW+hLrQWGn8++GcyV63O7szszNz7937/JKbOXPuueeeZ5+Z/95z7p1zRkdjfHy8DxKMMaY5SJqIiNH51NHJZclLwDmF9yuBv/RQxhhjTAXoJPA/DpwnaZWkpcB1wNi0MmPA+vx0zyXA4dnG940xxpTHnGP8EXFM0ueAB4ATgK0RsUfShrx/M3AfcBXwPHAE+OTgmmyMMWY+dHTrPyLuIwX3Yt7mQjqAjf1tmjHGmEFQ72kfjTHGdI0DvzHGNAwHfmOMaRgO/MYY0zDm/AHXwE4sTQJ/BQ53UPzUDssBnAH8vY91dnPuftfZqZZBnHsQupuqp8zPUFO/O7Cw9BS1nB8R85trIs37MfwNGAe2dFi2o3KtevtZZ5fn7mudnWoZ0LkHobuRekr+DDXyu7PQ9BS1dPM9areVPdRzT5/LlX3uhaRnELq7YSHpKfMzVAdvBlVnmecuU8+clDnUMx7znG9imPWWwULSAtZTdaynuhS19ENXmVf8W2pWbxksJC1gPVXHeqrLljbpnijtit8YY0w5lD3Gb4wxZsg48BtjTMOofOCXtFXSIUm7C3kXSnpU0tOS7pF0Ss5fKmlbzt8l6fLCMWty/vN5YfhSFrPto55HJO2TtDNv7dcoHJyWcyT9TtJeSXsk3ZLzT5P0oKT9+fUthWNuyx7sk/ThQn7p/vRZT+38kXR6Lv+apE3T6qqdP3MEb7pFAAAE4UlEQVToKdWfHrRcKWkiezAh6YpCXd17M9/nQQe9AR8ALgJ2F/IeBz6Y0zcDX8/pjcC2nD4TmAAW5fePAe8lLcR5P/CRmut5BBgt2ZuzgItyejnwHDACfBu4NeffCtyR0yPALmAZsAo4AJxQFX/6rKeO/pwEXApsADZNq6uO/symp1R/etDybuDtOX0B8PJ8vKn8FX9E7AD+OS37fGBHTj8IXJPTI8DD+bhDwKvAqKSzgFMi4tFIf6mfAOsG3faZ6IeeITSzIyLiYEQ8kdOTwF7SWstrgTtzsTuZ+luvBX4REUcj4gXS+g3vqYo//dIz3Fa3p1s9EfF6pOVT/12sp67+tNNTBXrQ8mREtFY13AO8SdKyXr2pfOBvw27g4zl9LVPLPu4C1kpaLGkVsCbvO5u0PGSL1mLwVaFbPS225W7qV8roeheRdC7pquSPwNsir8CWX1vd6LOBFwuHtXyonD/z1NOibv60o67+zEUl/OlByzXAkxFxlB69qWvgvxnYKGmC1E36T87fShI+DnwX+ANwjNQFmk6VnmPtVg/A9RHxLuCyvN0w1BYXkHQy8Gvg8xHxr9mKzpAXs+SXQh/0QD39aVvFDHl18Gc2KuFPt1okvRO4A/hsK2uGYnN6U8vAHxHPRsSHImIN8HPS2CoRcSwivhARqyNiLbAC2E8KnisLVVRqMfge9BARL+fXSeBnlDTEIGkJ6YP704j4Tc5+JXdBW8MEh3L+S/x/j6XlQ2X86ZOeuvrTjrr605Yq+NOtFkkrgbuA9RFxIGf35E0tA3/rDrykRcCXgc35/YmSTsrpK4FjEfFM7jJNSrokd+nWA3eX0/rj6VZPHvo5I+cvAT5KGi4adrsF/BjYGxHfKewaA27M6RuZ+luPAdflsclVwHnAY1Xxp196auzPjNTYn3b1lO5Pt1okrQB+C9wWEb9vFe7Zm/nenR70RroCPgi8Qfrv9ingFtJd8OeAbzH1C+RzgX2kGyUPAe8o1DNKMvcAsKl1TB31kJ5WmACeIt3o+R75aZIha7mU1K18CtiZt6uA00k3pffn19MKx9yePdhH4emDKvjTLz019+dPpIcPXsufz5Ga+3Ocnir4060W0gXh64WyO4Eze/XGUzYYY0zDqOVQjzHGmN5x4DfGmIbhwG+MMQ3Dgd8YYxqGA78xxjQMB37TWCR9VdIXZ9m/TtLIMNtkzDBw4DemPetIz30bs6Dwc/ymUUi6nfTrxheBv5F+yHMY+AywlDTD5g3AauDevO8wUzOm/gB4K3AE+HREPDvM9hvTDxz4TWOQtAbYDlwMLAaeIE2PsS0i/pHLfAN4JSK+L2k7cG9E/CrvexjYEBH7JV0MfDMirjj+TMZUm8VlN8CYIXIZcFdEHAGQNJbzL8gBfwVwMvDA9APzLIrvA35ZmMF32cBbbMwAcOA3TWOmLu52YF1E7JJ0E3D5DGUWAa9GxOrBNc2Y4eCbu6ZJ7ACulvRmScuBj+X85cDBPFPj9YXyk3kfkeZKf0HStZBmV5R04fCabkz/8Bi/aRSFm7t/Js3W+Axp1sMv5byngeURcZOk9wM/Ao4CnwD+C/yQtF7qEtKyi18bughj5okDvzHGNAwP9RhjTMNw4DfGmIbhwG+MMQ3Dgd8YYxqGA78xxjQMB35jjGkYDvzGGNMw/gcXg6ybbZkAhwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "time_series.pc_wet.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Estimate ENSO phases\n",
+    "\n",
+    "We first need to estimate when El Niño and La Niña were active. This is indicated by the SOI being below -8 or above +8 for a sustained period, for each driver respectively (see the [Bureau of Meteorology information page on the SOI](http://www.bom.gov.au/climate/enso/history/ln-2010-12/SOI-what.shtml) for more details). We will take a four-month rolling mean and find periods where this mean was greater than or less than +8 or -8."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rolling_soi = soi.reindex(time_series.index).interpolate().rolling(28 * 4).mean().SOI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "la_nina = rolling_soi > 8\n",
+    "el_nino = rolling_soi < -8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAARRElEQVR4nO3cf6xkZX3H8ffHXdAAWhQWC7so2xSh20YUtqiJrahBAdOSYpsAbVHUbmmg0aZphPR38A9/NtaAbjcWrUkrqZXWpa6SllRtRSu7Lb8WWFzRwgopi9RfmBZXv/1jzsIwO/fOzL3n3r0+eb+Sm3vOc55zzveemedzz5yZM6kqJEk/+p5ysAuQJPXDQJekRhjoktQIA12SGmGgS1IjDHRJasTEQE9yTZKHktwxx/IkeV+S3UluS3Jq/2VKkiaZ5gz9w8BZ8yw/Gzix+9kEfGDxZUmSZjUx0Kvqc8Aj83Q5F/hIDXwRODLJsX0VKEmazuoetrEWuH9ofk/X9uBoxySbGJzFc/jhh5928sknL2iH3/zf78/U/8inHfLkhu98b/D76Yc9vr0D+oz27/o+vu5c9vcb3dckw+tNs87ofuYw17E68mmHPGnZkU87ZPpagW8eMs/xGtnPNLXM0mei+f6OKY/bTNsfs839z6mJx3hCPZOOx3xjYewxG7P/WcfTTPsbY3R/o4//nNuZ79jNMGb273+aekcfvwMez1kM17iI5+GOHTserqo145b1EegZ0zb2+wSqaguwBWDjxo21ffv2Be3wul0H/K+Y13knjbxg+Gy335dtfHx7B/QZ7d/1fXzduezvN7qvSYbXm2ad0f3MYa5jdd5Jxz5p2XknHTt9rcB1P752qn7Dx3W+WmbpM9F8f8eUx22m7Y/Z5v7n1MRjPKGeScdjvrEw9piN2f+s42mm/Y0xur/Rx3/O7cx37GYYM/v3P029o4/fAY/nLIZrXMTzMMl/zbWsj0+57AGOH5pfBzzQw3YlSTPoI9C3Ahd1n3Z5MfCtqurnX74kaWoTL7kk+ShwBnB0kj3AHwOHAFTVZmAbcA6wG/gecPFSFStJmtvEQK+qCyYsL+DS3iqSJC2Id4pKUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhphoEtSIwx0SWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNmCrQk5yVZFeS3UkuH7P8x5Jcn+TWJDuTXNx/qZKk+UwM9CSrgKuBs4ENwAVJNox0uxS4s6pOAc4A3pPk0J5rlSTNY5oz9NOB3VV1b1U9BlwLnDvSp4CnJwlwBPAIsK/XSiVJ85om0NcC9w/N7+nahl0F/BTwAHA78Oaq+uHohpJsSrI9yfa9e/cusGRJ0jjTBHrGtNXI/KuBW4DjgBcAVyV5xgErVW2pqo1VtXHNmjUzFytJmts0gb4HOH5ofh2DM/FhFwPX1cBu4KvAyf2UKEmaxjSBfjNwYpL13Rud5wNbR/rcB7wSIMmzgZOAe/ssVJI0v9WTOlTVviSXATcAq4Brqmpnkku65ZuBK4EPJ7mdwSWat1bVw0tYtyRpxMRAB6iqbcC2kbbNQ9MPAK/qtzRJ0iy8U1SSGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhphoEtSIwx0SWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhphoEtSI6YK9CRnJdmVZHeSy+foc0aSW5LsTPLZfsuUJE2yelKHJKuAq4EzgT3AzUm2VtWdQ32OBN4PnFVV9yU5ZqkKliSNN80Z+unA7qq6t6oeA64Fzh3pcyFwXVXdB1BVD/VbpiRpkmkCfS1w/9D8nq5t2POAZyb5TJIdSS4at6Ekm5JsT7J97969C6tYkjTWNIGeMW01Mr8aOA14DfBq4A+TPO+Alaq2VNXGqtq4Zs2amYuVJM1t4jV0Bmfkxw/NrwMeGNPn4ap6FHg0yeeAU4B7eqlSkjTRNGfoNwMnJlmf5FDgfGDrSJ9PAD+XZHWSw4AXAXf1W6okaT4Tz9Cral+Sy4AbgFXANVW1M8kl3fLNVXVXkk8DtwE/BD5YVXcsZeGSpCeb5pILVbUN2DbStnlk/l3Au/orTZI0C+8UlaRGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhphoEtSIwx0SWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGjFVoCc5K8muJLuTXD5Pv59N8oMkv9xfiZKkaUwM9CSrgKuBs4ENwAVJNszR7x3ADX0XKUmabJoz9NOB3VV1b1U9BlwLnDum328DHwce6rE+SdKUpgn0tcD9Q/N7urbHJVkL/BKweb4NJdmUZHuS7Xv37p21VknSPKYJ9Ixpq5H59wJvraofzLehqtpSVRurauOaNWumrVGSNIXVU/TZAxw/NL8OeGCkz0bg2iQARwPnJNlXVf/QS5WSpImmCfSbgROTrAe+DpwPXDjcoarW759O8mHgHw1zSVpeEwO9qvYluYzBp1dWAddU1c4kl3TL571uLklaHtOcoVNV24BtI21jg7yqXr/4siRJs/JOUUlqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhphoEtSIwx0SWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNmCrQk5yVZFeS3UkuH7P8V5Pc1v3clOSU/kuVJM1nYqAnWQVcDZwNbAAuSLJhpNtXgZdV1fOBK4EtfRcqSZrfNGfopwO7q+reqnoMuBY4d7hDVd1UVf/TzX4RWNdvmZKkSaYJ9LXA/UPze7q2ubwR+NS4BUk2JdmeZPvevXunr1KSNNE0gZ4xbTW2Y/JyBoH+1nHLq2pLVW2sqo1r1qyZvkpJ0kSrp+izBzh+aH4d8MBopyTPBz4InF1V3+inPEnStKY5Q78ZODHJ+iSHAucDW4c7JHkOcB3w61V1T/9lSpImmXiGXlX7klwG3ACsAq6pqp1JLumWbwb+CDgKeH8SgH1VtXHpypYkjZrmkgtVtQ3YNtK2eWj6TcCb+i1NkjQL7xSVpEYY6JLUCANdkhphoEtSIwx0SWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhphoEtSIwx0SWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaMVWgJzkrya4ku5NcPmZ5kryvW35bklP7L1WSNJ+JgZ5kFXA1cDawAbggyYaRbmcDJ3Y/m4AP9FynJGmCac7QTwd2V9W9VfUYcC1w7kifc4GP1MAXgSOTHNtzrZKkeayeos9a4P6h+T3Ai6bosxZ4cLhTkk0MzuABvptk1xT7Pxp4eIp+B8NKrW2l1gXWthArtS6wtoVYbF3PnWvBNIGeMW21gD5U1RZgyxT7fGLDyfaq2jjLOstlpda2UusCa1uIlVoXWNtCLGVd01xy2QMcPzS/DnhgAX0kSUtomkC/GTgxyfokhwLnA1tH+mwFLuo+7fJi4FtV9eDohiRJS2fiJZeq2pfkMuAGYBVwTVXtTHJJt3wzsA04B9gNfA+4uMcaZ7pEs8xWam0rtS6wtoVYqXWBtS3EktWVqgMudUuSfgR5p6gkNcJAl6RGHJRAT3JNkoeS3DHUdkqSLyS5Pcn1SZ7RtR+S5K+69ruSXDG0zgVd+21JPp3k6GWs69AkH+rab01yRtd+WJJPJrk7yc4kb19MTX3WNrRsS5J7uhpfu8i6jk/yL91jszPJm7v2ZyX5pyRf7n4/c2idK7qvidiV5NVD7ad1Ne/uvkpi3MdhD0ptQ8u3Dj8GB7uuJRgDM9WW5Kiu/3eTXDW0nd7HQV+1dct6GwcLqOvMJDu6x21HklcMbWtxY6Cqlv0H+HngVOCOobabgZd1028AruymLwSu7aYPA74GnMDgDd2HgKO7Ze8E/mQZ67oU+FA3fQywg8E/yMOAl3fthwL/Cpy9zMdsbG3d/J8Cb+umn7L/+C2irmOBU7vppwP3MPiKiHcCl3ftlwPv6KY3ALcCTwXWA18BVnXLvgS8hMF9DZ9a7HHrs7Zu+XnA3ww/BgezriUaA7PWdjjwUuAS4Kqh7fQ+Dvqqre9xsIC6Xggc103/DPD1oW0tagwsKmQW+eCcwJPD6ds88Sbt8cCd3fQFwPXdk/eo7mA9CzgE2MvgrqkAm4FNy1jX1cCvDfW7ETh9zPb+HPiNZT5mc9bG4I7ew5fwcf0EcCawCzh26Am/q5u+ArhiqP8N3RP4WODuofYLgL9YCbV100cA/9YN1EUFeo/HbEnGwCy1DfV7PSOhuVTjoI/alnIcTFtX1x7gGwz+WS96DKyka+h3AL/YTf8KT9yo9HfAowy+RuA+4N1V9UhVfR/4LeB2BjcxbQD+chnruhU4N8nqJOuB03jyzVUkORL4BQaBuhRmqq2rB+DKJP+R5GNJnt1XMUlOYHD28e/As6u7F6H7fUzXba6viVjbTY+2r4TaAK4E3sPgY7m9WUxdSz0Gpqxtmu30Pg4WU9tSjoMF1PVa4D+r6v/oYQyspEB/A3Bpkh0MXrY81rWfDvwAOI7By83fTfITSQ5h8GR+YbfsNgZnMstV1zUMDvh24L3ATcC+/SslWQ18FHhfVd27BHUtpLbVDO7i/XxVnQp8AXh3H4UkOQL4OPCWqvr2fF3HtNU87Qe9tiQvAH6yqv6+j3p6rGvJxsAMtU3aTu/joIfalmQczFpXkp8G3gH85v6mMd1mGgPTfJfLsqiqu4FXASR5HvCabtGFwKe7s5GHknwe2Mjg8gtV9ZVunb9lcJ1qWeqqqn3A7+zvl+Qm4MtDq24BvlxV7+27pkXU9g0GZ5j7g+ljwBsXW0cXLB8H/rqqruua/zvJsVX1YAbfvPlQ1z7X10Ts6aZH21dCbS8BTkvyNQZj5pgkn6mqMw5yXS+A/sfAjLVN0us46Km23sfBrHUlWdft/6L9jx89jIEVc4ae5Jju91OAP2BwPRAGl1lekYHDgRcDdwNfBzYkWdP1OxO4a7nq6t7FP7ybPhPYV1V3dvNvA34MeEvf9SymthpcmLseOKPbxCuBOxdZQxi8zL+rqv5saNFW4HXd9OsYXFfc335+kqd2l4NOBL7UvST9TpIXd9u8aGidg13bB6rquKo6gcGbbPcsMsx7qYslGAMLqG2+bfU6Dvqqre9xMGtd3SWfTzJ4X+TzQ3UtfgwsxZsCU7xp8FEG18S/z+C/0huBNzN4w/Me4O088WbfEQz+g+5kcNB/b2g7lzB4At/G4AE6ahnrOoHBmx53Af8MPLdrX8fgZdJdwC3dz5uW+ZiNra1b9lzgc90xuxF4ziLremn399429Peew+AV1I0MXhncCDxraJ3fZ/BJjV0MvYvP4JXXHd2yq/b/PSuhtqHlJ7D4T7n0ecz6HgMLqe1rwCPAd7vn5oalGAd91db3OJi1LgYnX48O9b0FOKaPMeCt/5LUiBVzyUWStDgGuiQ1wkCXpEYY6JLUCANdkhphoEtSIwx0SWrE/wPDzInThAPbQwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot the El Niño and La Niña periods.\n",
+    "for i, group in la_nina.groupby(np.cumsum(la_nina != la_nina.shift())):\n",
+    "    if not group.iloc[0]:\n",
+    "        continue\n",
+    "\n",
+    "    start = group.index[0]\n",
+    "    end = group.index[-1]\n",
+    "    plt.axvspan(start, end, facecolor=\"lightblue\")\n",
+    "\n",
+    "for i, group in el_nino.groupby(np.cumsum(el_nino != el_nino.shift())):\n",
+    "    if not group.iloc[0]:\n",
+    "        continue\n",
+    "\n",
+    "    start = group.index[0]\n",
+    "    end = group.index[-1]\n",
+    "    plt.axvspan(start, end, facecolor=\"pink\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cumulative distributions of wet surface area for each phase\n",
+    "\n",
+    "For El Niño, La Niña, and the neutral phase (when neither El Niño nor La Niña are active), collect all surface area observations that occurred during that phase. We can then treat these surface area observations as samples of a random variable, conditioned on the ENSO phase."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pc_wet</th>\n",
+       "      <th>px_wet</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>date</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1987-12-07</th>\n",
+       "      <td>0.004000</td>\n",
+       "      <td>32563.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1987-12-08</th>\n",
+       "      <td>0.005016</td>\n",
+       "      <td>40380.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1987-12-09</th>\n",
+       "      <td>0.006031</td>\n",
+       "      <td>48197.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1987-12-10</th>\n",
+       "      <td>0.007047</td>\n",
+       "      <td>56014.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1987-12-11</th>\n",
+       "      <td>0.008063</td>\n",
+       "      <td>63831.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2020-04-01</th>\n",
+       "      <td>0.127500</td>\n",
+       "      <td>984239.500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2020-04-02</th>\n",
+       "      <td>0.138125</td>\n",
+       "      <td>1066206.875</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2020-04-03</th>\n",
+       "      <td>0.148750</td>\n",
+       "      <td>1148174.250</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2020-04-04</th>\n",
+       "      <td>0.159375</td>\n",
+       "      <td>1230141.625</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2020-04-05</th>\n",
+       "      <td>0.170000</td>\n",
+       "      <td>1312109.000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>11809 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              pc_wet       px_wet\n",
+       "date                             \n",
+       "1987-12-07  0.004000    32563.000\n",
+       "1987-12-08  0.005016    40380.000\n",
+       "1987-12-09  0.006031    48197.000\n",
+       "1987-12-10  0.007047    56014.000\n",
+       "1987-12-11  0.008063    63831.000\n",
+       "...              ...          ...\n",
+       "2020-04-01  0.127500   984239.500\n",
+       "2020-04-02  0.138125  1066206.875\n",
+       "2020-04-03  0.148750  1148174.250\n",
+       "2020-04-04  0.159375  1230141.625\n",
+       "2020-04-05  0.170000  1312109.000\n",
+       "\n",
+       "[11809 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "time_series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "en_wet = time_series[el_nino].px_wet\n",
+    "ln_wet = time_series[la_nina].px_wet\n",
+    "neutral_wet = time_series[~el_nino & ~la_nina].px_wet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then estimate and plot the cumulative distribution functions (CDF) of the wet surface area."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pcs = np.linspace(0, 100, 100)\n",
+    "en_cdf = np.interp(pcs, np.linspace(0, 100, len(en_wet)), np.sort(en_wet))\n",
+    "ln_cdf = np.interp(pcs, np.linspace(0, 100, len(ln_wet)), np.sort(ln_wet))\n",
+    "neutral_cdf = np.interp(\n",
+    "    pcs, np.linspace(0, 100, len(neutral_wet)), np.sort(neutral_wet)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEMCAYAAAArnKpYAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdeXhU5d3/8fedfSP7QkgIAUIgAcIWdhAUQXZEVLQtuD5UrXvR4vZUW+1jrbVqW+3PKhZEVFwARUUFAUF2SFiTkA2SkH3fZ71/fySkoIGEkGQC831dF1cyM2fmfDMk5zPn3JvSWiOEEEIAONi6ACGEEF2HhIIQQogmEgpCCCGaSCgIIYRoIqEghBCiiYSCEEKIJk62LuBSBAYG6sjISFuXIYQQl5UDBw4Ua62Dmnvssg6FyMhI9u/fb+syhBDisqKUOnW+x+TykRBCiCYSCkIIIZpIKAghhGhyWbcpNMdkMpGTk0N9fb2tS+my3NzcCA8Px9nZ2dalCCG6mA4LBaXUcmA2UKi1HtR4nz/wERAJnARu1lqXNT72BHAXYAEe1Fp/05b95uTk0K1bNyIjI1FKXfLPcaXRWlNSUkJOTg69e/e2dTlCiC6mIy8f/QeY/pP7lgGbtdb9gM2Nt1FKxQK3AAMbn/OGUsqxLTutr68nICBAAuE8lFIEBATImZQQolkddqagtf5BKRX5k7vnAZMbv18BbAV+13j/h1prA5CplEoDRgG72rJvCYQLk/dHiM5jtVoxGAzU19djMBioq62lKi8Pr/p6/IOD8R08+KJeT2tNSm45AAPC/Nq93s5uUwjRWucBaK3zlFLBjfeHAbvP2i6n8b6fUUotAZYAREREdGCpbefo6Mjgs/6jb7nlFpYtW8bkyZN5+eWXiY+PP2f7yZMnU11d3TTmYv/+/SxdupStW7eyf/9+Vq5cyeuvvw7Am2++yYoVKwgPD2fZsmU/ey0hRPvRWmM0GpsO6Gd/be77ptt1ddTV1mIwGDBZLM2+dq8dOxgydCjD/vKXVtWRll/JtmO5/HA8j4KKOkZFBfHHW0e194/cZRqam/vo2uzqP1rrt4C3AOLj47vkCkHu7u4kJiZe1HMKCwv5+uuvmTFjxjn3x8fHn3Pgv/fee7n33nvbpU4h7InVaqWwsJCSkpLzHtyb+9rSQmQOSuGsFE4WC44GA6q2FqqrcTUa8TAacTCZcFEKd29vPP396RYUhHdoKMHXXEPggAHnfd06o5mMgkr2pBbyw/E88spqcXRQjOgTyKJJ0YztH9LebxHQ+aFQoJQKbTxLCAUKG+/PAXqetV04kNvJtdnUY489xvPPP/+zUNi6dSsvv/wyGzZs4NlnnyUrK4uMjAyysrJ4+OGHefDBBwF45ZVXWL58OQB33303Dz/8cKf/DEJ0JfX19eTk5JCdnU1OTg45OTkYjcZztlFK4erqipubGy7Ozrg4OuIBeDs54ejqigPgUFMD1dVQUYEuK8NaUoKqrMTRaMTRZEJZLCjAxd8fj4gIPHv1wjMu7r/f9+qFi7//BS/bVtWZSM+vIDW/gvT8StLyKsgpqUHTEDrDegdwy/i+jBvQHW93l4582zo9FD4HbgNebPy6/qz7VyulXgF6AP2AvZe6s6N//COVSUmX+jLn8I6JYdAzz1xwm7q6OoYOHdp0+4knnmDhwoUXfM7YsWNZu3YtW7ZsoVu3bufdLjk5mS1btlBVVUX//v259957OXz4MO+++y579uxBa83o0aOZNGkSw4YNu7gfTojL1Nm96s6EQGFhw2dOpRQBXl5E+fkRAHjW1UFZGdbiYsxFRRiLizGUlGCpqWn2tZ39/HANDMQ1IAC3iAhchg/HNTAQt8BAXAIDcQsKwqNnT5y9vVtVq9Fs4UhWKSmny0nLryQtv4KC8rqmx4O83Yjq7sPkQWFEdfcmJtwPH4+ODYKzdWSX1A9oaFQOVErlAL+nIQzWKKXuArKAmwC01seUUmuA44AZ+I3WuvkLcZeBtlw+Anj66ad5/vnn+fOf/3zebWbNmoWrqyuurq4EBwdTUFDAjh07mD9/Pp6engDccMMNbN++XUJBXNa01YqpqgpzZSXGigpMFRWYKisxVVRQWVpKQUUFRfX1lJrNlDs6YnZs6LDoaDTiWVREaGEhXkVFeBQX42g2A1DT+O/sA73fkCG4BAaec6B3PfMvIACHdhjPU1hRx960QvalFpJwsgSDqeHw1sPfg/49fJk1vBdR3b3p290bX0/XS97fpejI3ke3nuehKefZ/gXghfasoaVP9F3NNddcwzPPPMPu3bvPu42r639/YRwdHTGbzS1e8xSiq6jNzqb88OH/HuTPPtg3HvCbvlZVgdaYXVyo8/OjNjCQmoAAaoKCMDV+AFKAp8FAiMGAn9YEODvj160bLtHROMfH4+zjg7OPDy7e3g1fAwLa7UDfkpTccnYk5bM3tZCTRVUAdPd157qh4YzsG8zAnn54unW9AaRdpaFZNHrqqae455576NOnT6ufc9VVV3H77bezbNkytNasXbuW9957rwOrFKJ1tNZUJiWR/9135H/33c8u5zq4uDQduJ26dcMcGkrdgAFUe3hQ5exMudbUntV7x8fTk77du9MzIoLwyEhCQ0O73Mj81LwKVmxNYV9aEY4OisER/iwZGsPIqGB6Bnh2+S7hEgod4KdtCtOnT+fFF19s1XNnzpxJUFCz05yf1/Dhw7n99tsZNaqhe9rdd98tl46EzWiLhdIDB8j79lvyv/uOupwcUAr/+Hhin3wS39GjMbq4UKM1ZZWVFBQUkF1QQEFBASaTCWhoBwj086Nv9+6EhITQvXt3unfv3nSJtCs6WVjFiq0p7EwpoJu7M3deM4DZIyK65NnAhajL+dJDfHy8/ul6CklJScTExNioosuHvE+iPWmLhZK9e8nduJGsLVuorq/H5OODy6BBOPTpg9nXl+r6eioqKqj5SYOum5tb04H/zNegoCCcnC6Pz6zlNQZWbD3BxoQs3FycWDCmD/NHR+Lp2nXDQCl1QGvd7CCny+NdF0J0GUajkdzcXEpKSshPSqIgNZWKsjLqXVwweXigp5zbbOhcVYWPgwM+Pj50794dHx8fvL298fHxwd/fH29v7y5/SaU5RrOFtXtO8uGONAxmC3NHRvLLif3w7sSeQh1BQkEIcV5aayoqKsjOzm7q6pmfn//fzg1WKy719Xh6e9MzJITgqCj8AgObDvo+Pj64ubldlgf989FasyulgLc2JZFXVsuYfsHcfW0MPQO9bF1au5BQEEKco7S0lJSUlKYgqK6uBsDZyQlfs5nQ5GTcT58mOCiI6FtuIXz2bJzc3W1cdec4WVjFm98eIzGzhIhAL/70y1GM6HNxbYBdnYSCEAKAiooKtm3bRmJiIlprfH19Cff3x8NoRO/ZA0eP4uDkRI9Zs+j9+OP4Dh16RZ0BXEhlnZH3tp1gw/5TeLg6c9/0gcweEYGjw5W3TpmEghB2rqKigl27djVNyDgkKorwnBwqPv+cmpMnwcGBoDFjCP3DHwi97jpcAwJsW3AnsmrNVwezWLElhep6E7NG9GLxpOjLvt3gQiQUhLBDJpOJ5ORkEhMTycjIQClFHzc3AnfuxPTuu+Q5OhIwdix9776b7tOm2VUQnJFdXM3fNhzmWHYZcb38ufe6gfQJad1UFpczCYUO4OXl1XQd9mJs3bqVq6++ms8//5w5c+YAMHv2bJYuXcrkyZO5++67efTRR4mNjaW0tJSbbroJR0dHhg0bdsGpMYSAhgbS7OxsEhMTOXbsGEajES9nZ/qUluK+bRuuVVV4DRtG2LPP0mPmTLsMAgCLVfPJrgze23YCV2dHls4dwrVxYXZzqUxCoYsJDw/nhRdeaAqFs7399ttN3/v7+7N58+bOLE1cpgoLCzly5AhHjhyhoqICJwcHutfU4LFrF545OXhGRBB+++2EzZuHl50v0VpQXsuf1yVyLLuM8QO6c/+Mgfh7udm6rE4lodBJvvjiC55//nmMRiMBAQG8//77hIT8fD70IUOGYDKZ+O6775g6deo5j529SI+XlxcPPfQQGzZswN3dnfXr1xMSEtLq/YgrW2VlJUePHuXIkSPk5+ejgECzmT4JCXRLTcXD15ceM2fSY/Zs/IYPt5tPweejtWbL0Vz+8fVRtIbH5w1hSly4rcuyiSs6FN785hgZBZXt+pp9Qry597qBF/28CRMmsHv3bpRSvP3227z00kv89a9/bXbbp59+mqeffvpnoXC2mpoaxowZwwsvvMDjjz/Ov//9b55++umL2o+4stTW1nL8+HGOHj3KqVOnAPADeh07hvexY7g7OxM6fTphTzxBwOjROFwmI4Y72rHsUt7elMzxnDJiwn353fXDCPXzsHVZNiO/FZ0kJyeHhQsXkpeXh9FopPcFTtMnTpwIwPbt28+7jYuLC7NnzwZgxIgRfPfddxe9H3H5q6ur48SJExw9epSMjAysViveDg70OnkSz4QEPAwGQq65hrC//Y3gSZNwdLXttMxdSW5pDe9sTmZHcj7+Xq48NGsw1w0NvyK7mV6MKzoU2vKJvqM88MADPProo8ydO5etW7fy7LPPXnD7p556ihdeeOG88784Ozs3nfKfmUK7LfsRl5+KigqSk5NJSUnh1KlTWK1WPB0cCDt9Gs/9+3EvKyNw9GjCn3yS0OnTW734i72was3n+06yfHMyDg6KxZOiWTCmN24uV/ThsNXkXegkFRUVhIWFAbBixYoWt582bRrPPPMMubkXtyrpxe5HdH1aa/Lz8zlx4gTJycnk5+cD4O3oSPjp07gnJOBRXIz/sGGE3ncfPaZPx71HDxtX3TXll9Xy1y8OcfhUKaOignhoVhyB3vbVkNwSCYUOUFtbS3j4fxupHn30UZ599lluuukmwsLCGDNmDJmZmS2+zlNPPcW8efMuat9t2Y/oeqqqqkhPTyc9PZ2MjAxqa2sBCPb0pF9xMc4//ohbRQW+Q4fSY8kSQmfMwEOC4Ly01mw6fJo3Nh4DBY/OiWPakHC7b2BvjkydbafkfepaLBYLp06dIi0tjfT09Kb1hT09PAjz9sYrJwf9zTeokhLcw8PpuWABPefPx6NnTxtX3vVV1hr5x9dH2XY8j0ER/jw+bwghvvbbkAwydbYQXVJNTQ2pqamcOHGC9PR0jEYjjg4OhHh5MdjBAbekJCwHDoDZjIObGz2mT6fnjTcSMHo0ys4bQ1vDYtV8nZDFf7akUGswc/vV/bl5XF8cHeTs4EIkFIToJGfaBs4EwenTpwHwcHKih8GAZ0oKTomJOJrNOLi44DNkCP7/8z/4jxhBwMiROHldGVMzd4Zj2aW8sfEYafmVDI7w577p9jFFRXuQUBCiA9XV1ZGenk5aaiqpJ05QW18PgHddHWEZGXTLzMS9tBQXb2/8RozA/5FHCIiPx2fwYOk+2gal1fUs35zCd4dzCOzmxhPzhzFpYKi0HVwECQUh2pHWmtzcXJL27yc1NZXCxqUnHQ0GvHNzCTp9Gt/iYgL79sVn0CB8Fy7EZ9AguvXrJ5eELoHFamX9vlO8t+0ERpOFheP6cuvEKNylm+lFk3dMiEugrVaKkpNJ2ruXjKws8kwmTI1jSzyKiwktKKCHqysRffviO3s2voMH49W3r4wmbkfHc8p4/csjZBZWEd83iHuviyU8QC61tZX8ZgrRSlprarOzKU9M5OSRI6Tn51Po4ECNnx8ohVN9PQF1dYT7+NBvwAC633wz3aKicHDuugu4X84qao28+30yXydkE+jtxjM3Dmf8gO5yqegSSSh0AKUUjz76aNOcQy+//DLV1dVtGl1cXl7O6tWrue+++y76uZGRkezfv5/AwMCLfq4Ac3U15UeOUJaYSFliIsWHDlHo7U1RdDS1QUEQEIA/EB0cTP8hQ4gaORJHlyt38ZWuwmCysG5vJh/+mE690cKCMb1ZNClaLhW1E3kXO4CrqyufffYZTzzxxCUfkMvLy3njjTeaDQWLxYKjo+Mlvb5ooK1WqjMzKUtIoCwhgfLERCpPnACrlXpvb8pGjaJo+nTMSuHXrRsTRo9myLBheHjYd3/3zmSxar4/cpoVW1MoqqxnTL9g7pwygF5B3Wxd2hVFQqEDODk5sWTJEv72t7/xwgsvnPNYUVER99xzD1lZWQC8+uqrjB8/nmeffRYvLy+WLl0KwKBBg9iwYQPLli0jPT2doUOHMnXqVGbNmsVzzz1HaGgoiYmJHD9+nOuvv57s7Gzq6+t56KGHWLJkSaf/zJcbU2UlZYcOnRMCpsqGGXWdunXDb+hQuk+ZQqq7O6mFhTg6OhIbG8uIESOIiIiQSxSdSGvN7hOF/GdLCieLqogO9eGxeUMZEmmfiwB1tCs6FDZu3Ng0T0x76d69O9OnT29xu9/85jfExcXx+OOPn3P/Qw89xCOPPMKECRPIysriuuuuIykp6byv8+KLL3L06FESExOBhtXZ9u7dy9GjR5tmQF2+fDn+/v7U1dUxcuRIFixYQICdrpp1PsbycvK//ZbSgwcpS0ykOi0NtAal6BYdTeiMGfgNH47fkCHUeXuzfccOjh49inN9PePGjWPcuHF4enra+sewO0dOlfDO98kk5ZQT5u/JkzcMY2JsKA4Syh3mig4FW/L29mbx4sW8/vrruLu7N92/adMmjh8/3nS7srKSqqqqi3rtUaNGnTMl9uuvv87atWsByM7OJjU1VUKBhk+YZQkJnFq9mtwvv8RqNOLs54ff0KGEzZ6N37Bh+MbF4dyt4fJDQUEBG3/4gePHj+Ps7Mz48eMZO3ashIENZBZUsnxLCntTCwns5sZDswYzbUg4To7SbbejXdGh0JpP9B3p4YcfZvjw4dxxxx1N91mtVnbt2nVOUEDDJSer1dp0u75xkFNzzj5Ibd26lU2bNrFr1y48PDyYPHnyBZ9rD0xVVZz+/HNOrV5NZXIyTl5e9LzpJnotXIh3bOzPLv3k5uayfft2kpOTcXFxYcKECYwdO1baC2ygsKKOldtOsOlQDp5uTtw9ZQBzR0bi6ixtZ53lig4FW/P39+fmm2/mnXfe4c477wQapsT+xz/+wWOPPQZAYmIiQ4cOJTIykg0bNgBw8ODBptlNu3XrdsEziYqKCvz8/PDw8CA5OZndu3d38E/VNWmtKTtwgKw1a8j96issdXV4DxxI3PPPEzZ3Lk4/+bSvtSYjI4Mff/yRzMxM3NzcmDRpEqNHj/5ZYIuOV2c0s2ZnOp/uysCq4caxfbh5fF+83aU3V2ezSSgopR4B7gY0cAS4A/AAPgIigZPAzVrrMlvU155++9vf8o9//KPp9uuvv97U3mA2m7nqqqv417/+xYIFC1i5ciVDhw5l5MiRREdHAxAQEMD48eMZNGgQM2bMYNasWee8/vTp0/nXv/5FXFwc/fv3Z8yYMZ3689maqaqKrI8/Juujj6hOS8PR05OwefPotXAhPoMH/+yswGq1cvz4cX788Ufy8/Px8vLi2muvZcSIEbi5ybz6nc1i1Ww6nMN/tqRQWm1g8sAe3HlNf7ufxdSWOn3qbKVUGLADiNVa1yml1gBfAbFAqdb6RaXUMsBPa/27C72WTJ3ddpf7+2SqqiJzxQoyli/HVFGB37BhRCxcSI+ZM392VgANl+MOHjzI3r17qaioICAggHHjxhEXF3fe1e1Ex9FasyulgHe3pJBVXE1MmC+/nhZLTLifrUuzC11x6mwnwF0pZaLhDCEXeAKY3Pj4CmArcMFQEPbHVFnZEAbvvoupooKQKVOIvv9+fOPimt2+vLyc3bt3k5CQgNFoJDIykhkzZhAdHS3dSm3k0MkSln+fTPLpcsIDPHn6xuFMkJHIXUanh4LW+rRS6mUgC6gDvtVaf6uUCtFa5zVuk6eUCm7u+UqpJcASgIiIiM4qW9hYfVERGcuXc2r1aszV1YRce21DGAwe3Oz2ZWVlbN++nUOHDgEN4z7GjBlDaGhoZ5YtznKysIp3NiexN62IQG83Hp0Tx7VxYTjKRIBdSqeHglLKD5gH9AbKgY+VUr9q7fO11m8Bb0HD5aMOKVJ0GbW5uaS9+SbZn3yC1Wymx4wZRN1zDz6xsc1uX15ezrZt2zh06BAODg6MGDGC8ePH4+Pj08mVizOKK+tZuS2F7w7l4O4iPYq6OltcProWyNRaFwEopT4DxgEFSqnQxrOEUKCwrTvQWsup6AVcDkuwmqqqSPvXv8hYvhyA8PnziVqyBM/IyGa3t1qt7N69my1btgANYznGjx9Pt24yBYKt1BvNfLIrgzW7MrBaNdeP7s2t46Pw9pAeRV2ZLUIhCxijlPKg4fLRFGA/UAPcBrzY+HV9W17czc2NkpISAgICJBiaobWmpKSky/a0sRgMZH/8MSmvvYaxtJSw669nwG9/e8FF6U+fPs2GDRvIz8+nf//+zJgxQ84MbMhi1Ww+0tCjqKTKwMSYUO6aMoBQP+lRdDmwRZvCHqXUJ8BBwAwk0HA5yAtYo5S6i4bguKktrx8eHk5OTg5FRUXtVfIVx83NjfDwcFuXcQ5TVRWnPviAjHffxVBYiP+oUQx84onzNiAD1NbWsnnzZg4ePIiXlxc333wzAwYMkA8DNmLVmh+T8lm57QRZxdVE9/DhqQXDGdjT39aliYvQ6V1S21NzXVLF5cVQWkrG8uWcXLUKc1UVgePGEfXrXxM4fvx5D+5Wq5WDBw/y/fffU19fz+jRo5k8eTKusnylTWit2ZNayHvbTpCWX0lEoBeLJ0UzPqa7zFHURXXFLqnCzpmrq0lfvpyMd97BXFND6PTpRC1ZcsEzA4CTJ0+yceNGCgoK6NWrFzNnziQ4uNmOaqKDaa3Zn17Eym0nOJFbQaifB4/NG8LVg8JwdJAwuFxJKIhOpS0WMleuJPWNNzCWltL9uusY8MgjdOvX74LPKy8v59tvvyUpKQkfHx8WLFjAwIED5VKRDVi15kB6Ee9vTyUpp5wQH3cenj2YqXEyYd2VQEJBdBqLwUDCb39L3tdfEzh+PDFLl7Z4ZmA2m9m5cyfbt29HKcXkyZMZN24czrLEZaerMZj47lAOX+w7RU5pDUHeDbOXTh0SjrOEwRVDQkF0ClNVFXuXLKF0715in3ySvnfd1eJz0tLS+PrrryktLSU2NpZp06ZJryIbyCur5dPdGWw6nEOd0UJMmC+/u34oE2NDJQyuQBIKosNZzWYOPPAAZQcPMvxvfyNs7twLbl9WVsY333xDSkoKAQEBLFq0iD59+nRSteKMylojq3ek8cW+kw1naQN7MHdkL6J7+Nq6NNGBJBREh0t66SWKtm9nyP/93wUDwWQysX37dnbu3ImDgwPXXnstY8aMkXWoO5nFqvlsdwYf7Eijzmhm2tCeLJ4UTUC3rjm2RbQvCQXRoTLfe4+Md96h9+LFRNx8c7PbaK1JSkri22+/paKigsGDB3Pttdfi7e3dydWKGoOJFz9LYG9aEaOigrhrSgyRwTIq3J5IKIgOk/fNNxx97jlCrr2W2KeeanaboqIiNm7cSEZGBsHBwdx+++306tWrkysVAKdLavjDxwfIKq7mgZmDmD1C/h/skYSC6BDlhw9z8JFH8Bs6lOGvvorDT9YsKC0tZdu2bRw5cgQXFxemT5/OyJEjcZAZMztdaXU9q7en8dXBLNycHXn+FyMZ0SfI1mUJG5FQEO2uLjeXvUuW4BoUxMh//Quns5a3rKio4IcffiAxMREHBwfGjBnDhAkTZD1kG6ioNbJ2Tyaf7cnEbLEyY1hPfjGxn7Qd2DkJBdGuzLW17P31r7HU1TF25UpcAwMBqKqqYvv27Rw8eBCtNSNGjGDixIkyi6kNnCqqYu2eTDYfOY3RbGVSbCi3Xd2fMP+fr1gn7I+Egmg3pspKDj3xBJVJSYz697/pFh1NTU0NP/74I/v27cNisTB06FCuuuoqfH2lW2Nn0lpzMKOYT/dkciC9CBcnB6YMDuP6Ub2lIVmcQ0JBXBKtNeWJiZz68ENOb9iAtb6e2GXL8IiP55tvvmH//v1YLBYGDx7MpEmT8PeXGTM7k8VqZduxPD7elUFGQSX+Xq7cNjmaWSN64SPrGohmSCiINjHX1JCzbh2nVq+mMjkZRw8PwufNI/iGG0goLOSD117DarUSFxfHhAkTCGy8jCQ6R73JwjcJWXy6O5OCijoiAr14dE4cVw/qgYuTjPsQ5yehIC5KfUEBmStXcuqDDzBVVOA9cCCD//hHwufOpcZiYdWqVZSWljJ06FAmTJiAn5+frUu2K7UGMxsOnOLT3RmU1xgZ2NOP+6YPZFS/YJnGWrSKhIJolerMTFLfeIPTX3yBNpvpPm0afe+6C7/hw1FKUVxczHvvvYfBYGDx4sUy1qCT1dSbWLv3JGv3ZFJdb2JEn0BunRDF4F4Bti5NXGYkFMQFmWtrSX3jDdLffhsHJyd63XILfe64A8+zDvrl5eWsXLkSq9XK7bffTvfu3W1YsX2pM5pZt/ckn+zKoLrexJh+wdw6MYoBYXKGJtpGQkGcV8H333P4f/+X+rw8wufPJ+Z3v8Mt6NxBTTU1NaxatQqj0cgdd9xBSEiIjaq1LzUGE18dyOLjXRlU1BoZ3S+YRZOi6Rcqs8iKSyOhIJpVtGMH++65B6+oKIa/+ioB8T9fua++vp5Vq1ZRUVHBokWLJBA6QWFFHev2ZvJ1Qja1BjMj+gSyeHK0nBmIdiOhIH6mOiOD/fffj1dUFBPWrMHJy+tn2xiNRlavXk1hYSG33norERERNqjUPmitST5dzto9mWxPygfgqthQ5o/uzYAwGe8h2peEgjiHsayMvXffjYOzM6PeeqvZQNBas27dOrKzs7nxxhuJioqyQaVXvnqjmS3Hctmw/xRp+ZV4uDpxw5jezBsZSbCPe8svIEQbSCiIJhaDgX333ktdXh5jV63CIzy82e22bdtGUlISU6dOZeDAgZ1c5ZXvVFEVXx3M4rtDOdQYzPQO7sYDMwdxzaAwPFzlT1Z0LPkNE0DDp/9DTz5J6b59DH/1VfxHjGh2u+TkZLZt28aQIUMYO3ZsJ1d55ao1mNl6LJdvE7NJOl2Ok4NiYmwoc+J7ERvuh5IxBqKTSCgIAE78/e+cXoj8158AACAASURBVLeO/o8+SticOc1uU1RUxNq1awkLC2P27NlyoGoHyafL2HAgix+O52EwWYgI9GLJ1BimDA7D19PV1uUJOyShIMjftIkTr71G+A030O+++5rdpqSkhJUrV+Ls7MzNN9+Mk5P86rSVyWJl+/E81u09SUpuOe4ujlw9qAfTh/ZkQJivhK2wKfnLtnM1WVkkLF2Kz8CBxD3/fLMHpOLiYlasWIHWmsWLF8symW1UXFnPxoQsvjyYRWm1gfAAT34zfSDXxoVLW4HoMuQ30Y5ZDAYOPPAASini//lPHF1/frni9OnTrF69GqUUixcvJjg42AaVXr4sVs3+9EK+OpjN3tQCrBpGRQUxb1RvhvcJlPmIRJcjoWDHkv7yFyqOHiX+zTfx6NnzZ4+npaWxZs0aPD09+dWvfkVAgMyj01olVfV8dTCLjYnZFFfW4+fpyk1j+zJ9WE96yGI2oguTULBT+Zs2kfnuu0QuWkTotGnnPGa1Wvnhhx/Ytm0bISEh/PKXv5QV0lop+XQ56/Zm8sPxPKxWzfC+Qdw7LZYx0SE4Ocr606Lrk1CwQ7W5uSQ+/jg+AwcS+8QT5z5WW8unn35KRkYGcXFxzJo1CxcXWYzlQixWK9uT8lm3J5Ok0+V4uDgxJ74X80ZGylmBuOzYJBSUUr7A28AgQAN3AinAR0AkcBK4WWtdZov6rmQWg4EDv/kN2mJhxOuvn9OOkJ+fz4cffkh1dTVz5sxh2LBh0hPmAmoNZjYmZrNuT8NCNj38Pbj3ulimDgnH09XZ1uUJ0Sa2OlN4Ddiotb5RKeUCeABPApu11i8qpZYBy4Df2ai+K9ax55+n/PBh4t94A8/IyKb7jx8/zrp163Bzc+POO++kR48etiuyiyuvMfDJrgy+OphFjcHMoAh/7rmu4RKRNByLy12rQkEpFQL8CeihtZ6hlIoFxmqt37nYHSqlvIGrgNsBtNZGwKiUmgdMbtxsBbAVCYV2dWb5zL53303oddcBDSOZt2/fzpYtWwgPD2fhwoV4NTPfkWiYrvrTXZl8ujsDo9nChJhQFozpI5PSiStKa88U/gO8CzzVePsEDZd6LjoUgD5AEfCuUmoIcAB4CAjRWucBaK3zlFLS97EdVZ04weGnn8Z/1CgGPPYYAGazmc8//5wjR44wZMgQZs+eLYPSmlFrMPPVwSw++jGNyjoTE2NCuW1yND0DJTzFlae1R4BArfUapdQTAFprs1LKcgn7HA48oLXeo5R6jYZLRa2ilFoCLAFkuuZWMtfUsP/++3Hy9GTEa6/h4OREXV0dH374IVlZWVxzzTVMmDBB2g9+oriynvX7TvLlgVPUGMwM6x3Indf0J7qHnBmIK1drQ6FGKRVAQ6MwSqkxQEUb95kD5Git9zTe/oSGUChQSoU2niWEAoXNPVlr/RbwFkB8fLxuYw12Q2vN4WeeoTozk7ErV+IWHExZWRmrV6+mrKyMBQsWMGjQIFuX2aWcLKxizc50th7LRWvN+AGh3Di2tyxkI+xCa0PhUeBzoK9S6kcgCLixLTvUWucrpbKVUv211inAFOB447/bgBcbv65vy+uLc51ev57T69fT/+GHCRw7lvT0dD755BMAFi1aRK+z1lq2d1lFVby/PY1tx3JxdXZkTnwv5o/qTXc/D1uXJkSnaVUoaK0PKqUmAf0BBaRorU2XsN8HgPcbex5lAHcADsAapdRdQBZw0yW8vqBhPMKR3/8evxEjiLr3Xnbs2MHmzZsJDg5m4cKF+Pv727rELiGrqIoPdqSx5WhDGCwc35cFY/rg7SHjM4T9uWAoKKVuOM9D0UoptNaftWWnWutE4OeL/jacNYh2oK1WEh97DG21MuSll9jw1VckJCQwaNAg5syZIwPSgGPZpazZmcHuEwW4Ojty49g+3Di2j0xZLexaS2cKzU+s30ADbQoF0fEyV6ygZPduYl94gS927iQ1NZWJEydy9dVX23WDslVrdp8o4OOdGRzPKcPb3ZlfXdWPOfG9JAyEoIVQ0Frf0VmFiPZTfuQISS+9hO+0aXxfVUVeXh6zZs0iPr65kzP7YLZY2XI0lzU708kqribE1537pg/kuiHhuLlIN1whzmjp8tGvtNarlFKPNve41vqVjilLtJWpqooDDz6IOSKCA/36UVtUxC233EJ0dLStS7OJepOFrw9m8enuDIoq6+kd3I3fXT+USQNDcXSQCeqE+KmWPiKdmc2ruSkypTtoF3T0uecorqvj5NSpOFqt3H777XY5ZUW90cwXB07xya4MymuMDOzpx4MzBzMyKsiuL58J0ZKWLh/9v8ZvN2mtfzz7MaXU+A6rSrRJ3rffkrRzJ5kzZuDl6cmiRYvsrodRvcnC+r0n+XR3BhW1Rob1DuSXE6MY3EvWghCiNVp7MfXvNIxCbuk+YSN1ubl8//e/kz51Kv4BAXa3bKbFauWbxBze23aC0moD8X2D+MXEKAb2tK9QFOJStdSmMBYYBwT9pF3BG3DsyMJE61mMRj774x9Ji48nPCSEX9x2G+7u7rYuq1Nordl1ooB3v08hq7iamHBfnlownEEREgZCtEVLZwougFfjdme3K1TSxhHNon1prfn45ZdJ696dPn5+3Hr33XYzqd3hUyUs35xM0ulywgM8+d+bRjCuf4i0GQhxCVpqU9gGbFNK/UdrfaqTahKtZLVa+XT5clJMJnqbzfzqgQfs4oCYWVDJO98nsy+tiMBubjw8ezDThoRLbyIh2kFrP1K6KqXeomFVtKbnaK2v6YiiRMssFgtr/vMfTpw+Tc/sbG597bUrPhBKqupZufUE3x7KxsPVmbunDGDuyEhcneVKphDtpbWh8DHwLxqW0GzrlNminZjNZlYvX05mXh69UlO5+aWXcPa8ctcCrjea+WR3Jh/vTMdssXL96N78YkI/urnLkpdCtLfWhoJZa/1mh1YiWsVkMrHi1Vc5XVNDn+PHueGll/C4Qsch/LRH0YQB3blrygB6+F+5ASiErbU2FL5QSt0HrAUMZ+7UWpd2SFWiWfVlZSx/6SWK3NwYWFLCnDfewDUw0NZltTutNTtTCnj3+2SyS2oY2NOPp28cLt1LhegErQ2F2xq/PnbWfZqGpTVFJzDV1vLu889T5O3NaD8/rnvmGdQV1rCqteZARjErtqRwIq+C8ABPfn/zCMZGS48iITpLa9dT6N3RhYjzs5hMrHz2WQq9vRkdHs70u+6ydUnt7nhOGe9sTuZoVikhvu78dm4cUwaHSY8iITpZq0JBKeVBw+prEVrrJUqpfkB/rfWGDq1OoLXmk2efJcfTkzg/vysuEMprDLyzOZlvD+Xg7+XK/TMGMX1YT5wdJQyEsIXWXj56FzhAw+hmaFhn+WNAQqGDffunP5Hs4kKkiwvXP/CArctpN1at+fpgFsu/T6HOaObmcX355cQomcZaCBtr7V9gX631QqXUrQBa6zolF3k73P5//pO9dXUEODnxi6VLr5jr6vlltbyy4TCHTpYQ18uf+2cMoldQcxPxCiE6W2tDwaiUcqdxumylVF/O6oUk2l/6hx+yKT0d527dWPzIIzg7X/598rXWbDiQxdubknBQiodmDWbGsJ5XTNgJcSVobSj8HtgI9FRKvQ+MB27vqKLsmdaa1H/8g007dmCIiWHRL3+Jt4+Prcu6ZCVV9fz1i8McSC9iRJ9AHp4dR7CPfUzaJ8TlpLW9j75TSh0ExgAKeEhrXdyhldkhq9FI4rJlpP7wA0WzZzNi+HD69Otn67Iu2fakPF778ghGk4X7Zwxi9ogIOTsQootqbe+j+cD3WusvG2/7KqWu11qv69Dq7IjFYGD/b35DwZYtFN95Jx4uLkyZOtXWZV2SOqOZNzYe49tDOUT38OHxeUPpGehl67KEEBfQ6stHWuu1Z25orcuVUr8HJBTagdVoZN+vf03R9u14PvYYxQUFzJ0587JeEyEpp4yX1ieSV1rLrROi+NVV/XCSbqZCdHmtDYXm/pql72A7yVm3jqLt2xn0hz+wobSU0NBQhg4dauuy2qTWYOY/W1L4fN9Jgnzc+cviMbIUphCXkdYe2PcrpV4B/klDD6QHaBi3IC6R1pr05cvxjonBNHIkpR98wA033HDZXXPXWrMrpYA3vjlGcWU9c0dGcvvV/fFwlc8OQlxOWvsX+wDwDPBR4+1vgac7pCI7U7hlC9WpqQx9+WV+2LcPLy8vYmNjbV3WRUk+Xca/NzVMUdEryIu/3TGOmHA/W5clhGiDFkNBKeUIrNdaX9sJ9dgVrTWpb76Je1gY7uPHk/bmm1x11VU4Ol4ei8bkl9Xy9uYktifl4+fpyoMzG6aokPmKhLh8tRgKWmuLUqpWKeWjta7ojKLsRXliImUHDzLo97/nQEICDg4OjBgxwtZltchssfLp7gze/yEVpRSLrurHgrF9cJcpKoS47LX2r7geOKKU+g6oOXOn1vrBDqnKTmS8+y5OXl6EzJnDmrfeIiYmBm9vb1uXdUHHskt57csjnCqqZnz/EO65bqAMQhPiCtLaUPiy8Z9oJ+lvv03ul18Sdc89HEpOpr6+nlGjRtm6rPOqMzb0Klq/t6FX0XML4xkTHWLrsoQQ7ay1I5pXNM59FKG1Tungmq5YWmtqTp4k+9NPSXvzTXrMnEmf++/n7//8J7179yYiIsLWJTYr8WQxr3xxmMLyOuaOjOSOa/rLpSIhrlCtHdE8B3gZcAF6K6WGAn/QWs9t644bG7D3A6e11rOVUv409G6KBE4CN2uty9r6+l2FqaqK4l27KNq+naLt26nNzgagx8yZDHvlFXbv20dNTQ2TJ0+2baHNsFg17/+QyurtqYT5e/LybWMZFCFLYgpxJWvtx71ngVHAVgCtdaJS6lJXY3sISALOXERfBmzWWr+olFrWePt3l7gPm9Bak7liBXkbN1KWkIA2m3H09CRw7Fj63n03QRMn4tmrFyaTiZ07d9KnT58ud5ZQUlXPi2sTOHyqlKlDwrl/+kBZ60AIO9Dav3Kz1rriJwOqdFt3qpQKB2YBL9CwohvAPGBy4/craAigyzIU0t58k+S//hXv2Fj6/s//EDRxIv7DhuHg4nLOdnv37qWmpoarrrrKRpU2b19aIX9Zf4h6k4Wlc4cwdUi4rUsSQnSS1obCUaXULwDHxqU4HwR2XsJ+XwUeB85eWSVEa50HoLXOU0oFN/dEpdQSYAnQ5T5dAxRs2ULyK68QNncuw1555bwjk+vr69mxYwdRUVH06tWrk6tsntliZeXWE3y0M53ewd14csFwImQCOyHsSmtHGT0ADKRhYZ3VQAXwcFt2qJSaDRRqrds0TYbW+i2tdbzWOj4oKKgtL9Fh6vLzSVi6FO8BA4j7058uOFXFrl27qK+v55prrunECs8vv6yW367YxUc705k5PILX7hwvgSCEHbrgmYJSyg24B4gCjgBjtdbmS9zneGCuUmom4AZ4K6VWAQVKqdDGs4RQoPAS99OptNVK4tKlWA0GRrz+Ok4XmOG0rq6OPXv2EBMTQ2hoaCdW2bytx3J57csjKOCpBcO5Ktb2NQkhbKOlM4UVQDwNgTCDhh5Il0Rr/YTWOlxrHQncQsM6Db8CPgdua9zsNmD9pe6rM518/32Kd+1i4NNP49WnzwW33bVrFwaDgUmTJnVSdc2rN1n424bD/N9nCfQK8uKNJRMlEISwcy21KcRqrQcDKKXeAfZ2YC0vAmuUUncBWcBNHbivdlV7+jRJf/kLQRMnErFw4YW3ra1lz549xMbGEhJiu8FfJwur+NNnB8kqqmbh+L4snhQt6x0IIVoMBdOZb7TW5vaezllrvZX/dnMtAaa06w46ydE//AGsVuKef77FKa93796N0Wi06VnCd4dy+PtXR3B3deKFX45iRJ+u1TYjhLCdlkJhiFKqsvF7Bbg33laA1lp37Yl6OkHB999TsGkTMY8/jkf4hbtunmlLiI2NJTi42c5VHcpotvCPr4/yTWIOcb38WTZ/GAHd3Dq9DiFE13XBUNBaXx5zONuIqaqKw888g1dUFH3uuKPF7ffu3YvRaLTJuITyGgPPrTnA8Zwybp0QxaJJ/WSKayHEz8gQ1Utw/P/+j/rCQib8858/G5j2U0ajkT179hAdHd3pbQmniqr43w/3UVpt4OkFw5kojclCiPOQUGij4t27yfroI/r+z//g14r1lPfv309dXR0TJkzohOr+a2dyPi+tT8TN2Ym/LB7LgDDfTt2/EOLyIqHQBhaDgcNPP41Hz55EP/RQi9sbjcamOY569uzZCRWCVWtWbUvl/e2p9O/hyzM3DSfIW9Y9EEJcmIRCG5x8/31qMjMZvXz5BQepnbF//35qamo6rcdRvdHMX9YfYkdyPlOHhPPgzEG4OEnzkBCiZRIKF8lUVUXqG28QOH48wa04yJ99ltAZczUVVdbx7Ef7ySioZMnUGG4Y3bvFbrJCCHGGhMJFOrV6NaayMmKWLm3V9gcOHOi0s4Tk0+U8t2Y/9UYLzy0cyah+nd/tVQhxeZNQuAgWg4GM//yHwHHj8I2La3F7k8nEjz/+2Cmrqm09lstfPz+Ev5cr//fL0UQGd2v5SUII8RMSChch57PPMBQWMvSll1q1fWJiIjU1NUycOLHDatJa8+GP6fxnSwqDIvz535tG4ONx4e6xQghxPhIKrWQ1m0l76y184+IIakW3UqvVys6dOwkPDycyMrJDajp7hPI1g3rwyJw4aVAWQlwSCYVWyv3yS2qzshj45JOtarjdtWsX5eXlzJgxo0Maegsr6nj+k4Ok5Jbzi4lRLJ4ULQ3KQohLJqHQCtpqJe3NN+kWHU3IlJbn7CspKWHr1q3ExMQQHR3d7vUknizmT58mYDJbeebG4UyIkRHKQoj2IaHQCgWbN1OVmtqwvGYL8wVZrVbWr1+Pk5MTM2bMaPdavk7I4u9fHSXM35P/vWkEPWV1NCFEO5JQaIHWmtQ338QjIoIes2a1uP2uXbvIzs5m/vz5dOvWfj2ATBYry79P5rPdmcT3DeLJBcPwdHVut9cXQgiQUGhR2YEDlB86xOA//AEHpwu/XRkZGWzevJmYmBgGDx7cbjWk51fwl/WHyCysYu7IXtwzLVZmOBVCdAgJhRZkrlyJs7c34fPnX3C70tJSPv74YwIDA5k3b167NPparJqPfkxj1Q+p+Hi48NzCeMZE2261NiHElU9C4QLq8vLI27iR3rffjpOHx3m3q66uZtWqVSiluOWWW3B1db3kfZfXGPjzukQOZhQzeWAPfjNjIN7uMv5ACNGxJBQu4OSqVWit6b148Xm3MRgMvP/++1RXV7N48WL8/f0veb/Hskv502cJVNQYeWT2YKYP6/g5k4QQAiQUzstiMHDqo4/ofu21511m02w289FHH1FYWMgtt9xCeAvLcba4T6uV939I44MdqYT4evDqHeOICvW5pNcUQoiLIaFwHrkbNmAqK6P3okXNPm61Wlm7di2ZmZnMnz+ffv36tXlfWmuSTpfz1rfHSTpdztS4cO6dHiu9i4QQnU5C4TxOffABXn37EjB27M8es1qtrFu3juPHjzNt2jTiWjE5XnPMFivbk/JYu+ckKbnleLk588QNw5g8sMelli+EEG0iodCMypQUyhISiH3qqZ/1IjKbzXz++eccOXKEKVOmMLaZ0GiJwWTh8/0nWbfnJMVV9YT5e/Kb6QOZOiQcdxf5LxFC2I4cgZpxctUqHFxc6PmTbqhVVVWsWbOGnJwcpkyZctHrLVusmk2Hc1i57QTFlfUM7R3Ag7MGMTIqGAeZt0gI0QVIKPyEsaKCnLVrCZs3Dxc/v6b7s7Ky+PjjjzEYDNx4440MHDjwol53f3oR//4uiZNFVfTv4cvvrh9KXK+A9i5fCCEuiYTCT2R//DGWurqmbqhaa3bt2sWmTZvw9fVl0aJFBAe3fkWzvLJa/vXtcXafKCDUz4OnFgxnYkx3mdFUCNElSSicRVssZL73Hv6jRuETG0ttbS1ffPEFycnJDBgwgHnz5uHm5taq16o3WfhoRxof78rA0UFx5zUDmD86UtY7EEJ0aRIKZynZv5+6nBxili4lLS2N9evXU1tby7Rp0xgzZkyrPt1rrdmRnM9b3yVRWFHHNYN6cPe1MQR0a12YCCGELUkonCX/m29QLi4cAva9/z5BQUH84he/IDS0desVFFbU8coXh0nILKZ3cDdevm0sgyMufYSzEEJ0FgmFRlpr8jdvxjR1KocPHmTkyJFMmzYNpxZmRj3jWHYpf/j4AEaTlfuui2V2fC+ZyVQIcdnp9KOWUqqnUmqLUipJKXVMKfVQ4/3+SqnvlFKpjV/9Wnqt9lSdnk51fj5pISGEhoYyY8aMVgWC1pqNCVn87r09uLs48eqd45g3qrcEghDismSLI5cZ+K3WOgYYA/xGKRULLAM2a637AZsbb3eawm3byImPp9ZsbvW6ylV1Jv70WQJ/23CEgRF+vH7neHoFtd/COkII0dk6/fKR1joPyGv8vkoplQSEAfOAyY2brQC2Ar/rrLqOHThASXQ048ePp2fPni1uf+RUCX9el0hptYE7ru7PTeP64ugg3UyFEJc3m7YpKKUigWHAHiCkMTDQWucppVo/GOASlRYWctjXF1/g6quvvuC2FquVVdtS+fDHNLr7efC3O8bRv4dv5xQqhBAdzGahoJTyAj4FHtZaV7Z2MJdSagmwBCAi4tLXGbBYLKxZvRqtFNPj43F0PP84gvzyWl5cm0BSTjlTh4Rz33UD8XCVtnohxJXDJq2hSilnGgLhfa31Z413FyilQhsfDwUKm3uu1votrXW81jo+KCjokmv5+uuvKaiooNfevfSdNOm82207lsu9b23nVFE1T8wfxtK5QyQQhBBXnE4/qqmGU4J3gCSt9StnPfQ5cBvwYuPX9R1dy8GDBzlw4AARublEBQfj5OX1s22MZgtvbDzG1wnZxIT5smz+MLr7nX9pTiGEuJzZ4qPueGARcEQpldh435M0hMEapdRdQBZwU0cXkpiYSHBgIAHvvUfQo4/+7PGiyjr+8PEBTuRWsHB8XxZPisbJUbqaCiGuXLbofbQDOF8DwpTOrKWmpgZ/R0eU1vjHx5/z2NGsUp7/5CD1JjO/v3kE4/p378zShBDCJuz6onhNTQ0BWoNS+AweDDQMRvt0dybvbE6mu587L/5qNJHBMvZACGEf7DYUrFYrBoMBamrw6NkTJ3d3DCYLf16bwI8pBYwf0J3fzonD003WSRZC2A+7DYW6ujoAdHExXn36YDRb+OMnB9ifVsSSqTHcMLq3rHkghLA7dttqWl9fD4AuKsI1PJwX1yayL62IB2cNZsGYPhIIQgi7ZLdnCk2hUFnFZ90GsSc5n19Pi2Xm8EsfECeEEJcruw+Fo31Hk1jnweJJ0dwwureNqxJCCNuy+8tHJyJHMmdwCL+YGGXjioQQwvbsNhRyiysACCo9zb1zh0sbghBCYMehkJzVMLXS/IpjsiCOEEI0stujYXllDVYN4ZFhti5FCCG6DLsNhbqqCqxWhXf//rYuRQghugy7DQUHYyVmA3jHxNi6FCGE6DLsMhS01jhpA7reTLco6XUkhBBn2GUomEwmFOCkFE6enrYuRwghugy7DAWj0QiAs5Pdjt0TQohm2WcomC1Aw5mCEEKI/7LLUKg3mABwcpBQEEKIs9llKBhMDZePHB0dbVyJEEJ0LXYZCmaTGUBGMgshxE/Y5VHRYtUAOMiZghBCnMNOQ8EKgIO0KQghxDnsMhSsZ84U5PKREEKcwy6Pik2hIF1ShRDiHPYZClpCQQghmmPXoaCkTUEIIc5hl6FgsTQ0NEuXVCGEOJddHhUtjeMUpPeREEKcyz5DwWgAwMFZJsQTQoiz2WUoWI0Ncx8pJ2cbVyKEEF2LXYaCpXHqbEeZOlsIIc5hl6GgTWfOFGSaCyGEOFuXCwWl1HSlVIpSKk0ptawj9qEbex8pBwkFIYQ4W5cKBaWUI/BPYAYQC9yqlIrtsB1K7yMhhDhHlwoFYBSQprXO0FobgQ+BeTauSQgh7EZXC4UwIPus2zmN9zVRSi1RSu1XSu0vKipq005c3VwwaifcXVzaXqkQQlyBulr3m+au5+hzbmj9FvAWQHx8vG5m+xZNmHoVE6Ze1ZanCiHEFa2rnSnkAD3Puh0O5NqoFiGEsDtdLRT2Af2UUr2VUi7ALcDnNq5JCCHsRpe6fKS1Niul7ge+ARyB5VrrYzYuSwgh7EaXCgUArfVXwFe2rkMIIexRV7t8JIQQwoYkFIQQQjSRUBBCCNFEQkEIIUQTpXWbxn91CUqpIuDUJbxEIFDcTuW0t65cG3Tt+rpybdC16+vKtUHXrq8r1wbn1tdLax3U3EaXdShcKqXUfq11vK3raE5Xrg26dn1duTbo2vV15dqga9fXlWuD1tcnl4+EEEI0kVAQQgjRxN5D4S1bF3ABXbk26Nr1deXaoGvX15Vrg65dX1euDVpZn123KQghhDiXvZ8pCCGEOIuEghBCiCZ2GQpKqelKqRSlVJpSapmt6zmbUmq5UqpQKXXU1rX8lFKqp1Jqi1IqSSl1TCn1kK1rOptSyk0ptVcpdaixvudsXdNPKaUclVIJSqkNtq7lp5RSJ5VSR5RSiUqp/bau52xKKV+l1CdKqeTG37+xtq7pDKVU/8b37My/SqXUw7au6wyl1CONfw9HlVIfKPX/2zv3YKvKMoz/Hi7KRRSBaLxgxxxMUycFNS6NY1KMGmM2lUpeusxYTiUVUTOUTY7alKOZ44ySChYF6CgimBXiWF7CMAdQERCn1ATzQoIIaoPg0x/ft7eLzd77HOSyNpz3N7PmrO/b63vPs/fsvd7vtt5XPZpe39nWFCR1BZ4BPk1K6vMYMNb2slKFZSSdBGwAfmf76LL1FJF0AHCA7UWS+gALgTNb6LMT0Nv2Bkndgb8B37G9oGRpVSSNB44H9rU9oAQA0AAAB81JREFUpmw9RSQ9Dxxvu+UewJI0FXjY9uSca6WX7dfL1lVLvr+8CHzc9vY8WLuj9BxE+h181Pbbkm4H/mT7t43adMaRwonAP20/a3sjcBvw2ZI1VbH9ELCmbB31sP2S7UX5fD2wnJoc2mXixIZc7J6Plun1SDoY+AwwuWwtuxOS9gVOAqYA2N7Yig4hMwr4Vys4hALdgJ6SugG9aCebZWd0CgcBKwvlVbTQjW13QVIbcBzwaLlKtiRPzzwOvArcZ7uV9F0L/BB4t2whDTAwT9JCSV8vW0yBDwOrgd/kqbfJknqXLaoB5wC3li2igu0XgauBF4CXgHW25zVr0xmdgurUtUxvcndA0j7AncB3bb9Rtp4itjfbPpaU3/tESS0xBSdpDPCq7YVla2nCSNtDgNOAb+WpzFagGzAEmGT7OOBNoKXWAgHytNYZwB1la6kgaX/STMihwIFAb0nnNWvTGZ3CKmBQoXww7QyngvfIc/V3AtNtzypbTyPy9MIDwKklS6kwEjgjz9vfBpwiaVq5krbE9n/y31eBu0hTra3AKmBVYdQ3k+QkWo3TgEW2XylbSIFPAc/ZXm37HWAWMKJZg87oFB4DBks6NHv2c4C7S9a0W5AXcqcAy21fU7aeWiR9QFLffN6T9IN4ulxVCdsTbR9su430nfuL7aY9tl2JpN558wB5amY00BI74Gy/DKyU9JFcNQpoic0NNYylhaaOMi8AwyT1yr/fUaS1wIa0XI7mnY3tTZK+DdwLdAVusb20ZFlVJN0KnAwMkLQK+KntKeWqqjISOB9YkuftAX6U82q3AgcAU/MOkC7A7bZbbutni/JB4K5036AbMMP23HIlbcHFwPTckXsW+GrJerZAUi/SjsZvlK2liO1HJc0EFgGbgMW0E+6i021JDYIgCBrTGaePgiAIggaEUwiCIAiqhFMIgiAIqoRTCIIgCKqEUwiCINhN2NaAmZLOkrQsB8Sb0aE2sfsoCIJg92BbAmZKGgzcDpxie62kgfnBxKbESCEIgrpIOlPSzZLmSBpdtp6gfsBMSYdJmptjVj0s6Yj80oXA9bbX5rbtOgQIpxCUhKRfFWPOS7pX0uRC+Zc5zHSj9n0lfXMnaRuXY/ZP3xn2dxWSekp6MD/Mt83Ynm37QuArwNnZ5l6SHsoRN4PW4CbgYttDgQnADbn+cOBwSfMlLZDUoZAv4RSCsniEHINFUhdgAHBU4fURwPwm7fsCO9QpKNEl2z3d9rk70v771LI9fA2YZXvzdtq5BLgeUthq4H6ykwjKJQenHAHckaMM3Eh6sh/Sk+mDSRESxgKTK2FgmhFOISiL+bwXmOsoUpyd9ZL2l7Q3cCSwWNJ5StnUHpd0Y6HX+wvgsFx/VdFwjuPzR6UMbE9JOltSW3FxTtIESZfm+uWSbiCFAphCCtV8t6Tv5Wtn56H50mJIaUkXSHoy/5/f57pGeregns06WgY1stdIUw3nAnMKtp+WNDVrnplDMyDphFzXI392SyUdnR3TlcCfK3k0MrOz7aB8ugCv2z62cByZX1sFzLH9ju3ngBUkJ9Ec23HEUcoBPA8cQooXcxFwOXA6KcbSQyTH8Aege77+BuCCfN4GPNXA7ueBmwvl/WqvJw2zL8317wLDanQNKJT75b89Sc6rP8mRrahcB/RrpreOxno2t9DSzvvfqn2N/b2AlwvlNlKI+JG5fAswofD6FaS4+9cDE3PdOFJ2vV8DFxWu7QqsLvv701mPOt/lR4Av5nMBH8vnpwJT8/kAUh6Z/u3Zj3nBoEwqo4URwDWkZEcjgHWkL/ooYCjwWA7U1pOUPKc9lgBX517uPbYfVoor34h/u3nKznGSPpfPB5F6WycAM51TV9peI+lL26C3ns2Xa7Q0e//12r9WsD8AqM1OttJ2ZUpuGummf3UuX0aKIPy/XI/t64DraoXb3ixpo6Q+Thn4gl2E6gTMJI3aJkm6hJRt8DbgCVLQz9GSlgGbgR/Yfq2u4QLhFIIyqawrHEPq7a4Evg+8QerJtpF6OhO3xajtZyQNJY06fi5pXrZXnC4tJi9/s5EtSSeTQnAPt/2WpAdyW7F1ciZ1RG8Tm7Va6tprp32Ft+vU1eotlvsB+5BuKj1o8plk9iY5kGAXYntsg5e2WkR2GiKMz0eHiTWFoEzmA2OANU4Z09aQFpCHA38nLWh+QdJAAEn9JH0ot10P9KlnVNKBwFu2p5F6wkOAV4CBkvrnNYsxHdS4H7A233yPAIbl+vuBsyT1r2hrR29HbNbSyF677Z22IXaVVHQMh0gans/HkhK6V7gJ+AkwHbiy2QeS33MlaUuwhxFOISiTJaRpjgU1dets/9f2MtLOl3mSngTuI++syMPg+Xkh+aoau8cA/8i7MX4MXJFvYJeRckrfQ8eT78wFuuX/f3lFq1MOjp8BD0p6Arimmd6O2Kylib0OtQfmAZ8olJcDX87t+gGTIC2YA5tszyAt4J8g6ZQmn8kngVbJoRHsYOKJ5iDYQ5F0HDDe9vmS2kjrK9uds1rSLNJi9IrttRW0HjFSCII9FNuLgb822hb7flDKfDY7HMKeS4wUgiAIgioxUgiCIAiqhFMIgiAIqoRTCIIgCKqEUwiCIAiqhFMIgiAIqoRTCIIgCKqEUwiCIAiqhFMIgiAIqoRTCIIgCKr8H+RWRf/ISqDpAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(en_cdf, pcs, label=\"El Niño\", c=\"firebrick\")\n",
+    "plt.plot(ln_cdf, pcs, label=\"La Niña\", c=\"steelblue\")\n",
+    "plt.plot(neutral_cdf, pcs, label=\"Neutral\", c=\"grey\")\n",
+    "plt.ylabel(\"Percentile\")\n",
+    "plt.xlabel(\"Wet surface area (px$^2$)\")\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see that Kati Thanda is considerably wetter during La Niña than during El Niño or neutral. We can also see that Kati Thanda during El Niño is nearly the same as during the neutral phase of ENSO."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CDFs are often hard to interpret, so it is also worth looking at the probability density function (PDF), which describes the probability density of observing the waterbody at a given wet surface area during each phase. We can make the (invalid, but useful) assumption that the PDF is well-described by a Gaussian kernel, and then perform a kernel density estimate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = np.linspace(time_series.px_wet.min(), time_series.px_wet.max(), 100)\n",
+    "en_pdf = scipy.stats.gaussian_kde(en_wet)\n",
+    "ln_pdf = scipy.stats.gaussian_kde(ln_wet)\n",
+    "neutral_pdf = scipy.stats.gaussian_kde(neutral_wet)\n",
+    "\n",
+    "en_pdf = en_pdf(xs) / en_pdf(xs).sum()\n",
+    "ln_pdf = ln_pdf(xs) / ln_pdf(xs).sum()\n",
+    "neutral_pdf = neutral_pdf(xs) / neutral_pdf(xs).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEMCAYAAADTfFGvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdd3hUVf748fcnk957gRCJEBAIJCSBAAIbEBSxi33XvnZddf3aVl3Z3667dldxddW1roLYsKMiwiLSa+hFghASElJI7/P5/TGTGELKBDIp5Lye5z4z995z7nyGh2c+ueece46oKoZhGIbhKJeuDsAwDMPoWUziMAzDMNrFJA7DMAyjXUziMAzDMNrFJA7DMAyjXUziMAzDMNrFtasD6AyhoaHav3//rg7DMAyjR1m7dm2eqoY1Pd4rEkf//v1Zs2ZNV4dhGIbRo4jIL80dN01VhmEYRruYxGEYhmG0i0kchmEYRrv0ij4OwzB6r5qaGjIzM6msrOzqULotT09PoqOjcXNzc6i8SRyGYZzQMjMz8fPzo3///ohIV4fT7agq+fn5ZGZmEhsb61Ad01RlGMYJrbKykpCQEJM0WiAihISEtOuOzNxxHIO6ykryV63C4u2Nu78/npGRuPn7d3VYhmG0wCSN1rX338fccRyD7c88w8prr2XZpZey+MwzWTB+PMU7dnR1WIZhdFMWi4XExMSG7fHHHwcgLS2t2WfM0tLSSElJadhfs2YNaWlpDe//8Ic/NJx7+eWXGTNmDBdddFGnPa9m7jjaqTInh73vvkvUmWcSc+ml1Bw+TPojj7D9mWcY/eqrXR2eYRjdkJeXFxs2bGhXndzcXObPn8+ZZ555xPGUlJQjksott9zCLbfc0iFxOsrccbTTrpdfRq1Whtx3H+ETJtD3nHMYeNNN5CxcSL55Ot0wjA5y77338re//e2o44sXL+bss88GYObMmVx33XWkpaVx8skn88ILLzSUe/bZZ4mPjyc+Pp5//vOfHRqbueNoh/KsLPbNnUu/GTPwiYlpOB57zTVkvPMO2554glM/+MC0pxpGN7X5r3+leNu2Dr2m/5AhxD/ySKtlKioqSExMbNh/8MEHufTSS1utM3bsWObNm8eiRYvw8/Nrsdz27dtZtGgRJSUlDB48mFtuuYX09HTefPNNVq5ciaqSmprKb37zG0aOHNm+L9cCc8fRDrtfeglVJe6224447urlxaA77qBw3TpyFi7sougMw+iu6puq6re2kka9hx9+uNm7jsbOOussPDw8CA0NJTw8nJycHJYuXcoFF1yAj48Pvr6+XHjhhfz4448d8VUAc8fhsPLMTPZ9+CEnXXYZ3n37HnU+5uKL2fP662x/+mkiJk1CLJYuiNIwjNa0dWfQ3UyePJlHHnmEFStWtFjGw8Oj4b3FYqG2thZVdWpc5o7DQb/Mng0iDLz55mbPu7i5MfjuuynZtYvcDszshmH0bg899BBPPvlku+pMnDiRTz/9lPLycsrKypg3bx4TJkzosJicmjhEZJqI7BCR3SLyQDPnRUResJ9PF5Ek+3FPEVklIhtFZIuI/KVRnZkickBENti36c78DvXyli8nKDERr6ioFstETp2KxdubnO+/74yQDMPoIer7OOq3Bx446uewRdOnTycs7KglMVqVlJTENddcw+jRo0lNTeX3v/99h/VvAIizbmlExALsBKYCmcBq4HJV3dqozHTgDmA6kAo8r6qpYutd9lHVUhFxA5YCd6rqChGZCZSq6tOOxpKSkqLHM765pqSEb5KSiLv1Vk65++5Wy6657TYK1q1j6k8/IS7mhs4wutq2bdsYMmRIV4fR7TX37yQia1U1pWlZZ/6yjQZ2q+oeVa0G3gfOa1LmPOAdtVkBBIpIlH2/1F7Gzb45t9GuFQVr1oDVSuiYMW2WjZgyharcXA5v2tQJkRmGYXQ+ZyaOvsD+RvuZ9mMOlRERi4hsAHKBBaq6slG52+1NW2+ISFDHh36kvOXLcXF3J8iBW736jvGDCxY4OyzDMIwu4czE0dzDDE3vGloso6p1qpoIRAOjRSTefv5lYACQCGQDzzT74SI3isgaEVlz6NChY4m/Qf7KlQSNHInF07PNsu6BgQSnpJhhuYZhnLCcmTgygX6N9qOBrPaWUdXDwGJgmn0/x55UrMBr2JrEjqKqr6pqiqqmtLdjqbGa4mKKtm4lJDXV4TqRU6dSsnMnZfv2HfPnGoZhdFfOTByrgTgRiRURd+Ay4PMmZT4HrrKPrhoDFKlqtoiEiUgggIh4AVOA7fb9xsOaLgA2O/E7kL96NVithDjQv1Ev4rTTADhoRlcZhnECclriUNVa4HbgW2Ab8IGqbhGRm0Wk/mGIr4E9wG5sdw+32o9HAYtEJB1bAlqgql/azz0pIpvs5yYBrQ9zOk75K1fa+jcaTRfQFp+YGPwGDTLDcg3DOCE5dbyoqn6tqoNUdYCqPmY/9m9V/bf9varqbfbzw1V1jf14uqqOVNURqhqvqv+v0TWvtJcdoarnqmq2M79D3ooVBCUlYWn0dKYjIqdMIX/1aqoLC50UmWEYPYWvr+8x1Vu8eDEiwhdffNFw7Oyzz2bx4sUA/P73v2frVtsTDgUFBZx22mmcfvrp3H///ccdc2vMgwatqC4qonjrVoeG4TYVMWUKWK0cWrrUCZEZhtFbREdH89hjjzV77j//+Q9Dhw4FIDg4mIULF/Ldd9/xxBNPODUmkzhaUbBqFai2q3+jXsCwYbj6+pK/apUTIjMMo6f74osvSE1NZeTIkUyZMoWcnJxmyyUkJBAQEMCCZob4N14IytfXl4ceeoiEhATGjBnTcD1HP6c9zCSHrchbuRIXDw8CR4xod10XV1eCk5NtneuGYXQLL3+7hT05xR16zZMj/LnljGHtrjd+/HhWrFiBiPCf//yHJ598kmeeafbpAh5++GEefvhhpk6d2uL1ysrKGDNmDI899hj33Xcfr732Gg8//HC7PsdRJnG0Iur00/Ht37/d/Rv1gkePJvepp6jKz8cjJKSDozMMoyfLzMzk0ksvJTs7m+rqamJjY1ssWz9BYWtTo7u7uzcs8JScnNxwh9Kez3GUSRytCBk9mpDRzT4m4nB9sA3p7TNtWkeFZRjGMTqWOwNnueOOO/jjH//Iueeey+LFi5k5c2ar5R966CEee+wxXF2b/9l2c3NrWESufnr1Y/kcR5g+DicKjI/HxdPT1ldiGIbRSFFREX3ta/u8/fbbbZY//fTTKSwsZOPGjU79HEeYxOFELu7uBCclmQ5yw+jlysvLiY6ObtieffZZZs6cycUXX8yECRMIDQ116DoPPfQQmZmZ7frsY/mctjhtWvXu5HinVT8eO2fNYsfzz3PG2rW4BwR0SQyG0ZuZadUd012mVTewdZCjapua3TAM4wRgEoeTBSUm4uLuTv7KlW0XNgzD6AFM4nAyi4cHgQkJFJjnOQzDOEGYxNEJQkaPpmjLFmpLS9subBiG0c2ZxNEJQkaPRuvqKFi7tqtDMQzDOG4mcXSCoJEjEYvFJA7DME4IJnEcg/z8fFasWEFNTY1D5V19fPA/5RQK161zcmSGYXRHIsI999zTsP/0008f8xPchw8f5qWXXjqmuv379ycvL++Y6jZmEkc77dq1i9dee41vv/2WV155xeGHcYKSkijcuBGrfRoAwzB6Dw8PDz755JMO+dFuLXHU1dUd9/UdYRKHg1SVpUuXMnv2bIKCgrjwwgupra3ljTfe4IcffqCtBymDk5KoKy+nePv2TorYMIzuwtXVlRtvvJHnnnvuqHOHDh1ixowZjBo1ilGjRvHTTz8Btie+n3766YZy8fHx7N27lwceeICff/6ZxMRE7r33XhYvXsykSZO44oorGD58OADnn38+ycnJDBs2jFdffbXjv0+HX/EEtWLFChYuXMiwYcM477zzcHNzIy4ujm+++YYff/wRPz8/Ro0a1WL9oBTbw5eF69YRGB/fWWEbhtHIN998w8GDBzv0mpGRkUxzYBLT2267jREjRnDfffcdcfzOO+/k7rvvZvz48ezbt48zzjiDbdu2tXidxx9/nM2bN7NhwwbAtkrgqlWr2Lx5c8PMt2+88QbBwcFUVFQwatQoZsyYQUgHztDt1MQhItOA5wEL8B9VfbzJebGfnw6UA9eo6joR8QSWAB72GD9S1UftdYKBuUB/YC9wiao6dX1WVWXt2rXExMQwY8aMhhkoPT09Oe+88ygtLWXBggXExcURGBjY7DW8oqLwjIykcN06Yq+6ypnhGobRDfn7+3PVVVfxwgsv4OXl1XD8+++/b1j+FaC4uJiSkpJ2XXv06NFHTJf+wgsvMG/ePAD279/Prl27ekbiEBEL8C9gKpAJrBaRz1V1a6NiZwJx9i0VeNn+WgVMVtVSEXEDlorIfFVdATwALFTVx0XkAfu+UxfYzcrKIj8/n3HjxjUkjUbfk3POOYeXXnqJzz//nCuvvPKoMvXlgpKSzMgqw+hCjtwZONNdd91FUlIS1157bcMxq9XK8uXLj0gmYGveslqtDfuVlZUtXtfHx6fh/eLFi/n+++9Zvnw53t7epKWltVr3WDizj2M0sFtV96hqNfA+cF6TMucB76jNCiBQRKLs+/VPy7nZN21Up35u4LeB8534HQDYuHEjrq6uDWv7NhUQEMDUqVPJyMhgXSsjp4KTkqjIyqIiO9tZoRqG0Y0FBwdzySWX8PrrrzccO/3003nxxRcb9uuboPr379/we7Ju3ToyMjIA8PPza/WOpKioiKCgILy9vdm+fTsrVqzo8O/hzMTRF9jfaD/TfsyhMiJiEZENQC6wQFXrJ3uKUNVsAPtruBNib1BXV8fmzZsZPHgwnp6eLZZLTk4mNjaW7777jqKiombLBCcnA1C4fr1TYjUMo/u75557jhhd9cILL7BmzRpGjBjB0KFD+fe//w3AjBkzKCgoIDExkZdffplBgwYBEBISwqmnnkp8fDz33nvvUdefNm0atbW1jBgxgkceeYQxY8Z0+HdwZh/H0e01v941tFlGVeuARBEJBOaJSLyqbnb4w0VuBG4EiImJcbTaUXbt2kVFRQUj2lh3vHGT1XfffcfFF198VBn/IUNsCzutXUuf6dOPOSbDMHqW0kbTDUVERFBeXt6wHxoayty5c4+q4+XlxXfffdfs9WbPnn3EflpaWsN7Dw8P5s+f32y9vXv3tiPqljnzjiMT6NdoPxrIam8ZVT0MLAbqGydzRCQKwP6a29yHq+qrqpqiqilhYWHH+h1IT0/Hx8eHAQMGtFk2KCiICRMmsHXrVn7++eejzru4uRGUkGAeBDQMo0dzZuJYDcSJSKyIuAOXAZ83KfM5cJXYjAGKVDVbRMLsdxqIiBcwBdjeqM7V9vdXA5856wtUVFSwc+dO4uPjsVgsDtUZN24cwcHBzJ8/v2HN38aCkpIo2rqV2oqKjg7XMAyjUzgtcahqLXA78C2wDfhAVbeIyM0icrO92NfAHmA38Bpwq/14FLBIRNKxJaAFqvql/dzjwFQR2YVtxNYRQ3w70pYtW6irq2uzmaoxV1dXzjzzTPLz81m+fPlR54OTktDaWoo2berIUA3DMDqNU5/jUNWvsSWHxsf+3ei9Arc1Uy8dGNnCNfOB0zo20uYVFxcTGRlJVFRUu+oNHDiQIUOGsGTJEuLj4wkKCmo4FzTS9rUK1qwhZPToDo3XMIzmqWqzw+QNm/YuIW6mHGnF5MmTueGGG47pP9wZZ5yBxWLhww8/PKLJyj0oCN+4OLOUrGF0Ek9PT/Lz89v949hbqCr5+fmtjhptykw50gYXl2PLrQEBAVxwwQW8//77fPvtt5x11lkN50JSUjjwxRdoXR3iYN+JYRjHJjo6mszMTA4dOtTVoXRbnp6eREdHO1zeJA4nGjx4MOPGjWPZsmX069evoa8kOCWFX+bMoXjHDgJaeKjQMIyO4ebmdsR0HMbxM01VTjZ58mRiYmL48ssv2b/f9qxjsH0yRLMOuWEYPZFJHE5msVi46KKL8PHx4a233mLZsmV49emDZ1SU6ecwDKNHMk1VncDPz4+bbrqJzz77jAULFvDLL78QmZpK3rJlZrSHYRg9jvSGkQYpKSm6phv8da+qrFq1igULFlBXV4drRQVxw4YRERODt7c33t7ehIWFERYWZpKJYRhdTkTWqmpK0+PmjqMTiQipqakMHTqUzT/9xOo5c9jr58e2PXuOKOfl5UVMTAyJiYmccsopXRStYRhG88wdRxdRq5VvU1KIOuMM4v/2NyoqKigrKyM7O5tffvmFjIwMioqKSExMZNq0aXh4eHR1yIZh9DLmjqObERcXglNSyF+9GovFgq+vL76+vkRERJCYmEhdXR3/+9//WLp0Kb/88gszZsygb9+ms9IbhmF0PjOqqgsFJydTlpFBVaO5+etZLBYmT57MNddcg9Vq5b333mtxnQ/DMIzO1GbiEJH4zgikN2p4nqOV5WRjYmK48sorqaur4+OPP6aurq6zwjMMw2iWI3cc/xaRVSJya/1U50bHCIyPx8XTk/w2lnYMCQnhnHPOYf/+/fzwww+dFJ1hGEbz2kwcqjoe+C22BZfWiMhsEZnq9Mh6ARd3d0JGj+bQTz+1WTY+Pp7k5GSWLVvGzp07OyE6wzCM5jnUx6Gqu4CHgfuB3wAviMh2EbnQmcH1BmHjx1P6889UZDVdHPFo06ZNIyIigi+++IKamppOiM4wDONojvRxjBCR57AtxjQZOEdVh9jfP+fk+E54YePHAzh01+Hq6sq0adMoLS1lbSv9IoZhGM7kyB3Hi8A6IEFVb1PVdQCqmoXtLsQ4Dn6DBuERHs6hpUsdKt+/f39iY2NZunQp1dXVTo7OMAzjaI4kjk9U9b+q2rBItojcCaCq/3VaZL2EiBB26qm2eausVofqpKWlUVZWxmozu65hGF3AkcRxVTPHrnHk4iIyTUR2iMhuEXmgmfMiIi/Yz6eLSJL9eD8RWSQi20RkS32isp+bKSIHRGSDfZvuSCzdWdj48VQXFFC0datD5WNiYhgwYAA//fQTVVVVTo7OMAzjSC0mDhG5XES+AGJF5PNG2yIgv60Li4gF+BdwJjAUuFxEmq5adCYQZ99uBF62H68F7rH3pYwBbmtS9zlVTbRvR6xp3hOFnnoqgMPNVQCTJk2ioqKCVatWOSsswzCMZrV2x7EMeAbYbn+t3+4Bpjlw7dHAblXdo6rVwPvAeU3KnAe8ozYrgEARiVLV7EZ9KSXYOuZP2Pk2PMPC8D/lFPLakTj69u1LXFwcy5cvP2JNc8MwDGdrMXGo6i+qulhVx6rq/xpt61TVkV+qvsD+RvuZHP3j32YZEekPjARWNjp8u71p6w0RCWruw0XkRhFZIyJresJaw6GnnkrB2rXUVlS0XdhuzJgxVFRUsGXLFidGZhiGcaTWmqqW2l9LRKS40VYiIsUOXLu5BSWaTsXbahkR8QU+Bu5S1frPfBkYACQC2djugo6+iOqrqpqiqilhYWEOhNu1wiZMwFpdTUE7mp5iY2MJCQmhu838axjGia21O47x9lc/VfVvtPmpqr8D187E9rR5vWig6VNuLZYRETdsSeM9Vf2kUVw5qlqnqlbgNWxNYj1eyKhRuLi7k7tkicN1RITk5GQyMzM5ePCgE6MzDMP4lSMPAA4QEQ/7+zQR+YODc1atBuJEJFZE3IHLgM+blPkcuMo+umoMUKSq2WJb/u51YJuqPtsknqhGuxcAmx2IpduzeHoSNmEC2d984/CwXIDExERcXV3NXYdhGJ3GkeG4HwN1IjIQ2495LDC7rUr2fpDbgW+xdW5/oKpbRORmEbnZXuxrYA+wG9vdw63246cCVwKTmxl2+6SIbBKRdGAScLcjX7Qn6HPWWVQePEjh+vUO1/Hy8mLYsGFs2rTJDM01DKNTOLKQk1VVa0XkAuCfqjpLRBz6ZbMPlf26ybF/N3qvwG3N1FtK8/0fqOqVjnx2TxQxeTIu7u5kffUVwcnJDtdLSUlh48aNpKenM8o+VbthGIazOHLHUSMilwNXA1/aj7k5L6Tey83Pj/C0NLLmz29Xc1Xfvn2JjIxkzZo19IalgA3D6FqOJI5rgbHAY6qaISKxwLvODav36nPWWVTl5lLQjj6L+k7y3NxcsrOznRidYRiGY+txbFXVP6jqHPt+hqo+7vzQeqeISZNw8fQk66uv2lVv2LBhWCwWNm7c6KTIDMMwbBwZVXWqiCwQkZ0iskdEMkRkT2cE1xu5+vgQMXmyrbmqHcvEenl5MXjwYDZt2mSWlzUMw6kcaap6HXgWGA+MAlLsr4aT9Jk+ner8fPJXrmy7cCMJCQlUVFSwa9cuJ0VmGIbhWOIoUtX5qpqrqvn1m9Mj68XC09KweHtz4Isv2lVv4MCB+Pj4mOYqwzCcypHEsUhEnhKRsSKSVL85PbJezNXLi77nnEPmp59SlZfncD0XFxeGDx/Ozp07KS8vd2KEhmH0Zo4kjlRszVN/59cZcp92ZlAGDLjhBqw1NWS8/Xa76iUmJmK1Wtm0aZOTIjMMo7dzZFTVpGa2yZ0RXG/mGxtL5Omns/fdd6ktK3O4XkREBJGRkaa5yjAMp3FkVFWEiLwuIvPt+0NF5Hrnh2YMvPFGaoqL+WXu3HbVS0hIIDs7m9zcXCdFZhhGb+ZIU9Vb2Oab6mPf3wnc5ayAjF8FJSYSkprKntdfx1pT43C94cOH4+LiYu46DMNwCkcSR6iqfgBYoWHyQvOgQCcZcMMNVB482K4RVj4+PgwcOJD09HSs7Zi6xDAMwxGOJI4yEQnBvsBS/fTnTo3KaBCelob/Kaew47nnqCkpcbheYmIipaWl7NljntU0DKNjOZI4/oht3YwBIvIT8A5wh1OjMhqICCMee4zKnBw2Pfqow/Xi4uLw8vIyzVWGYXQ4R0ZVrQN+A4wDbgKGqWq6swMzfhWUmMigO+7gwGefkfnZZw7VcXV1JT4+nu3bt1NZWenkCA3D6E1aW3P8wvoNOBcYDAwCzrEfMzrRwFtuISg5mU1//jPlmZkO1UlISKC2tpYtW7Y4OTrDMHqT1u44zrFv12Obr+q39u0/wO+cH5rRmIurK0nP2lbRXX3zzZQfONBmnT59+hAaGmqaqwzD6FAtJg5VvVZVr8XWKT5UVWeo6gxgWKdFZxzBOzqa5FmzKN+/nyXnnkvukiWtlhcREhIS2L9/P3ntmLrEMAyjNY50jvdX1carA+Vga7Jqk4hME5EdIrJbRB5o5ryIyAv28+n1c2CJSD8RWSQi20Rki4jc2ahOsH2a91321yBHYjlRhE+cyIRPP8UzIoKV113Hlr//neLt21tc+S8xMREXFxfWrl3byZEahnGikraWGhWRF4E4YA62u4/LgN2q2urIKhGxYHtYcCqQCawGLlfVrY3KTMc2Qms6tjmxnlfVVBGJAqJUdZ2I+AFrgfNVdauIPAkUqOrj9mQUpKr3txZLSkqKrmnHino9QW15OZsefZTMefNAFe9+/QgZPRqLtzcubm6oKtUFBVTl5bE+KIhCPz+SFy1CqqvxDA/Hq29fvGNiiJwyhZDRoxEXR/6GMAyjNxGRtaqactRxR9aoFpELgIn23SWqOs+BOmOBmap6hn3/QQBV/UejMq8Ai+tXFxSRHUBakzscROQz4EVVXdC4jD3BLFbVwa3FciImjnpVeXkcXLiQg999R9HWrVhrarBWVwPgERyMe0gIJZGRrA4PJ7m6mhgRKnNyqMjKonTvXqyVlXhFR9PvwguJveYa3AMCuvgbGYbRXbSUOFwdqWxPFG0miyb6Avsb7Wdiu6toq0xfoCFxiEh/YCRQv6pRRH1isSeP8OY+XERuBG4EiImJaWfoPYdHaCgnXXopJ116aYtlVJWfX3yRXB8fzr7uuobjtRUVHPzuO/Z/8gk7Z81i39y5jHjsMSImTeqM0A3D6KGc2T4hzRxrenvTahkR8QU+Bu5S1eL2fLiqvqqqKaqaEhYW1p6qJxwRITk5mf379x8x8aGrlxfR553H2LffZsK8ebgFBLDq979nw333tespdcMwehdnJo5MoF+j/Wggy9EyIuKGLWm8p6qfNCqTY2+iwv5qpoB1QGJiIhaLhZaa7AKHD2fCp58y8JZbyPz0U1ZcdRXVhw93cpSGYfQEjkyrfraIHEuCWQ3EiUisiLhj61T/vEmZz4Gr7KOrxmBbpjZbRATbsyPbVPXZZupcbX9/NeDYo9S9nLe3N0OHDiU9PZ1qex9IUxYPD4b83/+R8tJLFG/fzvLf/Y6qfLNKsGEYR3IkIVwG7BKRJ0VkiKMXts+iezu2Kdm3AR+o6hYRuVlEbrYX+xrYA+wGXgNutR8/FbgSmCwiG+zbdPu5x4GpIrIL24itxx2NqbcbNWoUVVVVrFu3rtVykVOmMOrVVynNyGDZFVdQadb1MAyjEUdHVfkDlwP1DwS+CcxR1R7REH4ij6pqr7feeouCggLuvPNOLBZLq2XzV61i5fXX43vyyYx7/31cvbw6KUrDMLqDlkZVOdQEZe+Y/hh4H4gCLgDWiYiZJbeHGT9+PCUlJQ5NQxIyejRJ//wnRVu2sPH++1t8yNAwjN7FkT6Oc0VkHvAD4AaMVtUzgQTg/5wcn9HBBgwYQFRUFEuXLnVokafI005jyL33kvXVV+z61786IULDMLo7R+44LgKeU9URqvqUquYCqGo5cF3rVY3uRkSYMGEChYWFbN26te0KwIAbb6Tv+eez47nnyP7uOydHaBhGd+dI4shW1SNm0xORJwBUdaFTojKc6pRTTiE0NJQff/zRoeYnESHh738nYPhwNt5/P+VZTUdVG4bRmziSOKY2c+zMjg7E6Dwiwvjx48nNzXV4rQ6LhwfJzz+Pta6O9X/8I9baWidHaRhGd9XaQk63iMgm4BT7zLX1WwZgVgDs4YYPH05UVBTffvstVVVVDtXxOekkRvy//0fB6tXseuklJ0doGEZ31dodx2xsCzl9xq+LOp0DJKuqWciph3NxceGss86itLSUxYsXO1wv+vzziT7/fHbOmkW+GeJsGL1Sa5McqqruFZHbmp4QkWBVLXBiXN3alv0FfLchk0PFFeSVVFJVU16o2KYAACAASURBVMeogeGkDevD0H5BuEhzU3B1P3379iU5OZmVK1eSkJBAZGSkQ/WG/+UvFKxbx/p77iHtq69w9fV1cqSGYXQnbd1xgG0tjDX217WN9nud4vJqnvsynT++tZyl27Mpqayhb7APseH+fLdhP/e8vZyrZy1i2Y6DXR2qw0477TS8vLz4+uuvHX5Ow9XXl5FPPUVFVhZbHnvMyREahtHdtHjHoapn219jOy+c7mvtz4d44tMNlFTUcPHYk/ntxDi83H/956uormXFzhw+XLaHv3ywlmmJ/bj5jKFHlOmOvLy8mDp1Kp999hnLli3j1FNPdahecEoKA2+4gd2vvELk6aebqdgNoxdpccqR+mVcW6KqrU941I0c75Qju7KL+L+3lxMZ6M39FyRycoR/i2Vr6qz8d/FOPlj2M5FB3sy8JIX+4X7H/NmdQVX56KOP2Lp1K5dffjmDBjm0MjB1VVX8eMEFVBcUkDZ/Pu5BvWoVX8M44bV7BUARWdTK9VRVJ3dUcM52PIkj53A5d725DFeLC/+8dhwhfp4O1du0r4C/f7yO2jorf/9tKnFR3XtlvZqaGt58803y8/O57rrriIiIcKhe0dat/HjhhURNnUryrFlOjtIwjM7U7rmqVHVSK1uPSRrHo7SyhofnrKaqpo6/XjbK4aQBMDwmmGeuHouXhyv3vbOCTfu691gCNzc3LrvsMtzd3ZkzZw6lpaUO1QsYOpTBf/gDWV9/zYHPm86abxjGiai15zgm218vbG7rvBC7zkvfbCGroIw/X5x8TM1NfYJ9eObqsYT4efDQeyvZsDfPCVF2HH9/fy677DLKy8t57bXXOHjQsU7+ATfeSNDIkWx69FEqHKxjGEbP1dqoqt/YX89pZjvbyXF1C9dNPoWHLkoiMTb0mK8R5u/F01ePtfV3zF3Djqzuvape3759ufbaawF44403HJrPysXVlcSnnsJaU8PGBx4ws+gaxgnOofU4errusB5Hfkklf3xrGeVVtTxz9Vhiwrp3h3lpaSlz584lMzOT5ORk0tLS8G3jeY29777LpkcfZfhf/kL/35lnRA2jpzvm9ThEJEREXhCRdSKyVkSeF5EQ54R54grx8+Qfv03F1eLCg++tIudweVeH1CpfX1+uvvpqUlNTWb9+PbNmzeLHH39scdlZgJN++1vCJkxgyz/+QcmuXZ0YrWEYnanNOw4RWQAsAd61H/otkKaqU5wcW4fpDncc9fbkFHPvO8sJ9PHg2WvGEeDt3tUhtSk/P5/vv/+e7du34+npyciRI0lJSSE4OPiospW5ufzvrLPwCAtjwrx5WDw8uiBiwzA6wvGsABisqn9V1Qz79jcg0MEPnSYiO0Rkt4g80Mx5sd/N7LZPoJjU6NwbIpIrIpub1JkpIgeaWYu8Rzg5wp+Zl44i53AFf35/NZXV3X+W2ZCQEC699FKuu+46BgwYwMqVK5k1axazZ89m9+7dR/RpeIaHk/jkk5Ts2MG2x81y8IZxInIkcSwSkctExMW+XQJ81VYlEbEA/8I2BftQ4HIRGdqk2JlAnH27EXi50bm3gGktXP45VU20b1878B26leExwfzpwpHszDrM3+zPevQE/fr146KLLuKuu+5i4sSJZGVl8d577/Hiiy+yZs0a6urqAIiYNInYa68l4513OLjQLNliGCea1h4ALAEUEMAHqP91cwFKVbXlx6dt9ccCM1X1DPv+gwCq+o9GZV4BFqvqHPv+DmzNYNn2/f7Al6oa36jOTPvnP+3ol+xOTVWNfb1uH89/tYm0YX247/xELC49Y3LEenV1dWzdupWVK1dy4MABgoODmTRpEsOGDcNaXc3Siy6iIiuLiZ99hnd0dFeHaxhGOx3LA4B+qupvf3VRVVf75tJW0rDrC+xvtJ9pP9beMs253d609YaINDvPhYjcKCJrRGTNoUOHHLhk55ueFMN1kwezeEsWL3y1CWsPG+FmsVgYPnw4119/PZdffjmurq58/PHHvPnmmxSXl5MyaxZaV8ea226jzsE1PwzD6P4caapCRIJEZLSITKzfHKnWzLGmv4yOlGnqZWAAkAhkA880V0hVX1XVFFVNCQsLayvWLnPpqQO5YsJAvtmwn5e/3dIjn4EQEQYNGsRNN93EueeeS25uLv/+97/5ubiYkU8/TdHmzWyeObOrwzQMo4O0OXWriPweuBOIBjYAY4DlQFvTjmQC/RrtRwNNF6t2pMwRVDWnUWyvAV+2EUe3d9VvBlFVU8fHKzJwEeGm04f2mDU9GnNxcWHkyJHExsbyySefMG/ePBITExl4yy3sefllAhMSOOmyy7o6TMMwjpMjdxx3AqOAX1R1EjAScKTtZzUQJyKxIuIOXAY0nczoc+Aq++iqMUBRff9GS0QkqtHuBcDmlsr2FCLCDVOGcP7o/ny6ai9Pf7axx3SYNycwMJBrrrmGiRMnsmHDBtZHRBA0cSKbZs4kf9Wqrg7PMIzj5EjiqFTVSgAR8VDV7cDgtiqpai1wO/AtsA34QFW3iMjNInKzvdjXwB5gN/AacGt9fRGZg+3OZrCIZIrI9fZTT4rIJhFJByYBdzvyRbs7EeHm04dyddogFm46wF8+WENlTV1Xh3XMXFxcmDRpEueccw57MjLYNmYMbrGxrL7lFsr27u3q8AzDOA6OPAA4D7gWuAtb81Qh4KaqPeb5ie46qqolX6/bx6yvN3FyhD8PzUiiT7BPV4d0XLZv385HH31EoJ8fJ82di4+3N+M/+gj3QIceBzIMo4u0ez2OFi7yGyAA+EZVW557opvpaYkDYMXOHJ76bCNWVe4+ewQTh0a1Xakby8jIYPbs2QT7+ND39dcJHT6c1DffNE+WG0Y3djxPjiMiSSLyB2AEkNmTkkZPNWZQBC/dMJ6YUF8e+3gdz36xkcNlPXdIa2xsLBdddBGHios5eM01HFq9mvV//CNa13Ob4wyjt3JkksM/A28DIUAo8KaIPOzswAyICPTm6avHcsm4AXyffoBr/7WYD5f/THVtz/yxHTx4MOeffz7ZpaXk/f73ZH37LZsefbRHDkE2jN7MkT6ObcDIRh3kXsA6VR3SCfF1iJ7YVNXU/rxSXv1+G6t25RLq58kZif2YNrIf4QFeXR1au61atYr58+czwNUV/zfeYNDtt3PK3SfEGAfDOKG01FTV5nMcwF7AE6i073sAP3dcaIYj+oX68tfLRrF2zyE+WZHB7B93MWfpLhL6h5J0cigjY0M5OcK/R0xbMnr0aIqKili2bBnDLr+cXS++iFtAAAOuu66rQzMMwwEtJg4RmYXtKe4qYIt9enUFpgJLOyc8o6nkk8NIPjmMg4fLmb9uH8t25PD6wu0AeLhZ6BvsQ99gH6KCvPH3diPA2x0/T3c83S14ulnwcDvy1cvDtUseNpwyZQpFRUVs2bKFpPPOY+tjj+Hq7W0eEDSMHqC1SQ6vbq2iqr7tlIic4ERoqmpNQWklG/fmsyOriAMFZRzILyPncDm11rb7DgTw8XTF19ONIF8PQnw9CfX3JCrIm+gQX6KDfQgP9HJKcqmtreWdd94hKyuLlAMHqFmwgKRnn6Xvued2+GcZhtF+xzUc1/7k9yD77g5Vreng+JzqRE8czVFVyqtrKS6voaSimsqaOqpq6qisrrO9r7W9L6uqoayylpKKagrKqsgvriSvpJKK6l874H08XBkYFcCgqACG9gsiPiYYf6+OWYCqvLycN954g7KyMkZu20b1smWk/OtfRE6d2iHXNwzj2B1z4hCRNGyjqvZi+wO1H3C1qi7p+DCdozcmjuOhqhwuqyazoIz9eaX8fLCIndlFZOSUUFNnRbAtSDXy5FBGDwxnWL8gXC0OjexuVmFhIa+//jquFgvxy5dTtWkTo197jbDx4zvuSxmG0W7HkzjWAleo6g77/iBgjqomOyVSJzCJo2NU19axI6uI9L35bPwlny37Cqi1Kt4erowaEMapp0QyOi4cL3dHxlwcKSsri7feeovgwEDivvmGqj17SH3rLUJSjvo/axhGJzmexJGuqiPaOtadmcThHOVVtWzIyGPl7lxW7MzhcFk17q4upAwII21YH1IHReDpZnH4ert372bOnDlEhYcT88kn1B08yNj33iMwPr7tyoZhdLjjSRxvYlv977/2Q78FXFX12g6P0klM4nC+OquydX8BS7cfZMnWbApKq/B0szBucASnjYhmZGwIFpe2m7O2bdvGhx9+SN+ICKLnzIGyMsa9/z5+AwZ0wrcwDKOx40kcHsBtwHhsfRxLgJdUtcfMf2ESR+eqsyqb9uWzeHMWP27LprSylmBfD9Li+zB1RDQnR7S+gOSWLVv4+OOPiY6IIPKtt3CzWDj1gw/w7tOnk76BYRhwjIlDRFyA9MZrfvdEJnF0neraOlbtymXhpgOs2pVLrVUZEOHPlIRoJsf3IdCn+UkO09PT+fTTTwkLDKTP7Nn4+fpy6vvv4xEa2snfwDB6r+O543gPeFBV9zkrOGcziaN7KC6vZtGWLBZszGRXdhEWFyE1LpypCdGMHhh+1MisnTt38tFHH+FhsRDz2WdEhIcz7t13cfX17aJvYBi9y/Ekjh+wrQC4CiirP66qPeYpLZM4up+9uSUsSM9kYfoBCsuqCPB257ThfZmacGRT1sGDB5k9ezaV5eVE/+9/xPXpQ+prr+Hi3jHPkRiG0bLjSRy/ae64qv6vg2JzOpM4uq86q5U1Px/iuw2ZrNiZQ61VGRjpz+kJ0aTF9yXA253i4mI+/PBDMjMzCcrIYHRQEKnPPIM40NluGMaxa3fiEBFP4GZgILAJeN2+HGx7PnQa8DxgAf6jqo83OS/289OBcuAaVV1nP/cGcDaQ27iPRUSCgblAf2wPJV6iqoWtxWESR89QXF7Nos0HWJB+gF3ZRbjam7KmJESTfHIoq1YsZ/EPP+BSXs5IPz/OfOghpAvm2TKM3uJYEsdcoAb4ETgT+EVV72zHB1qAndgmRcwEVgOXq+rWRmWmA3dgSxypwPOqmmo/NxEoBd5pkjieBApU9XEReQAIUtX7W4vFJI6eJyOnmO/SM1m0KauhKSttWB+S+rix8pPZHBYhyM2NMy++mIEDB5oEYhhOcCyJY5OqDre/dwVWqWpSOz5wLDBTVc+w7z8IoKr/aFTmFWCxqs6x7+8A0lQ1277fH/iySeJoKCMiUfb6g1uLxSSOnqu+KWvBxgOs2JlDTZ2VmGBvBmSuxFpbQI2vD5GRkYwePZrhw4fj6tr+p9YNw2jesazH0TCRoarWHsNfdH2B/Y32M7HdVbRVpi+Q3cp1I+oTiz15hLc3MKPnsLi4kBoXQWpcBKWVNSzZms336Zks8h6OqJW44u14eJTw+eef8/3335OQkEBiYiLh4ea/RW+mqhRX1JBXXEF+SRUFpZUUlVdTVlVLeVUtVTV1KICCxSL4errh4+FKoI8HfYK86RviQ4ifZ5csOdATtJY4EkSk2P5eAC/7vgCqqq0/xWUr11TT2xtHyhwTEbkRuBEgJiamIy5pdDFfTzemJ8UwPSmGg4XlLFjzM1//cJid1UEEuZRwiksRK1asYPny5fTp04eEhATi4+Px9vbu6tANJ7CqkldcyYGCMjLzy8gqLCMrv4zsw+XkHK6gsuboJZYtLoKPhyvubhYEEBFq66yUVdZQVWs9oqy3uytD+gUR3y+IESeFMCQ6qEcslNYZWkwcqur4JEPNy8Q2k269aCDrGMo0lSMiUY2aqnKbK6SqrwKvgq2pqj2BG91fZJA3V04dzoWDA/jk+jvYEZPAzmHjKSKSKEshFBwma/58vv32W+Li4khMTCQuLg6L5Xj/Wxudrbi8+tfkUFBGpv39gYIyqholB3dXF/oE+dAnyIeRsaFEBHoT5u9JiJ8nIb4eBPh44OHq0mJ/WHVtHYfLfv2svbnFbN5XyNuLdwIQ7OvBhCFR/GZYFEOjg3p1v5pD63Ec04Vt/SI7gdOAA9g6x69Q1S2NypwF3M6vneMvqOroRuf7c3Qfx1NAfqPO8WBVva+1WEwfx4ntcHo6y377W3xiYwl46mWW7inkx23ZVJceJlIKiHQphNoqvH18SExIICkpiZCQkK4O27Crs1o5VFzJQfudQnZhOdmF5bY7iIJySit/Xf7HRYTIIC+ig32IDvGlb4gP0cE+Tm1aKi6vZl1GHku2ZrNqVy41dVYGRPgzY0wsE4f1we04lhTo7o5rIafj+NDpwD+xDcd9Q1UfE5GbAVT13/bhuC8C07ANx71WVdfY684B0oBQIAd4VFVfF5EQ4AMgBtgHXKyqBa3FYRLHiS9n0SJW33QTYePHM+qVV1CLK5v3FfDjtmx+2paNluYSSR6BWoSgxPSPZfy4sWZEVieorq0jt6iCnKIKcosqyD3c6H1RBYeKK7E2+h1yESEi0IuoIG+igrwblkPuY18SuSt/qMuqavjflmzmrcxgX14poX6eXDFhINNG9nNoEs+epksSR3dhEkfv8MvcuaT/6U/0u/hiEv7xj4aEYFVlW2Yhy3bksGLrL3B4P5F6CHdqcPXyY0RSCqdPHIuHu1sXf4Oeqb6vIavA1r+QXVBuu3uwJ4aC0iPnQ3URCPHzJDzAi8hAb8IDvIgItL2PCvQmLMCz2/8IW1VZ+/Mh5izdzZb9hcSE+nLDlCGMGhh2Qv0hYhKHSRy9wo5//pOds2Yx6I47GHzXXUedV1X25ZWyfHs269M3Yc3bgy/l1IgbHuEDGZmcTEpcFJGBpkO9qaqaOvbllbLvUAn788vYl1dKZn4p2YXlVDfqWLa4yK/JIODXxBAR4EVYgBehfp7HtWJkd6Kq/LT9IK//sJ2sgnLGDY7gjunxBPt6dnVoHcIkDpM4egVVZeODD7L/ww8Z8be/cdLll7davri8moUrNrJ5/WqspYeowZUDEglBJzEiNpyEk0IYcVIIof4nxg+BI1SVvJJKfj5YzJ6cYn4+WMze3BKyCsuw2n8uXEToE+xNdIgv0SH2piR701Kov1evG31UU2dl3soM3lm8Ew83C7ecMZTThvft8XcfJnGYxNFrWGtqWH3zzeQuWULKiy8SdcYZDtXbt28f3y74gazMX1CLB1kuUeyrDUbFhYhAL+L7BTO0XxBD+gbRP9y32zenOEJVyS2qYFe2bV353QeL2Z1dRFF5dUOZPsHexIb70z/Mj9hwP2LCfOkT7HNCdwofq/15pTz7RTpbMwuZMCSSu88egY9nz20CNYnDJI5epba8nBVXXUXRli2kvvkmoWPGOFx33759LFy4kH379uHnH0jQySPIrPZjy/7DFJbZ2us93CwMigpgUJ8A4qJsW59gn279wJiqknO4gt0Hi9iVbdt2HyxuSBIWF6F/mB8Do/wZEBnAwEh/YsP98fYwT+O3R51V+WTFHt74YQcRgV48NCOJuKiArg7rmJjEYRJHr1N9+DA/XXYZldnZjJs9m4Bhwxyuq6rs2rWL77//nkOHDhETE8Ppp5+OeAWy/cDhhm1PTjE1dbb2fQ83C7Hhfpwc4c9JYb7EhPpxUpgvwb4end5kUVZZw768UjJyS9ibW0JGrq3ZqbTSNk9pfZKIiwpgoD0Bxob74e5qnnPpKFv2F/D3T9ZTVFbNbWcO48yRPe9BZJM4TOLolSqys1l68cVYq6qOae1yq9XK+vXr+eGHHygvLycxMZEpU6bg4+MDQG2dlV8OlbL7YBF7cortW8kRzx54ulkahpJGBHoR5u9FmL8nwb4eBPp4EOjjjre7q8PJpc6qlFbWUFhaRWFZFfklleQcriCnyPb8Q2Z+2REjmTzdLPS3J7SBkba7iZMjTJLoDEXl1Twxbz1r9+RxQWosN0w5pUc1cZrEYRJHr1WakcGyyy5DLBbGvf8+PscwBU1lZSVLlixh5cqVuLu7M3nyZJKTk3Fp5kdAVSksq2LfoVJ+ySu1DVMtLOdAQRmHiiqOmtoCbENUvdxd8fZwxcPVgouLNHQw11mVWquV6horZVU1VFQfPZUG2J5sjgz0JjrEh36htk7r2HB/IgK9unUT2omuzmrl1QXb+HTVXlIGhPGnC0f2mH4PkzhM4ujVinfsYNkVV+Dm58e4OXPwioo6puvk5eXx9ddfk5GRQVRUFGeddRZ9+/Z1uL6qUlJRw6HiCgrLqjlcZrtrKKuspaK6lrKqWmpqrdRZrdRZFVVwtQgWFxfcXV3wsU/G5+vpRpCvB0E+HgT7ehAR6GXuILq5r9ft48X5m4kJ9eVvl4/uESP1TOIwiaPXO5yezvIrr8QjNJSx772HV2TkMV1HVdm6dSvffPMNZWVljBo1ismTJ+Ph4dHBERsnmnV78vh/H67Bz8udx64YTUyob1eH1CqTOEziMICCtWtZed11eISE2JLHMd55gK356ocffmD16tX4+fkxffp0TjnllA6M1jgR7cou4pE5q6m1WvnrZaMYEh3U1SG1qKXE0XN6aQyjAwQnJ5P65ptU5eez7IorqMhqazLmlnl6ejJ9+nSuv/56vL29mTt3LnPnzqW4uLjtykavFRcVwHPXjsPPy40H3l3J+oy8rg6p3cwdh9ErFW7YwIqrr8YtMJAxb72Fb2zscV2vrq6O5cuX87///Q8XFxcmT57MqFGjmu08NwyAgtJKHnx3FQcKynj4oiTGDIro6pCOYpqqTOIwmjicns7K668HEca8+Wa7nvNoSUFBAV999RV79uwhKiqKs88+mz59+nRAtMaJqLiimodmr+Lng8Xcd34iacO61/8V01RlGE0EjhjBuPffx8XdnWVXXEHeypXHfc3g4GB+97vfMWPGDEpKSnjttdf44osvKCsr64CIjRONv5c7T/xuDMP6BfHEvPV8n57Z1SE5xNxxGL1eRVYWK665hvL9+0n4xz+IPv/8DrluZWUlixcvZvXq1bi6ujJx4kRSU1NxdTVTeBhHqqyp49G5q9mYkc/d54zgjMR+bVfqBKapyiQOoxXVhw+z5rbbyF+xgrhbb2Xw3XcjHdQ/kZeXx4IFC9i5cyd+fn6MHz+epKSkbpVAqvLzKdm5k/IDB6jIyqIyO5ua4mJqy8qoLSsDVVzc3XFxd8fNzw/PyEg8w8PxjokhID4erz59evxMsF2tqqaOv3y4lrU/H+KO6fGcnXxSV4dkEodJHEZbrNXVbHr0UfZ98AGRZ5xB4hNP4Obn12HXz8jIYPHixbbJE/38SE1NJTExsWH6ks5SV1lJ/vr1ZK9aRc6WLZTu3UtNYSGo4lZRgWtlJZ5hYbgFBuLq44Orlxe4uGCtqcFaXU3N4cNU5uRQV1HRcE23gACCEhMJT0sjYtIkvPt1j7+Ye5rq2jr+9tE6Vu7K5bZpwzh3VP8ujcckDpM4DAeoKnveeINtTzyBd79+JM+aRcDQoR16/b1797JkyRL27t2LxWJhyJAhJCQk0L9//w6/C6muriYnJ4f927ezf/NmcnNyKFGlxtMTWrij8vDwIDg4mOjoaAYNGtRsXKpKbWkppT//TNHWrRRt3kz+ypWU7d0LgP+QIcRccgnR55+Pm79/h36nE111bR1//3g9y3fmcPPpQ7kg9fhG/B2PrlpzfBrwPLY1x/+jqo83OS/289OxrTl+jaqua62uiMwEbgAO2S/zJ1X9urU4TOIw2it/9WrW3Xkn1YWFDHvkEU66/PIOb4o5dOgQa9asYePGjVRVVeHm5sbAgQOJjY0lKiqKiIgI3Nwcm9OopqaGwsJC8vPzycnJITc3l4MHDlDY6JkSl5oavCsrCfb3JyQ6mrCBAwkIDcVisaCqqCrFxcUUFBSQl5fHvn37qK2txc3NjWHDhjF27FjCw8NbjaM0I4OcRYs48PnnFG3ahIunJ33POYe4m2/Gp3//4/nn6lVq6qz84+N1/LQjhxunDmHGmJO7JI5OTxwiYgF2AlOBTGA1cLmqbm1UZjpwB7bEkQo8r6qprdW1J45SVX3a0VhM4jCORVVeHuv/7/849OOPhE2YwIi//x1vJwytra2tJSMjgx07drBz505KSkoAEBECAgLw8/PD19f3iClN6urqqKiooLy8nJKSkoY69byrq3HLzsa7sJBQPz8GjB3LyWecgd/Jjv8A1dTUsHfvXrZv386mTZuoqakhLi6OiRMnEh0d3Wb9w5s3s+/999k/bx5aU0P0BRcw6PbbTTOWg2rrrDw+bz0/bjvIdZNP4dJT2zezc0foisQxFpipqmfY9x8EUNV/NCrzCrBYVefY93cAaUD/luqaxGF0JrVa2fvuu2x76inExYUh99/PSZdeilicM6Fg/V/92dnZZGVlcfjwYUpLSyktLaWq6tep0l1cXPD29sbb2xsfHx+8amqo3bSJ8iVLcMvOxq9PH/pdeCF9zzmnQ/7SLy8vZ/Xq1axatYry8nISEhKYMmUKvr5tz7VUeegQu195hV/eew9VZeANNzDw1lttfSdGq+qsVp78dCOLt2RxddogrpgQ16mf3xWJ4yJgmqr+3r5/JZCqqrc3KvMl8LiqLrXvLwTux5Y4mq1rTxzXAMXAGuAeVS1sLRaTOIzjVb5/Pxv/9Cfyli3Df8gQhj74IGGnntqlMdWUlHDgiy/YN3cuRZs34+LhQZ8zz6TfJZcQMmpUh40Ka6y6upolS5awfPly3NzcGp6Qd6QZr+LgQbY//TSZ8+bh1bcv8X/+M5FTpnR4jCeaOquVZz5PZ+GmA1wxYSBX/WZQp41g64oHAJv7Zk2zVEtlWqv7MjAASASygWea/XCRG0VkjYisOXToUHNFDMNh3v36Meadd0h+4QVqS0tZcdVVrLj2WgrWrKEzB5io1UreihWsv/devhszhk2PPIK1pob4Rx9l6vLljHzmGUJTU52SNADc3d2ZMmUKt956K9HR0cyfP5///ve/FBUVtVnXKzKSkU8/zbg5c3D18WH1TTex7o9/pNqBur2ZxcWFe85N4PSEaGb/uJvXF27v1P9zzelxsT7I1AAAFhhJREFUTVVNPqM/8KWqxrcWi7njMDpSXVUVe//7X3a9/DI1hw8TmJjIgOuuI2LKFCxOmFpd9f+3d+fRVdZnAse/T3Kzh+wECIEkUkS2sIfFOgdREZcptU5dam3t9NR6OpXWjlNrp6u1Z2DqdGrrVitOHWt1rCJQ24K2FhcQhRAghLAvWWQJWcnNnvvMH+8bvITckECSewPP55x7cu973/eX596T3Oe+v9/v/T1KXXExH/3pT5StWkXTkSN44uPJuPFGsm69lcTJk4NyDYWqsmXLFtauXUtYWBjXXXcdubm5PYrF19rKvqeeYs9jjxGVlsaUpUtJv+KKAYh68PKp8sSaIv64+TD/ODOLry2a2O8FuoLRVeXBGeC+CijHGeD+nKoW+e1zA/B1Ph4c/6Wq5nV3rIiMUNUj7vH34XRh3dZdLJY4TH9oa2igbMUK9i9fTkNJCREJCQy/9loybriB1Ly880oirSdPUr1lC8fffpujf/0rjeXlSHg4Q6+4gszFixl29dV4YmP78NWcu+rqalauXElJSQmTJk3ihhtuIDq6Z0WKagoLKbj/fur37eOSL3+Z8fffT1hkZD9HPHipKs/8bRevvH+Aa6Zkct+Nk/u1FG2wpuNeD/wCZ0rts6r6UxG5B0BVn3Kn4z4GLMKZjvslVd0c6Fh3+/M43VQKHAK+2pFIArHEYfqTtrdz/N13+ej11zn65pu01dcTFhlJ4uTJpM6cSfzYscSNHk3sqFFEJCYSFhmJiKDt7bTW1dFaW0tDWRn1+/dzcv9+arZupba4GHw+wqKiGPrJTzL86qsZtmABUWlpwX65XfL5fLz33nusW7eOxMREbrrpJkb3sERve1MTO5cu5dDzz5OUm8v0Rx89p/K+FwtV5YV39vL8O3u5fNwwvvOZaf1W/dEuALTEYQZAe3MzJ9avp/KDD6jcvJnaHTvQtrYz9guLjMTX0nLGds+QISROmEBqXh4ps2aRPG1ayJxZ9ERZWRkrVqygpqaGefPmMX/+/B5f1Hhk7Vq2PvAAqDJl2TIyFi3q52gHt5UfHuTJtTuZkp3KD2+ZQVxU39cxt8RhicMEQXtzM43l5XgPH6ahrIw2rxdfczPtTU2ER0cTkZBARGIiMSNGEP+JTxCVljbo13xqbm5m7dq1FBQUkJ6ezk033cTwHpbpbSgrI3/JEmq2bSPnrruY8MAD1nXVjbcKy3lk9TZy0ofwk9tnkRLft3XMLXFY4jBmQO3Zs+fUkvJ5eXnMnz+/R2MfvpYWdi5bxsHf/pakKVOY8atfETty5ABEPDh9uPc4D7+6haS4SB6+bRajh/bd+mqWOCxxGDPgGhoaeOutt8jPzyc2NpYFCxYwdepUwntwAeVHa9aw7YEHkLAwpixbxoiFCwcg4sFpz0c1/OClzbS2t/PDW2aSm5XaJ+1a4rDEYUzQHDlyhDVr1lBSUkJ8fDx5eXnMnDmTmLNcPe4tKSF/yRJqCwvJvvNOJjz4YJez1VSVhoYG6urqaGxspKWlhRZ3DMnj8RAREUFMTAzJycnExsYO+u7ArhytaeD7L27iSHUD914/qU9qeljisMRhTFCpKvv37+f999/nwIEDhIeHk52dzdixYxkzZgwpKSld1mj3tbRQ/Mgj7H/2WSImTmTkkiU0DRlCVVUVVVVVVFZWUltbS3t7e4/iiIiIIDU1lczMTDIzM8nKyiIpKamvX25QnGxs5aevbqHg4Ak+nZfN3deMP6/pupY4LHEYEzKOHTtGQUEB+/bto7KyEnDW30pMTCQxMfFUV1bHmUR9fT3e+vrTlp6IiIggJSWF1NRUkpKSSEhIICEhgdjYWCIjI4l0B9Xb2tpobW3F6/VSU1NDdXU1x48fp7y8/NRZSXp6Opdeeinjx49nxIgRg/qMpN3n4zd/3cVrHxxkWk4a3715Ggkx5zbBwBKHJQ5jQlJVVRWHDx+mqqqKmpoaamtr8fl8gLNCcMdCjvHx8QyJiqLmtdeoW7OG1Kwscn/8Y1JmnvG51iM+n4+KiopTKxMfPnwYVSUtLY2pU6eSm5vLkD4s5DXQ1m4t5bG/7OAHn53BrE90vxx+IJY4LHEYc8E4snYtOx56iKajR8n8zGcY/+1vEz106Hm12djYSHFxMVu3bqW0tBQRYcKECeTl5TFq1KhBeRZSebKJ1CHnPkXXEoclDmMuKG0NDex9/HH2L1+OhIWRfccdjLn77vNOIACVlZXk5+dTUFBAU1MTw4cPZ+7cuUycOLFHM8IuFJY4LHEYc0HyHjrEnscfp3zVKsTjYdTNNzP61ltJmtTt2qc90tLSQmFhIRs3buTEiRMkJCQwZ84cpk+fflphrQuVJQ5LHMZc0LyHDrH3qacoX70aX3MzCRMmkLl4MelXXkn8JZecV1eTqrJ37142bNjA4cOHiY6OZubMmcyePbtHxawGK0scljiMuSi01tVRvno1h19+mboiZzHumMxMhs6bR+KkSSROmkTCuHGE93AF387Ky8tZv349xcXFeDwepkyZwpw5c0gL0QUoz4clDkscxlx0GsrLOf722xxft46q/Hxaa2pOPRc9bBgxmZnEjhxJZEoKkcnJRCYn44mLwxMXR3hsLOFRUYRFRREWGUlYRAQSHo54PEhYGNV1dXy4fTs7du+mvb2dsTk5zJo+nazRowlz9wuLiOi3oloDwRKHJQ5jLmqqSmN5OTWFhdTv20dDaSkNZWU0HjlCS1UVbfX159Rua3Q0FePGUTFuHO3R0URXV5O+axfJBw8S3taGeDyER0fjiY/HExdHRGIiUWlpRKWlET18OHGjRhGblUV8Tg4RCQl9/KrPT6DE0bP1jo0xZpATEWIzM4nNzOzy+fbmZlpra2nzemnzemlvaKC9uRlfczO+lha0rQ1fezva1ob6fODzOT9VUZ+P1rY2Dnq97I6IoCQ5mY/mzSMrIoKcsDASmptpb2igzeultboa78GDVG3eTEtV1WkxxGRkkHDZZSROnEjS1KkkT5tGZGLiQLw9vWKJwxhjgPCoKMLTz+1CuQ6XAgtVKSkpoaCggKKiIva3tDB06FAmT57MpEmTSE5OPrV/W2MjjaWleEtKqN+/n7pdu6grLubYunXgXgQZP3YsabNnkzp7Nql5eSFRzMu6qowxpp80NTWxY8cOCgsLKSkpAWDEiBGMGzeOcePGMWzYsC5ne7V5vdRs3051QQGVmzZRtXkz7Q0NACRcdhlpl19O2ty5pObl4YmL67f4bYzDEocxJohqamooKipi9+7dlJaWAhAfH09OTg45OTlkZWWRnJzcZSLxtbZSW1TEiQ0bOLFhA1X5+fhaWhCPh6TcXNLmziVl1ixSpk3D04fTg4NVc3wR8ChO3fBnVHVpp+fFff56nJrjd6nqlu6OFZEU4P+AbJya47eoanV3cVjiMMaEEq/Xy549ezhw4AAHDx7E6/UCEBsby8iRI8nIyGDYsGGkp6eTnJx8xqrB7U1NVOXnc+L996ncuJGa7dvR9nYICyNh/HiSp0whKTeXpNxc4seMIayH5Xs7G/DEISLhwB7gGqAM2ATcrqo7/fa5HrgXJ3HMBh5V1dndHSsi/wlUqepSEfkOkKyqD3QXiyUOY0yoUlUqKiooLS2lrKyMsrIyTpw4cer58PBwUlJSSElJITk5mYSEBBITExkyZAjx8fHExcUhzc3UbNtG1ebNVG3eTE1h4alZYjOfeIIR1157TrEFY1ZVHrBPVQ+4AbwELAZ2+u2zGPhfdbLXRhFJEpEROGcTgY5dDMx3j38OWAd0mziMMSZUiQjp6emkp6czY8YMAFpbW6moqODYsWNUVFRQXV1NVVUVBw4coLW19Yw2PB4P0dHRzu3KK4lYuJDwtja0vp7W7Ow+j7k/E8dIoNTvcRnOWcXZ9hl5lmOHqeoRAFU9IiJdToMQkbuBuwFGjx59ji/BGGMGXkREBBkZGWRkZJy2XVVpamqitraWkydP4vV6T92amppobm6mqamJlpYWvC0ttAJ6jlfId6c/E0dXC8N07hcLtE9Pju2Wqj4NPA1OV1VvjjXGmFAkIsTExBATE8Pw4cODFkd/XgtfBvgXvc0EPurhPt0de8ztzsL9ebwPYzbGGHMW/Zk4NgFjRSRHRCKB24DVnfZZDXxBHHOAWrcbqrtjVwNfdO9/EVjVj6/BGGNMJ/3WVaWqbSLydWAtzpTaZ1W1SETucZ9/CvgzzoyqfTjTcb/U3bFu00uBl0Xky0AJ8Nn+eg3GGGPOZBcAGmOM6VKg6biDd71fY4wxQWGJwxhjTK9Y4jDGGNMrljiMMcb0ykUxOC4iFcDhczw8DThx1r2CJ5TjC+XYILTjC+XYILTjC+XYILTj6xxblqoO7bzTRZE4zoeIbO5qVkGoCOX4Qjk2CO34Qjk2CO34Qjk2CO34ehqbdVUZY4zpFUscxhhjesUSx9k9HewAziKU4wvl2CC04wvl2CC04wvl2CC04+tRbDbGYYwxplfsjMMYY0yvWOIwxhjTK5Y4uiEii0Rkt4jsc+ubhwwReVZEjovIjmDH0pmIjBKRv4tIsYgUicg3gh1TBxGJFpEPRWSbG9uPgx1TV0QkXEQKROT1YMfiT0QOiUihiGwVkZBbOdQtP/2KiOxy//7mBjumDiIyzn3fOm51IvLNYMfVQUTuc/8ndojIiyISsHSgjXEEICLhwB7gGpzCUpuA21V1Z7cHDhAR+QegHqdm+6Rgx+PPLbA1QlW3iMgQIB/4dCi8dyIiQJyq1otIBPAe8A1V3Rjk0E4jIt8CZgIJqnpjsOPpICKHgJmqGpIXsInIc8C7qvqMW8snVlVrgh1XZ+7nSzkwW1XP9eLkvoxnJM7/wgRVbRSRl4E/q+pvu9rfzjgCywP2qeoBVW0BXgIWBzmmU1T1HaAq2HF0RVWPqOoW9/5JoBinjnzQqaPefRjh3kLq25OIZAI3AM8EO5bBREQSgH8AlgOoaksoJg3XVcD+UEgafjxAjIh4gFjOrNh6iiWOwEYCpX6PywiRD7/BRESygWnAB8GN5GNuN9BWnLLDb6pqyMTm+gXwbcAX7EC6oMAbIpIvIncHO5hOLgEqgP9xu/meEZG4YAcVwG3Ai8EOooOqlgOP4BTHO4JTjfWNQPtb4ghMutgWUt9MQ52IxAOvAt9U1bpgx9NBVdtVdSpOLfs8EQmZrj4RuRE4rqr5wY4lgMtVdTpwHfAvbpdpqPAA04EnVXUa4AVCamwSwO1C+xTwh2DH0kFEknF6VHKADCBORD4faH9LHIGVAaP8HmfSzambOZ07fvAq8IKqrgh2PF1xuzHWAYuCHIq/y4FPuWMJLwELROR3wQ3pY6r6kfvzOPAaTpduqCgDyvzOIF/BSSSh5jpgi6oeC3Ygfq4GDqpqhaq2AiuAeYF2tsQR2CZgrIjkuN8QbgNWBzmmQcEdgF4OFKvqz4Mdjz8RGSoiSe79GJx/mF3BjepjqvqgqmaqajbO39xbqhrwm99AEpE4d7IDbhfQQiBkZvWp6lGgVETGuZuuAoI+IaMLtxNC3VSuEmCOiMS6/79X4YxNdskzYGENMqraJiJfB9YC4cCzqloU5LBOEZEXgflAmoiUAT9U1eXBjeqUy4E7gUJ3LAHgu6r65yDG1GEE8Jw7qyUMeFlVQ2rKawgbBrzmfK7gAX6vqmuCG9IZ7gVecL/sHQC+FOR4TiMisTgzNb8a7Fj8qeoHIvIKsAVoAwroZvkRm45rjDGmV6yryhhjTK9Y4jDGGNMrljiMMcb0iiUOY4wxvWKJwxhjLjC9XQRVRG4RkZ3uIoe/P+v+NqvKGGMuLL1ZBFVExgIvAwtUtVpE0t0LPAOyMw5jzHkRkU+LyG9EZJWILAx2PKbrRVBFZIyIrHHXGXtXRC5zn/oK8LiqVrvHdps0wBKHCXEi8t/+NQtEZK2IPOP3+L/cJcgDHZ8kIl/rp9iWuDUfXuiP9geKiMSIyNvuRZG9pqorVfUrwF3ArW6bkSLyjrvSqgkNTwP3quoM4H7gCXf7pcClIrJeRDaKyFmX4LHEYULdBtw1c0QkDEgDJvo9Pw9Y383xSUCfJg5xhLntXq+qd/Rl++cYy/n4Z2CFqrafZzvfAx4HZ0lz4G+4icQEl7vg6DzgD+5qDr/GWUUBnFUAxuKsRHE78EzHsjyBWOIwoW49Hy+2NhFnbaSTIpIsIlHAeKBARD4vTmW/rSLya79vz0uBMe72n/k37K699CdxqgHuEJFbRSTbf0BRRO4XkR+524tF5AmcZRmW4yzjvVpE7nP3Xel2AxT5LzkuIl8Qke3u73ne3RYo3tN01WYXsYwK1F6gmDq5A1jl1/YuEXnOjfkVd5kMRGSWuy3afe+KRGSSm7yWAX/pqMPiWum2bYIvDKhR1al+t/Huc2XAKlVtVdWDwG6cRBKYqtrNbiF9Aw4Bo3HW97kH+AlwPc6aWO/gJI8/AhHu/k8AX3DvZwM7ArR7M/Abv8eJnffHOaX/kbvdB8zpFFea3+MU92cMToJLxUl2uzv2A1K6i7eLGLtq87RYzvL6zzi+U/uRwFG/x9k45QMudx8/C9zv9/zDOHUbHgcedLctwany+BRwj9++4UBFsP9+LtZbF3/LG4DPuvcFmOLeXwQ8595Pw6lDlNpd29b/aAaDjrOOecDPcQpqzQNqcf4ZrgJmAJvcBfhicIo0nU0h8Ij7bfl1VX1XnLoEgRzW7kvMLhGRm9z7o3C+tc0CXlG31KqqVonI53oRb1dtHu0US3evv6vjK/3aTwM6V8krVdWO7r/f4SSGR9zHD+GsHN3kbkdVfwn8snPgqtouIi0iMkSdSpBmgEgXi6DinP09KSLfw6l8+RKwDWch14UishNoB/5NVSu7bNhlicMMBh3jHJNxvjWXAv8K1OF8I87G+cb0YG8aVdU9IjID5+zlP0TkDbc9/y7caL/73kBtich8nCXa56pqg4isc48VziwAJj2Jt5s2O8fSZXtnOb5DYxfbOsfr/zgFiMf54Immm/fEFYWTZMwAUtXbAzx1xsC3Oqca33JvPWJjHGYwWA/cCFSpU72vCmfQey7wPs4g7D+JSDqAiKSISJZ77ElgSFeNikgG0KCqv8P5Rj0dOAaki0iqO4ZyYw9jTASq3Q/oy4A57va/AbeISGpHbGeJtydtdhaovbMer84UzHAR8U8eo0Vkrnv/duA9v+eeBr4PvAAs6+4NcV9zR2EgcwGxxGEGg0KcLpWNnbbVquoJVd2JM6PnDRHZDryJO2PEPeVe7w5+/6xTu5OBD91ZJv8OPOx+yD2EUyP9dXpe5GkN4HF//086YlWnhstPgbdFZBvw8+7i7UmbnXXTXo+OB94APun3uBj4ontcCvAkOIP8QJuq/h5n0sEsEVnQzXtyJRAKNVhMH7Mrx425yInINOBbqnqniGTjjPecdx12EVmBM4C++3zbMqHFzjiMucipagHw90BTgs+FOBX4VlrSuDDZGYcxxphesTMOY4wxvWKJwxhjTK9Y4jDGGNMrljiMMcb0iiUOY4wxvWKJwxhjTK9Y4jDGGNMrljiMMcb0iiUOY4wxvfL/QnEAF4Lo5IYAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(xs, en_pdf, label=\"El Niño\", c=\"firebrick\")\n",
+    "plt.plot(xs, ln_pdf, label=\"La Niña\", c=\"steelblue\")\n",
+    "plt.plot(xs, neutral_pdf, label=\"Neutral\", c=\"grey\")\n",
+    "plt.ylabel(\"Probability density\")\n",
+    "plt.xlabel(\"Wet surface area (px$^2$)\")\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here it is much more obvious that Kati Thanda is wetter during La Niña."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Difference between El Niño and La Niña compared to neutral\n",
+    "\n",
+    "We can characterise the influence of ENSO over our waterbody by a) assuming that there is no confounding correlation between ENSO and water surface area, and then b) calculating the distance between the above probability distributions. There are many, many ways of comparing probability distributions. We will employ three:\n",
+    "\n",
+    "1. The Kolmogorov-Smirnov (KS) distance, commonly used to determine whether two distributions are different in a test known as the \"KS test\". Arguably the most common statistical test, besides the Student t-test. While it is parameter-free and works on any distribution, it's also fairly weak and hence tends to under-predict differences in distributions, i.e. if it suggests that two distributions are different they probably are, but if it suggests that they are the same it might not be.\n",
+    "2. The sum-of-squares difference, or the Euclidean distance. This is a measure of how far apart the quantiles are, and is a good choice if you expect your quantiles to have normally-distributed noise.\n",
+    "3. The Kullback-Leibler (KL) divergence. This is an asymmetric measure of \"surprise\": given an expected distribution, how surprising is it to observe another distribution? This is a measure of relative information entropy. We will measure the KL divergence from neutral to El Niño/La Niña, which can be interpreted as the amount of information lost by approximating El Niño and La Niña as neutral. No information would be lost if they are the same distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Kolmogorov-Smirnov.\n",
+    "en_ks = abs(en_cdf - neutral_cdf).max()\n",
+    "ln_ks = abs(ln_cdf - neutral_cdf).max()\n",
+    "\n",
+    "# Euclidean.\n",
+    "en_euc = np.sqrt(np.mean((en_cdf - neutral_cdf) ** 2))\n",
+    "ln_euc = np.sqrt(np.mean((ln_cdf - neutral_cdf) ** 2))\n",
+    "\n",
+    "# Kullback-Leibler.\n",
+    "en_kl = np.sum(en_pdf * np.log(en_pdf / neutral_pdf))\n",
+    "ln_kl = np.sum(ln_pdf * np.log(ln_pdf / neutral_pdf))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABDAAAAFgCAYAAABNIolGAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzde5hkZXnv/e/PGVBUDCpj0DkI8cUYzAvRtKCiEWPUAQ9oYgxIJLgxE4zEmB33K3EbPJCT0XiIoJMJGRETIVFERx1F46ugG4kMBJGDmBFUxsFMcwYRcfDef6zVWDTdPd0z3bVqqr6f66qra63nWavugp67Vt/1PM9KVSFJkiRJkjTI7td1AJIkSZIkSdtiAUOSJEmSJA08CxiSJEmSJGngWcCQJEmSJEkDzwKGJEmSJEkaeBYwJEmSJEnSwLOAoQWX5M1J/rnrOHZWSS5PckjXcUhSPyQ5JMmmnu1pc+DkvpI0KpLsnaSSLG63v5Tkle3zY5J8ZQFe857XWChJVif58/b5jDk+yWlJ/mIh49HgsYChOUnynSS/0bN9RJKbkjyjy7gGTZJjk3wzyW1J/jvJp5Psvj3nqqrHV9WX5jlESZoX7efCj5Lc3vM4eb7Obw6UNOyG8fp6e4soVXVcVZ20EDFpOCzuOgDtvJL8HvBO4HlVdX7X8eyIJIuraus8nesZwF8BK6vqP5M8DHjBfJx7iteat7glaQe8oKr+vesgJGlnN0zX14PK6+edmyMwtF2SrAL+DnhuVZ2f5FFJ1iW5McnGJL8/zXETw91ekeTatrp8XJInJbk0yc2939wluV+SNyb5bpItSU5P8nM97Ue3bTck+fPeCnaS+yd5d5LN7ePdSe7fth2SZFOS1yf5AfCBbfS/Msnze153cZLrkzxxirf5JOCrVfWfAFV1Y1V9sKpua489Lcn7knym/aby/yTZq329m9qRG0/oea3e9/TmJB9N8s9JbgWOaYfzndSe57Ykn0uyZ8/xL2yHYN/c9v2ldv8JST466f/Pe5L8/Wx+ByRpJpk0fTD3He78sCQfaPPtTUk+Ps15enPgbm0OvSnJFTT5trfvo5KclWQ8yTVJXtPTdmCSr7a58LokJyfZtae92s+j/2rPf0qSzPN/Fkma1hTX15NHZsxlWnaSvDfJLe215bN6Gl7RXtveluTqJH8w6cDDk1yS5NYk306ycoqTP7K9dn/ddrzPxyX5fJq/G65K8tKetvtMC0nyhva6+ztJjprhvM9v4745yflJ9u9p+0573X8p8MOJzyLtfCxgaHu8CjgJeFZVbWj3nQFsAh4FvAT4q95EOYWDgH2B3wHeDfxv4DeAxwMvzc+GzB3TPp4J/ALwYOBkgCT7Ae8DjgIeCfwcsLTnNf438GTgV4ADgAOBN/a07wU8DHg0sGob/c8Ajuw59rnA9VV18RTv7T+A5yZ5S5KDJ4ogk7y0PfeewI+BrwIXt9sfpam8T+fwts8ewL+0+14GvAJ4BLAr8DqAJI9tY38tsARYD3yyvWg/AzgsyUPavovauD48w2tL0nz5EPBAmrz/COBdszjmTcBj2sdzgd+baEhyP+CTwNdpPgueBbw2yXPbLncDf0KTZ5/Stv/hpPM/n6YocgBNPnwuktQfU11f74iDgKtpct6bgI+lGRUMsIUm3z2E5vrxXRNfyiU5EDgd+F8015q/Bnyn98RJ9gbOBU6uqnfMJagkDwI+T3O9+Qia6+v3JXn8NIfs1b6HpTQ5f02SX5zivE8E1gJ/ADwc+Adg3aTr8COB5wF7OAJj5zVUBYwka9N8S3/ZLPu/NMkV7bfT/tE2e88GLgC+AZBkOfA04PVVdWdVXQKcCrx8hnOc1Pb9HPBD4Iyq2lJV3we+DEyMQDgKeGdVXV1VtwN/BhzRVk1fAnyyqr5SVXcBJwLV8xpHAW9tzzsOvGVSTD8F3lRVP66qH22j/4eBFyZ5YLv9Mqb5Q7+qvgz8JvBE4NPADUne2RYIJpxdVRdV1Z3A2cCdVXV6Vd0N/GvP+5/KV6vq41X10zZugA9U1bfa7X+jKcJAUyD6dFV9vqp+ArwD2A14alV9l6Zo8qK2768Dd1TVBTO8tjRr5uSR8vH2G6+Jx5Sj8CYkeSRwKHBcVd1UVT+pqnNn8TovBf6yHdl2LdA7YuxJwJKqemtV3VVVVwP/CBwB0ObcC6pqa1V9h+bidvL88r+pqpur6nvAF/lZLpWkhXav6+t5sAV4d5tf/xW4iuaPd6rq01X17WqcC3wOeHp73LHA2vba8adV9f2q+mbPefcDvkRzDb1mO+J6PvCdqvpAm48vBs6iua6fzp+31+vn0lxbv3SKPr8P/ENV/UdV3V1VH6T5kvDJPX3+vqqu7bl+1k5oqAoYwGnAfYY4TSXJvjR/DB9cVY+n+YZas3Mc8Fjg1HZ47aOAGyemSLS+y71HQ0z23z3PfzTF9oPb549qz9V73sXAz7dt1040VNUdwA09fac69lE92+NtAWGb/atqI3Al8IK2iPFC2gJG7r1w3Yq2/2eq6gU0IzwOpxlF0rtq82zf/1SunWLfD3qe38E0//2q6qft8RP/bz7Mz0aWTFuUkbbTaZiTR8WLqmqPnsc/bqP/cprPjZvm+Dr3yvvcO2c/GnhUbyEFeAPN5wVJHpvkU0l+kGYK3l/RfKvXa7pcKkkLbfL19Y76flX1frF3z3VtkkOTXNBO4bgZOIyf5cPlwLdnOO9RwPdpRgPTnu/pPdfCl28jrkcDB03K1UfRjLSYyk1V9cOp3scU5/3TSeddPqnvVNfQ2skMVQGjqs4Dbuzdl+QxST6b5KIkX07yuLbp94FTJi6eqmpLn8PdmW2hGXr7dJopHJuBh+Xed9lYQZPcdtRmmoTUe96tNH/wXwcsm2hIshvNkLGZjt3cs92b1GfTf2IayeHAFW1Rg6p6cM/je70nbCvXXwD+f+CXZ36rszY57pnc6z21H4jL+dn/m48AhyRZBrwYCxiaR+bkkfdDmikiE3ovTq+l+dzYY47nvI4mh01YMemc10wqpOxeVYe17e8HvgnsW1UPoSluuMaFpEEx+foaZs6j27J0UiFkBbC5nVJxFs2o3J+vqj1ophhP9L2WZpredN4MXA98eGJ0cVV9uedaeLqpIBOuBc6dlKsfXFWvmqb/Q9tpJ/d6H9Oc9y8nnfeBVXVGT5+5XENrQA1VAWMaa4A/qqpfpVkXYCIhPBZ4bJqFDy+YanEaTa+qNtNMOVgJ/E/gfOCvkzygXTDnWH62PsOOOAP4kyT7JHkwzTdm/9rOW/sozYiIp7ZrOryFe1+MngG8McmSNItangjMtPDRtvqfCTyHZo7itH/op1n46IgkD03jQJphyl1Mzfg34HlJnpVkF+BPaYbTnQ/QTpX5EvABmgv/KzuIUaPFnDw6LgF+LcmKNIsv/9lEQ1VdB3yGZt7zQ5PskuTXZnHOfwP+rD1mGfBHPW1fA25Ns0jbbkkWJfnlJBMLfe4O3Arc3hbOprtYlqRO9F5fJ3kXTR49os2RY8w8zWKyRwCvaY/9beCXaAoVuwL3B8aBrUkOpbm+nfBPwCvaa8f7JVna82UDwE+A3wYeBHwozfpD00n7t8E9D+BTNJ/3L29j2yXNYv6/NMN53pJk1yRPp5mC8pEp+vwjcFySg9rr7wcled6kL1g1BIa6gNH+wftU4CNJLqGZ7/rItnkxzSKSh9B8q37qdnwTNNLa+ce/TpNMNwJ701REz6aZF/f5eXiZtTQLvZ0HXAPcSXvBWlWXt8/PpPlW7jaa6vWP22P/AtgAXEozn/Didt90ZuzfXnB/leZ36l9nOM9NNN8m/xfNxfI/A2+vqvko6MxJVV0F/C7wXppq+Qtobnd4V0+3D9MsoOroCy0oc/JQ++Sk6XRnt58B/0qTUy+iuWjt9XKaC+Fv0uTu2UwbegvN8OFraOZsf2iioV1D6AU061ZcQ5PzTqVZ4BmagtnLaD4r/pGZ87gkdWLS9fX9aEZD3EST/+ZyrfYfNJ+r1wN/Cbykqm5op3y/hqYgfBNNXlzX8/pfo13YE7iFZrHO3hHKtNeRv0lTJFk7QxHjqTRToyc/nkOzPtFmmql7b6MpqkzlB22cm2m+HD1u0pocEzFtoLn+Prntv5FmCreGTO49NWrnl2ZV3E9V1S+nubvCVVX1yCn6rQYuqKrT2u0vACdU1YV9DFfzqP3j6Gaa4cHXdB2PJHOyJEmS5s9Qj8CoqluBa9phU7TDiQ5omz9Oc2tO2ukCj6W51ZB2IklekOSB7dy4d9CMnPhOt1FJmoo5WZIkSTtiqAoYSc6gGeL/i0k2JTmWZlXbY5N8HbicZgFGgHNobm95Bc2t0v5XVd0w1Xk10A6nGVK2mWaY3BE1bMOKpJ2UOVmSJEnzaeimkEiSJEmSpOEzVCMwJEmSJEnScFrcdQDzZc8996y999676zAkadYuuuii66tqSddxLARzsqSdzbDmZPOxpJ3RdDl5aAoYe++9Nxs2bOg6DEmatSTf7TqGhWJOlrSzGdacbD6WtDOaLic7hUSSRliStUm2JLlshj6HJLkkyeVJzu1nfJIkSdIECxiSNNpOA1ZO15hkD+B9wAur6vHAb/cpLkmSJOleLGBI0girqvOAG2fo8jLgY1X1vbb/lr4EJkmSJE1iAUOSNJPHAg9N8qUkFyU5uuuAJEmSNJqGZhFPSdKCWAz8KvAsYDfgq0kuqKpvTe6YZBWwCmDFihV9DVKSJEnDzxEYkqSZbAI+W1U/rKrrgfOAA6bqWFVrqmqsqsaWLBm6OxFKkiSpYxYwJEkz+QTw9CSLkzwQOAi4suOYJEmSNIIsYEjSCEtyBvBV4BeTbEpybJLjkhwHUFVXAp8FLgW+BpxaVdPeclWSNLMkK5NclWRjkhOmaD88yaXt7as3JHnabI+VpGHnGhiSNMKq6shZ9Hk78PY+hCNJQy3JIuAU4Nk0U/QuTLKuqq7o6fYFYF1VVZL9gX8DHjfLYyVpqDkCQ5IkSeqPA4GNVXV1Vd0FnAkc3tuhqm6vqmo3HwTUbI+VpGFnAUOSJEnqj6XAtT3bm9p995LkxUm+CXwa+B9zObY9flU7/WTD+Pj4vAQuSYPAAoYkSZLUH5liX91nR9XZVfU44EXASXM5tj3eu0JJGkoWMCRJkqT+2AQs79leBmyernNVnQc8Jsmecz1WkoaRi3hKC+i5J3266xDUJ+f8+fO6DkHSNpiTR8OA5+MLgX2T7AN8HzgCeFlvhyT/D/DtdhHPJwK7AjcAN2/rWGlnYk4eDfOdky1gSJIkSX1QVVuTHA+cAywC1lbV5T23rl4N/BZwdJKfAD8Cfqdd1HPKYzt5I5LUEQsYkiRJUp9U1Xpg/aR9q3uevw1422yPlaRR0vc1MJIsT/LFJFcmuTzJH0/R55AktyS5pH2c2O84JUmSJEnS4OhiBMZW4E+r6uIkuwMXJfl8VV0xqd+Xq+r5HcQnSZIkSZIGTN9HYFTVdVV1cfv8NuBKprmHtSRJkiRJEnR8G9UkewNPAP5jiuanJPl6ks8kefw0x69KsiHJhvHx8QWMVJIkSZIkdamzAkaSBwNnAa+tqlsnNV8MPLqqDgDeC3x8qnNU1ZqqGquqsSVLlixswJIkSZIkqTOdFDCS7EJTvPiXqvrY5PaqurWqbm+frwd2SbJnn8OUJEmSJEkDoou7kAT4J+DKqnrnNH32avuR5ECaOG/oX5SSJEmSJGmQdHEXkoOBlwPfSHJJu+8NwAq45z7YLwFelWQr8CPgiKqqDmKVJEmSJEkDoO8FjKr6CpBt9DkZOLk/EUmSJEmSpEHX6V1IJEmSJEmSZsMChiRJkiRJGngWMCRJkiRJ0sCzgCFJkiRJkgaeBQxJkiRJkjTwLGBIkiRJkqSBZwFDkiRJkiQNPAsYkiRJkiRp4FnAkCRJkiRJA88ChiRJkiRJGngWMCRJkiRJ0sCzgCFJkiRJkgaeBQxJkiRJkjTwLGBI0ghLsjbJliSXbaPfk5LcneQl/YpNkiRJ6mUBQ5JG22nAypk6JFkEvA04px8BSZIkSVOxgCFJI6yqzgNu3Ea3PwLOArYsfESSJEnS1CxgSJKmlWQp8GJg9Sz6rkqyIcmG8fHxhQ9OkiRJI8UChiRpJu8GXl9Vd2+rY1WtqaqxqhpbsmRJH0KTJEnSKFncdQCSpIE2BpyZBGBP4LAkW6vq492GJUmSpFFjAUOSNK2q2mfieZLTgE9ZvJAkSVIXLGBI0ghLcgZwCLBnkk3Am4BdAKpqm+teSJIkSf1iAUOSRlhVHTmHvscsYCiSJEnSjFzEU5IkSZIkDTwLGJIkSZIkaeBZwJAkSZIkSQPPAoYkSZIkSRp4FjAkSZIkSdLAs4AhSZIkSZIGngUMSZIkSZI08CxgSJIkSZKkgWcBQ5IkSZIkDTwLGJIkSVKfJFmZ5KokG5OcMEX7UUkubR/nJzmgp+07Sb6R5JIkG/obuSR1b3HXAUiSJEmjIMki4BTg2cAm4MIk66rqip5u1wDPqKqbkhwKrAEO6ml/ZlVd37egJWmAOAJDkiRJ6o8DgY1VdXVV3QWcCRze26Gqzq+qm9rNC4BlfY5RkgaWBQxJkiSpP5YC1/Zsb2r3TedY4DM92wV8LslFSVZNd1CSVUk2JNkwPj6+QwFL0iBxCokkSZLUH5liX03ZMXkmTQHjaT27D66qzUkeAXw+yTer6rz7nLBqDc3UE8bGxqY8vyTtjByBIUmSJPXHJmB5z/YyYPPkTkn2B04FDq+qGyb2V9Xm9ucW4GyaKSmSNDIsYEiSJEn9cSGwb5J9kuwKHAGs6+2QZAXwMeDlVfWtnv0PSrL7xHPgOcBlfYtckgaAU0gkSZKkPqiqrUmOB84BFgFrq+ryJMe17auBE4GHA+9LArC1qsaAnwfObvctBj5cVZ/t4G1IUmcsYEiSJEl9UlXrgfWT9q3uef5K4JVTHHc1cMCCByhJA8wpJJIkSZIkaeBZwJAkSZIkSQPPAoYkSZIkSRp4FjAkSZIkSdLAs4AhSZIkSZIGngUMSZIkSZI08CxgSJIkSZKkgWcBQ5IkSZIkDby+FzCSLE/yxSRXJrk8yR9P0SdJ/j7JxiSXJnliv+OUJEmSJEmDY3EHr7kV+NOqujjJ7sBFST5fVVf09DkU2Ld9HAS8v/0pSZIkSZJGUN9HYFTVdVV1cfv8NuBKYOmkbocDp1fjAmCPJI/sc6iSNPSSrE2yJcll07Qf1Y6EuzTJ+UkO6HeMkiRJEnS8BkaSvYEnAP8xqWkpcG3P9ibuW+QgyaokG5JsGB8fX6gwJWmYnQasnKH9GuAZVbU/cBKwph9BSZIkSZN1VsBI8mDgLOC1VXXr5OYpDqn77KhaU1VjVTW2ZMmShQhTkoZaVZ0H3DhD+/lVdVO7eQGwrC+BSZIkSZN0UsBIsgtN8eJfqupjU3TZBCzv2V4GbO5HbJKkaR0LfKbrICRJkjSaurgLSYB/Aq6sqndO020dcHR7N5InA7dU1XV9C1KSdC9JnklTwHj9DH2c1idJkqQF08VdSA4GXg58I8kl7b43ACsAqmo1sB44DNgI3AG8ooM4JUlAkv2BU4FDq+qG6fpV1RraNTLGxsbuM+1PkiRJ2hF9L2BU1VeYeo2L3j4FvLo/EUmSppNkBfAx4OVV9a2u45EkSdLo6mIEhiRpQCQ5AzgE2DPJJuBNwC5wz4i4E4GHA+9rZgCytarGuolWkiRJo8wChiSNsKo6chvtrwRe2adwJEmSpGl1dhtVSZIkSZKk2bKAIUmSJEmSBp4FDEmSJEmSNPAsYEiSJEmSpIFnAUOSJEmSJA08CxiSJEmSJGngWcCQJEmSJEkDzwKGJEmSJEkaeBYwJEmSJEnSwLOAIUmSJEmSBp4FDEmSJEmSNPAsYEiSJEmSpIFnAUOSJEmSJA08CxiSJEmSJGngWcCQJEmSJEkDzwKGJEmSJEkaeBYwJEmSJEnSwLOAIUmSJEmSBp4FDEmSJEmSNPAsYEiSJEmSpIFnAUOSJEmSJA08CxiSJElSnyRZmeSqJBuTnDBF+1FJLm0f5yc5YLbHStKws4AhSZIk9UGSRcApwKHAfsCRSfab1O0a4BlVtT9wErBmDsdK0lCzgCFJkiT1x4HAxqq6uqruAs4EDu/tUFXnV9VN7eYFwLLZHitJw84ChiRJktQfS4Fre7Y3tfumcyzwmbkem2RVkg1JNoyPj+9AuJI0WCxgSJIkSf2RKfbVlB2TZ9IUMF4/12Orak1VjVXV2JIlS7YrUEkaRIu7DkCSJEkaEZuA5T3by4DNkzsl2R84FTi0qm6Yy7GSNMwcgSFJkiT1x4XAvkn2SbIrcASwrrdDkhXAx4CXV9W35nKsJA07R2BIkiRJfVBVW5McD5wDLALWVtXlSY5r21cDJwIPB96XBGBrOx1kymM7eSOS1BELGJI0wpKsBZ4PbKmqX56iPcB7gMOAO4Bjquri/kYpScOjqtYD6yftW93z/JXAK2d7rCSNEqeQSNJoOw1YOUP7ocC+7WMV8P4+xCRJkiTdhyMwJGmEVdV5SfaeocvhwOlVVcAFSfZI8siquq4vAUrSgEoyBjwdeBTwI+Ay4N+r6sZOA5OkIeYIDEnSTJYC1/Zsb2r33UeSVUk2JNkwPj7el+Akqd+SHJPkYuDPgN2Aq4AtwNOAzyf5YLsQpyRpnm3XCIwkDwLurKq75zkeSdIcLXBOzhT7aqqOVbUGWAMwNjY2ZR9JGgIPAg6uqh9N1ZjkV2im3X2vr1FJ0giYVQEjyf1obtV0FPAk4MfA/ZOM0ywktKaq/mvBopQk3aPPOXkTsLxnexmweZ7OLUk7nao6ZRvtl/QrFkkaNbOdQvJF4DE0Q+X2qqrlVfUImnl/FwB/k+R3FyhGSdK99TMnrwOOTuPJwC2ufyFJkORvkzwkyS5JvpDkeq+HJWlhzXYKyW9U1U8m72wXKToLOCvJLvMamSRpOvOWk5OcARwC7JlkE/AmYJf2fKtpRnQcBmykuY3qK+bjDUjSEHhOVf1/SV5MM1rtt2kKzP/cbViSNLy2WcBI8mzgpUlOrqqvJ1nVznO+l6kupiVJ82u+c3JVHbmN9gJevX3RStJQmygUHwacUVU3JlMtGyRJmi+zGYHxhzTfuL0xycOBX1nYkCRJMzAnS9Jg+GSSb9LcQvUPkywB7uw4JkkaarNZA2O8qm6uqtcBz6FZME6S1A1zsiQNhjcBTwHG2lFvdwAv7DYkSRpusylgfHriSVWdAJy+cOFIkrbBnCxJg+GrVXXTxC2sq+qHwGc6jkmShto2p5BU1ScmnifZr6re29ue5JCq+tICxCZJmsScLEndSrIXsBTYLckTgImFLx4CPLCzwCRpBMz2LiQT/i3J6cDbgQcAfwuM0QyfkyT1lzlZkvrvucAxwDLgnT37bwPe0EVAkjQq5lrAOAh4G3A+sDvwL8DB8x2UJGlWzMmS1GdV9UHgg0l+q6rO6joeSRolcy1g/IRmpeXdaL7tu6aqfjrvUUmSZsOcLEkdqaqzkjwPeDxNDp7Y/9buopKk4TabRTx7XUhzsfwk4GnAkUk+Ou9RSZJmw5wsSR1Jshr4HeCPaNbB+G3g0Z0GJUlDbq4FjGOr6sSq+klV/aCqDgc+sc2jeiRZm2RLksumaT8kyS1JLmkfJ84xRkkaFTuckyVJ2+2pVXU0cFNVvYVm/aHlHcckSUNtTlNIqmrDFPs+NMfXPA04mZlv/fflqnr+HM8rSSNlnnKyJGn7/Kj9eUeSRwE3APt0GI8kDb05FTCSPAD4Q5qhygV8BXh/Vd0523NU1XlJ9p7L60qS7ms+crIkabt9KskeNHeCupgmD5/abUiSNNzmuojn6TS3iHpvu30k8CGaOX/z6SlJvg5sBl5XVZdP1SnJKmAVwIoVK+Y5BEkaeP3KyZKkSarqpPbpWUk+BTygqm7pMiZJGnZzLWD8YlUd0LP9xbbQMJ8uBh5dVbcnOQz4OLDvVB2rag2wBmBsbKzmOQ5JGnT9yMmSpGkkeSqwN+01dRKqaqZp0pKkHTDXRTz/M8mTJzaSHAT8n/kMqKpurarb2+frgV2S7DmfryFJQ2LBc7IkaWpJPgS8g2Ya35Pax1inQUnSkJvrCIyDgKOTfK/dXgFcmeQbQFXV/jsaUJK9gP+uqkpyIE2R5YYdPa8kDaEFz8mSpGmNAftVlaOAJalP5lrAWLmjL5jkDOAQYM8km4A3AbsAVNVq4CXAq5JspVnd+Qg/GCRpSjuckyVJ2+0yYC/guq4DkaRRMasCRpJU47sz9ZnNuarqyG20n0xzm1VJ0hTmMydLkrbbnsAVSb4G/HhiZ1W9sLuQJGm4zXYExheTnAV8oqomhiqTZFeaeX+/B3wROG3eI5QkTWZOlqTuvbnrACRp1My2gLES+B/AGUn2AW4GHgAsAj4HvKuqLlmYECVJk5iTJakjPaPgzt1Wn37GJUmjYFYFjKq6E3gf8L4ku9AMmftRVd28kMFJku7LnCxJnXIUnCR1ZK6LeFJVP8HFiiRpIJiTJanvHAUnSR2ZcwFDkiRJGlWOgpOk7ljAkCRJkraDo+Akqb/uN5fOafxukhPb7RVJDlyY0CRJMzEnS5IkaZTMqYBBM1zuKcCR7fZtwCnzGpEkabbMyZIkSRoZcy1gHFRVrwbuBKiqm4Bd5z0qSdJsmJMlqUNJHp3kN9rnuyXZveuYJGmYzbWA8ZMki4ACSLIE+Om8RyVJmg1zsiR1JMnvAx8F/qHdtQz4eHcRSdLwm2sB4++Bs4FHJPlL4CvAX897VJKk2TAnS1J3Xg0cDNwKUFX/BTyi04gkacjN6S4kVfUvSS4CngUEeFFVXbkgkUmSZjQfOTnJSuA9wCLg1Kr6m0ntPwf8M7CC5jPjHVX1gfmIX5J2cj+uqruSAJBkMe2IOEnSwpjrXUg+CPygqk6pqpOBHyRZuzChSZJmsqM5uZ1+cgpwKLAfcGSS/SZ1ezVwRVUdABwC/F0S19mQJDg3yRuA3ZI8G/gI8MmOY5KkoTbXKST7V9XNExvtgnFPmN+QJEmztKM5+UBgY1VdXVV3AWcCh0/qU8Duab5ifDBwI7B1x8KWpKFwAjAOfAP4A2A98MZOI5KkIZR2j5UAABdGSURBVDenKSTA/ZI8tL1IJsnDtuMckqT5saM5eSlwbc/2JuCgSX1OBtYBm4Hdgd+pKhcKlSTYDVhbVf8I94xq2w24o9OoJGmIzXUExt8B5yc5KclbgfOBv53/sCRJs7CjOTlT7Js8f/u5wCXAo4BfAU5O8pApT5asSrIhyYbx8fE5hCFJO6Uv0BQsJuwG/Pu2DkqyMslVSTYmOWGK9scl+WqSHyd53aS27yT5RpJLkmzY4XcgSTuZuS7ieXqbLH+d5sL3N6vqigWJTJI0o3nIyZuA5T3by2hGWvR6BfA3VVXAxiTXAI8DvjZFPGuANQBjY2MuZCdp2D2gqm6f2Kiq25M8cKYDetYeejZNDr4wybpJuftG4DXAi6Y5zTOr6vodC12Sdk5znv7RJliLFpI0AHYwJ18I7JtkH+D7wBHAyyb1+R7NXU6+nOTngV8Ert7O15OkYfLDJE+sqosBkvwq8KNtHHPP2kPtMRNrD92Tx6tqC7AlyfMWJmxJ2nnNqYCR5P7AbwF79x5bVW+d37AkSduyozm5qrYmOR44h+Y2qmur6vIkx7Xtq4GTgNOSfINmlMfr/eZPkgB4LfCRJBMj1x4J/M42jpnN2kMzKeBzSQr4h3bk230kWQWsAlixYsUcTi9Jg22uIzA+AdwCXAT8eP7DkSTNwQ7n5KpaT7Nyfu++1T3PNwPP2YEYJWkoVdWFSR5HMzItwDer6ifbOGw2aw/N5OCq2pzkEcDnk3yzqs6bIjan9EkaSnMtYCyrqpULEokkaa7MyZLUrSfxs1FwT0hCVZ0+Q//ZrD00rbaoTFVtSXI2zZSU+xQwJGlYzfUuJOcn+X8XJBJJ0lyZkyWpI0k+BLwDeBpNIeNJwNg2Drtn7aEku9KsPbRulq/3oCS7TzynGR132XaGL0k7pbmOwHgacEy7Cv2PaYbBVVXtP++RSZK2xZwsSd0ZA/Zr79I0K7NZeyjJXsAG4CHAT5O8FtgP2BM4Owk01/AfrqrPzus7kqQBN9cCxqELEoUkaXuYkyWpO5cBewHXzeWgWaw99AOaqSWT3QocMPcwJWl4zKmAUVXfTfJQYF/gAT1N353XqCRJ22ROlqRO7QlckeRr9CykXFUv7C4kSRpuc72N6iuBP6apCl8CPBn4KvDr8x+aJGkm5mRJ6tSbuw5AkkbNXKeQ/DHNAkUXVNUz21tHvWX+w5IkzYI5WZI6UlXndh2DJI2aud6F5M6quhMgyf2r6ps0976WJPWfOVmSOpLkyUkuTHJ7kruS3J3k1q7jkqRhNtcRGJuS7AF8HPh8kpuYw72rJUnzypwsSd05meY2qB+huSPJ0TRrEkmSFshcF/F8cfv0zUm+CPwc8Jl5j0qStE3mZEnqVlVtTLKoqu4GPpDk/K5jkqRhNqcpJEneNvG8qs6tqnXAX8x7VJKkbTInS1Kn7kiyK3BJkr9N8ifAg7oOSpKG2VzXwHj2FPsOnY9AJElzZk6WpO68nOZa+njgh8By4Dc7jUiShtysChhJXpXkG8DjklzaPr6R5DvANxY0QknSvZiTJWkgvKiq7qyqW6vqLVX1P4Hndx2UJA2z2a6B8WGaedV/DZzQs/+2qrpx3qOSJM3EnCxJ3fs94D2T9h0zxT5J0jyZVQGjqm4BbknyMeDGqrotyRuBJyY5qar+c0GjlCTdw5wsSd1JciTwMmCfJOt6mh4C3NBNVJI0GuZ6G9U/r6qPJHka8FzgHcBq4KB5j0yStC3mZEnqv/OB64A9gb/r2X8bcGknEUnSiJjrIp53tz+fB7y/qj4B7Dq/IUmSZsmcLEl9VlXfraovAb8BfLmqzqUpaCwD0mVskjTs5lrA+H6SfwBeCqxPcv/tOIckaX6YkyWpO+cBD0iyFPgC8ArgtE4jkqQhN9cL3ZcC5wArq+pm4GHA/5r3qCRJs2FOlqTupKruoLl16nur6sXAfh3HJElDbU5rYLRJ+mM929fRDJmTJPWZOVmSOpUkTwGOAo5t9811fTlJ0hzMagRGkq+0P29Lcmv7c+Jx68KGKEnqZU6WpIHwWuDPgLOr6vIkvwB8seOYJGmozfY2qk9rf+6e5BHt8y0LGZgkaWrmZEnqXrt457k921cDr+kuIkkafrMe5pbkzcCraUZtJMndNPP93rpAsUmSpmFOlqRuJHl3Vb02ySeBmtxeVS/sICxJGgmzKmAk+RPgYODAqrqm3fcLwPuT/ElVvWsBY5Qk9TAnS1KnPtT+fEenUUjSCJrtCIyjgWdX1fUTO6rq6iS/C3wO8GJZkvrHnCxJHamqi9qf5yZZ0j4f7zYqSRoNs72N6i69F8oT2mS9y/yGJEnaBnOyJHUkjTcnuR74JvCtJONJTuw6NkkadrMtYNy1nW2SpPlnTpak7ryWZhrfk6rq4VX1UOAg4OB2ip8kaYHMdgrJAdPcmi/AA+YxHknStpmTJak7TuOTpI7M9jaqi+brBZOsBZ4PbKmqX56iPcB7gMOAO4Bjquri+Xp9SdrZzWdOliTN2bTT+JI4jU+SFtBsp5DMp9OAlTO0Hwrs2z5WAe/vQ0ySNJKSrExyVZKNSU6Yps8hSS5JcnmSc/sdoyQNGKfxSVJHZjuFZN5U1XlJ9p6hy+HA6VVVwAVJ9kjyyKq6ri8BStKISLIIOAV4NrAJuDDJuqq6oqfPHsD7gJVV9b0kj+gmWkkaGE7jk6SO9L2AMQtLgWt7tje1++5TwEiyimaUBitWrOhLcJI0RA4ENlbV1QBJzqQpIl/R0+dlwMeq6nsAVbWl71FK0gBxGp8kdaeLKSTbkin21VQdq2pNVY1V1diSJUsWOCxJGjrTFYx7PRZ4aJIvJbkoydHTnSzJqiQbkmwYHx9fgHAlSZI0ygaxgLEJWN6zvQzY3FEskjTMZlMwXgz8KvA84LnAnyd57FQns6gsSZKkhTSIBYx1wNFpPBm4xfUvJGlBzKZgvAn4bFX9sF11/zzggD7FJ0mSJN2j72tgJDkDOATYM8km4E3ALgBVtRpYT3ML1Y00t1F9Rb9jlKQRcSGwb5J9gO8DR9CsedHrE8DJSRYDuwIHAe/qa5SSJEkS3dyF5MhttBfw6j6FI0kjq6q2JjkeOAdYBKytqsuTHNe2r66qK5N8FrgU+ClwalVd1l3UkiRJGlWDeBcSSVKfVNV6mpFvvftWT9p+O/D2fsYlSZIkTTaIa2BIkiRJkiTdiwUMSZIkSZI08CxgSJIkSZKkgWcBQ5IkSZIkDTwLGJIkSZIkaeBZwJAkSZIkSQPPAoYkSZLUJ0lWJrkqycYkJ0zR/rgkX03y4ySvm8uxkjTsLGBIkiRJfZBkEXAKcCiwH3Bkkv0mdbsReA3wju04VpKGmgUMSZIkqT8OBDZW1dVVdRdwJnB4b4eq2lJVFwI/meuxkjTsLGBIkiRJ/bEUuLZne1O7b16PTbIqyYYkG8bHx7crUEkaRBYwJEmSpP7IFPtqvo+tqjVVNVZVY0uWLJl1cJI06CxgSJIkSf2xCVjes70M2NyHYyVpKFjAkCRJkvrjQmDfJPsk2RU4AljXh2MlaSgs7joASZIkaRRU1dYkxwPnAIuAtVV1eZLj2vbVSfYCNgAPAX6a5LXAflV161THdvNOJKkbFjAkSZKkPqmq9cD6SftW9zz/Ac30kFkdK0mjxCkkkiRJkiRp4FnAkCRJkiRJA88ChiRJkiRJGngWMCRJkiRJ0sCzgCFJkiRJkgaeBQxJkiRJkjTwLGBIkiRJkqSBZwFDkiRJkiQNPAsYkiRJkiRp4FnAkCRJkiRJA88ChiRJkiRJGngWMCRJkiRJ0sCzgCFJkiRJkgaeBQxJkiRJkjTwLGBI0ghLsjLJVUk2Jjlhhn5PSnJ3kpf0Mz5JkiRpggUMSRpRSRYBpwCHAvsBRybZb5p+bwPO6W+EkiRJ0s9YwJCk0XUgsLGqrq6qu4AzgcOn6PdHwFnAln4GJ0mSJPWygCFJo2spcG3P9qZ23z2SLAVeDKze1smSrEqyIcmG8fHxeQ1UkiRJsoAhSaMrU+yrSdvvBl5fVXdv62RVtaaqxqpqbMmSJfMSoCRJkjRhcdcBSJI6swlY3rO9DNg8qc8YcGYSgD2Bw5JsraqP9ydESZIkqWEBQ5JG14XAvkn2Ab4PHAG8rLdDVe0z8TzJacCnLF5IkiSpCxYwJGlEVdXWJMfT3F1kEbC2qi5Pclzbvs11LyRJkqR+sYAhSSOsqtYD6yftm7JwUVXH9CMmSZIkaSou4ilJkiRJkgaeBQxJkiRJkjTwLGBIkiRJkqSBZwFDkiRJkiQNPAsYkiRJkiRp4FnAkCRJkiRJA88ChiRJkiRJGngWMCRJkiRJ0sCzgCFJkiRJkgZeJwWMJCuTXJVkY5ITpmg/JMktSS5pHyd2EackSZIkSRoMi/v9gkkWAacAzwY2ARcmWVdVV0zq+uWqev5Cx/PJxzxmoV9CA+AF3/521yFIkiRJknZAFyMwDgQ2VtXVVXUXcCZweAdxSJIkSZKknUQXBYylwLU925vafZM9JcnXk3wmyeOnOlGSVUk2JNkwPj6+ELFKkiRJkqQB0EUBI1Psq0nbFwOPrqoDgPcCH5/qRFW1pqrGqmpsyZIl8xymJEmSJEkaFF0UMDYBy3u2lwGbeztU1a1VdXv7fD2wS5I9+xeiJEmSJEkaJF0UMC4E9k2yT5JdgSOAdb0dkuyVJO3zA2nivKHvkUqSJEmSpIHQ97uQVNXWJMcD5wCLgLVVdXmS49r21cBLgFcl2Qr8CDiiqiZPM5EkSZIkSSOi7wUMuGdayPpJ+1b3PD8ZOLnfcUmSJEkLKclK4D00X+SdWlV/M6k9bfthwB3AMVV1cdv2HeA24G5ga1WN9TF0SepcJwUMSZIkadQkWQScAjybZl24C5Osq6orerodCuzbPg4C3t/+nPDMqrq+TyFL0kDpYg0MSZIkaRQdCGysqqur6i7gTODwSX0OB06vxgXAHkke2e9AJWkQWcCQJEmS+mMpcG3P9qZ232z7FPC5JBclWTXdiyRZlWRDkg3j4+PzELYkDQYLGJIkSVJ/ZIp9kxeqn6nPwVX1RJppJq9O8mtTvUhVramqsaoaW7JkyfZHK0kDxgKGJEmS1B+bgOU928uAzbPtU1UTP7cAZ9NMSZGkkWEBQ5IkSeqPC4F9k+yTZFfgCGDdpD7rgKPTeDJwS1Vdl+RBSXYHSPIg4DnAZf0MXpK65l1IJEmSpD6oqq1JjgfOobmN6tqqujzJcW37amA9zS1UN9LcRvUV7eE/D5zd3GWVxcCHq+qzfX4LktQpCxiSJElSn1TVepoiRe++1T3PC3j1FMddDRyw4AFK0gBzCokkSZIkSRp4FjAkSZIkSdLAs4AhSSMsycokVyXZmOSEKdqPSnJp+zg/icOXJUmS1AkLGJI0opIsAk4BDgX2A45Mst+kbtcAz6iq/YGTgDX9jVKSJElqWMCQpNF1ILCxqq6uqruAM4HDeztU1flVdVO7eQGwrM8xSpIkSYAFDEkaZUuBa3u2N7X7pnMs8JnpGpOsSrIhyYbx8fF5ClGSJElqWMCQpNGVKfbVlB2TZ9IUMF4/3cmqak1VjVXV2JIlS+YpREmSJKmxuOsAJEmd2QQs79leBmye3CnJ/sCpwKFVdUOfYpMkSZLuxQKGJI2uC4F9k+wDfB84AnhZb4ckK4CPAS+vqm8tZDCffMxjFvL0GiAv+Pa3uw5BkiTthCxgSNKIqqqtSY4HzgEWAWur6vIkx7Xtq4ETgYcD70sCsLWqxrqKWZIkSaPLAoYkjbCqWg+sn7Rvdc/zVwKv7HdckiRJ0mQu4ilJkiRJkgaeBQxJkiRJkjTwLGBIkiRJkqSBZwFDkiRJkiQNPAsYkiRJkiRp4FnAkCRJkiRJA88ChiRJkiRJGngWMCRJkiRJ0sCzgCFJkiRJkgbe4q4DkCRJkjRYPvmYx3QdgvrgBd/+dtchSHPiCAxJkiRJkjTwLGBIkiRJkqSBZwFDkiRJkiQNPAsYkiRJkiRp4FnAkCRJkiRJA88ChiRJkiRJGngWMCRJkiRJ0sCzgCFJkiRJkgaeBQxJkiRJkjTwLGBIkiRJkqSBZwFDkiRJkiQNPAsYkiRJkiRp4FnAkCRJkiRJA88ChiRJkiRJGngWMCRJkiRJ0sCzgCFJkiRJkgaeBQxJkiRJkjTwLGBIkiRJkqSBZwFDkiRJkiQNvE4KGElWJrkqycYkJ0zRniR/37ZfmuSJXcQpScPOfCxJ/bUjeXdbx0rSsOt7ASPJIuAU4FBgP+DIJPtN6nYosG/7WAW8v69BStIIMB9LUn/tSN6d5bGSNNS6GIFxILCxqq6uqruAM4HDJ/U5HDi9GhcAeyR5ZL8DlaQhZz6WpP7akbw7m2Mlaagt7uA1lwLX9mxvAg6aRZ+lwHW9nZKsoqlMA9ye5Kr5DXVo7Qlc33UQfZV0HcGoGbnfsZy4XYc9ep7DmKt5y8dgTt5OI/dvBTAn99fI/Y5tZz6G/uTkHcm7szkWMB/vgJH792I+7ruR+x2b75zcRQFjqn8ltR19qKo1wJr5CGqUJNlQVWNdx6Hh5e/YTmPe8jGYk7eH/1a00PwdGzg7knfNxwvMfy9aaP6O7bguChibgOU928uAzdvRR5K0Y8zHktRfO5J3d53FsZI01LpYA+NCYN8k+yTZFTgCWDepzzrg6HYV5icDt1TVfYYrS5J2iPlYkvprR/LubI6VpKHW9xEYVbU1yfHAOcAiYG1VXZ7kuLZ9NbAeOAzYCNwBvKLfcQ45hxT+3/buH0SOMg7j+PcpFJMUooWHYGMngsSgaAoDERGxCGhlaWMQGxELDSiYwitEsFAhTQiWiqKI5x+CSkgETzlNAtbaJI2CIETklPCz2IkZzrvN7d7N7uzt9wML78y+M++7MPuw/PYdRl3zGpsB5nEv+F1R17zGemQrubvRsVP4GDuZ3xd1zWtsi1K17q1zkiRJkiRJvTGNW0gkSZIkSZJGYgFDkiRJkiT1ngWMGZPkcpJzrdeRZv+pJP97JE+zf6W1fW+SU632m633nkmynOSD9c6lnS/JpTGPO5ikkhxq7VtKcrBpH09yZ9O+OclXSU4meW1bJi5NiZmsrpjH0ujMZHXFTO6PaTxGVVvzV1XdPeIxtyR5tKo+b++sqhVgpbV9DDi2DXPUfLoAvAR8svaNqnqq1f4deGiC85K6ZCarj8xjzSszWX1kJm8jV2DMh9eBl9fubCqCS037aJITTSX65yTPtvo9n+Sn5vXcBOetHkhyKMl3Sc4m+TLJwgZdzwN/JHl4nXP8989HkktJFpOcb/7JWBhxHGnWmckai3ksdcJM1ljM5OmwgDF7dq1ZGvfEJo75FlhN8uA1+t0BPALcB7yS5Lok9zB4fNf9wH7gcJJ9W/kAmjnfAPurah/wLvDCkL6vss6PgDX2AMtVtRc4DRweYxypL8xkTZJ5LA1nJmuSzOQp8BaS2TPO0ji4+qV5cUifT6tqlUGI/wosAA8AH1XVnwBJPgQOAGfHmINm023Ae0luBa4HftmoY1WdSUKSA0PO9zew1LR/AK5Uozc9jtQjZrImyTyWhjOTNUlm8hS4AmNOVNXXwA0MqsMbWW21LzMocKXLeWkmvAW8XVV3AU8zuI6GWWRwn99G/qmqatpXrrNxxpFmlpmsMZnHUgfMZI3JTJ4CCxjzZZHRlxydBh5LsjvJHuBx4My2z0x9diNwsWk/ea3OVXUSuAnY2+U40g5gJmtU5rHUHTNZozKTp8BbSGbPriTnWttfVNWRzRxYVZ8l+W2UwarqxyTvAN83u45Xlcvidq7dSS60tt8AjgLvJ7kILAO3b+I8i8DHI449zjjStJnJ6op5LI3OTFZXzOSeyNVVKpIkSZIkSf3kLSSSJEmSJKn3LGBIkiRJkqTes4AhSZIkSZJ6zwKGJEmSJEnqPQsYkiRJkiSp9yxgSJIkSZKk3rOAIUmSJEmSeu9fa0ZNYMgi3cMAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1080x360 with 3 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axs = plt.subplots(1, 3, figsize=(15, 5))\n",
+    "\n",
+    "axs[0].bar([0, 1], [en_ks, ln_ks], color=[\"firebrick\", \"steelblue\"])\n",
+    "axs[0].set_title(\"Kolmogorov-Smirnov\")\n",
+    "axs[0].set_ylabel(\"Distance (px$^2$)\")\n",
+    "axs[1].bar([0, 1], [en_euc, ln_euc], color=[\"firebrick\", \"steelblue\"])\n",
+    "axs[1].set_title(\"Euclidean\")\n",
+    "axs[1].set_ylabel(\"Distance (px$^2$)\")\n",
+    "axs[2].bar([0, 1], [en_kl, ln_kl], color=[\"firebrick\", \"steelblue\"])\n",
+    "axs[2].set_title(\"Kullback-Leibler\")\n",
+    "axs[2].set_ylabel(\"Distance (nats)\")\n",
+    "\n",
+    "for ax in axs:\n",
+    "    ax.set_xticks([0, 1])\n",
+    "    ax.set_xticklabels([\"El Niño\", \"La Niña\"])\n",
+    "\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All three metrics show that Kati Thanda is heavily affected by La Niña, but not very affected by El Niño."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "\n",
+    "## Additional information\n",
+    "\n",
+    "**License:** The code in this notebook is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). \n",
+    "Digital Earth Australia data is licensed under the [Creative Commons by Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) license.\n",
+    "\n",
+    "**Contact:** If you need assistance, please post a question on the [Open Data Cube Slack channel](http://slack.opendatacube.org/) or on the [GIS Stack Exchange](https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions [here](https://gis.stackexchange.com/questions/tagged/open-data-cube)).\n",
+    "If you would like to report an issue with this notebook, you can file one on [Github](https://github.com/GeoscienceAustralia/dea-notebooks).\n",
+    "\n",
+    "**Last modified:** September 2020"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tags\n",
+    "Browse all available tags on the DEA User Guide's [Tags Index](https://docs.dea.ga.gov.au/genindex.html)."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "**Tags**: :index:`NCI compatible`, :index:`sandbox compatible`, :index:`DEA Waterbodies`, :index:`time series`, :index:`water`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/Scientific_workflows/DEAWaterbodies/DEAWaterbodiesToolkit/ENSOInfluence.ipynb
+++ b/Scientific_workflows/DEAWaterbodies/DEAWaterbodiesToolkit/ENSOInfluence.ipynb
@@ -198,7 +198,7 @@
     "### Interpolate data to daily values\n",
     "\n",
     "DEA Waterbodies data is stored with one row per satellite observation. \n",
-    "To make our data easier to analyse by time, we can use interpolation the data to estimate the percentage coverage of water for every individual day in our time series."
+    "To make our data easier to analyse by time, we can interpolate the data to estimate the percentage coverage of water for every individual day in our time series."
    ]
   },
   {
@@ -502,7 +502,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that Kati Thanda is considerably wetter during La Niña than during El Niño or neutral. We can also see that Kati Thanda during El Niño is nearly the same as during the neutral phase of ENSO."
+    "The steeper the CDF at a given surface area, the more of the time the waterbody spends at that surface area. For El Niño and neutral, the CDF starts very steep and flattens, indicating that the lake is mostly dry. The curve is much shallower for La Niña, indicating that there is a wider range of surface areas occupied by the lake. We can therefore conclude that Kati Thanda is considerably wetter during La Niña than during El Niño or neutral. We can also see that Kati Thanda during El Niño is nearly the same as during the neutral phase of ENSO, as the CDFs are almost exactly the same."
    ]
   },
   {
@@ -559,7 +559,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here it is much more obvious that Kati Thanda is wetter during La Niña."
+    "PDFs can be clearer than CDFs. The higher the probability density at a given surface area, the more often the waterbody is at that surface area. Mathematically, the probability that the waterbody has a surface area between $x_1$ and $x_2$ is the total area under the PDF curve between these values:\n",
+    "\n",
+    "$$\n",
+    "    p(x_1 \\leq \\mathrm{surface\\ area} \\leq x_2) = \\int_{x_1}^{x_2} \\mathrm{PDF}(x)\\ \\mathrm{d}x.\n",
+    "$$\n",
+    "\n",
+    "The La Niña PDF is much higher than the El Niño or neutral PDFs for large surface areas, showing that Kati Thanda is wetter during La Niña. The PDF for La Niña is fairly flat, meaning that there is a roughly even chance of Kati Thanda being observed at any given surface area during La Niña."
    ]
   },
   {


### PR DESCRIPTION
### Proposed changes
Added notebook that estimates ENSO influence on DEA Waterbodies.


### Checklist (replace `[ ]` with `[x]` to check off)
- [x] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [x] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [x] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


