### PR TITLE
Fix hard-coded CRS

### DIFF
--- a/Scripts/dea_classificationtools.py
+++ b/Scripts/dea_classificationtools.py
@@ -378,8 +378,7 @@ def get_training_data_for_shp(gdf,
 
     # set up query based on polygon (convert to albers)
     geom = geometry.Geometry(
-        gdf.geometry.values[index].__geo_interface__, geometry.CRS(
-            'epsg:3577'))
+        gdf.geometry.values[index].__geo_interface__, geometry.CRS(f'EPSG:{gdf.crs.to_epsg()}'))
 
     q = {"geopolygon": geom}
 


### PR DESCRIPTION
### Proposed changes
The `collect_training_data` function has a hard-coded 'EPSG:3577' `crs` when extracting geometries for querying the datacube, when the `crs` on the shapefile doesn't match 3577, `load_ard` fails to find data.  This fix uses the shapefile's `crs` to query the datacube.

