### PR TITLE
Fix major scaling bug in xr_animation, remove deprecated funcs

### DIFF
--- a/Scripts/dea_plotting.py
+++ b/Scripts/dea_plotting.py
@@ -765,8 +765,7 @@ def xr_animation(ds,
         animate each frame in the animation. Plots array and any text
         annotations, as well as a temporal subset of `gdf` data based
         on the times specified in 'start_time' and 'end_time' columns.
-        """
-        
+        """        
 
         # Clear previous frame to optimise render speed and plot imagery
         ax.clear()
@@ -862,7 +861,7 @@ def xr_animation(ds,
 
     # Convert data to 4D numpy array of shape [time, y, x, bands]
     ds = ds[bands].to_array().transpose(..., 'variable')[0:limit, ...]
-    array = ds.values
+    array = ds.astype(np.float32).values
 
     # Optionally apply image processing along axis 0 (e.g. to each timestep)
     bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt} ({remaining_s:.1f} ' \

--- a/Scripts/dea_plotting.py
+++ b/Scripts/dea_plotting.py
@@ -23,7 +23,7 @@ Functions included:
     map_shapefile
     xr_animation
 
-Last modified: September 2020
+Last modified: October 2020
 
 '''
 
@@ -568,7 +568,7 @@ def xr_animation(ds,
     Supports .mp4 (ideal for Twitter/social media) and .gif (ideal 
     for all purposes, but can have large file sizes) format files. 
     
-    Last modified: April 2020
+    Last modified: October 2020
     
     Parameters
     ----------  
@@ -597,7 +597,9 @@ def xr_animation(ds,
         three-band arrays by percentiles to produce a more vibrant, 
         visually attractive image that is not affected by outliers/
         extreme values. The default is `(0.02, 0.98)` which is 
-        equivalent to xarray's `robust=True`.        
+        equivalent to xarray's `robust=True`. This parameter is ignored
+        completely if `vmin` and `vmax` are provided as kwargs to
+        `imshow_kwargs`.
     image_proc_funcs : list of funcs, optional
         An optional list containing functions that will be applied to 
         each animation frame (timestep) prior to animating. This can 
@@ -768,7 +770,10 @@ def xr_animation(ds,
 
         # Clear previous frame to optimise render speed and plot imagery
         ax.clear()
-        ax.imshow(array[i, ...].clip(0.0, 1.0), extent=extent, **imshow_defaults)
+        ax.imshow(array[i, ...].clip(0.0, 1.0), 
+                  extent=extent, 
+                  vmin=0.0, vmax=1.0, 
+                  **imshow_defaults)
 
         # Add annotation text
         ax.annotate(annotation_text[i], **annotation_defaults)
@@ -875,14 +880,17 @@ def xr_animation(ds,
 
     # Clip to percentiles and rescale between 0.0 and 1.0 for plotting
     vmin, vmax = np.quantile(array[np.isfinite(array)], q=percentile_stretch)
-    
+        
     # Replace with vmin and vmax if present in `imshow_defaults`
     if 'vmin' in imshow_defaults:
-        vmin = imshow_defaults['vmin']
+        vmin = imshow_defaults.pop('vmin')
     if 'vmax' in imshow_defaults:
-        vmax = imshow_defaults['vmax']
+        vmax = imshow_defaults.pop('vmax')
     
-    array = rescale_intensity(array, in_range=(vmin, vmax), out_range=(0.0, 1.0))
+    # Rescale between 0 and 1
+    array = rescale_intensity(array, 
+                              in_range=(vmin, vmax), 
+                              out_range=(0.0, 1.0))
     array = np.squeeze(array)  # remove final axis if only one band
 
     # Set up figure
@@ -928,474 +936,6 @@ def xr_animation(ds,
         progress_bar.last_print_n = len(ds.time)
 
 
-def animated_timeseries(ds,
-                        output_path,
-                        width_pixels=500,
-                        interval=200,
-                        bands=['nbart_red', 'nbart_green', 'nbart_blue'],
-                        percentile_stretch=(0.02, 0.98),
-                        image_proc_func=None,
-                        title=False,
-                        show_date=True,
-                        annotation_kwargs={},
-                        onebandplot_cbar=True,
-                        onebandplot_kwargs={},
-                        shapefile_path=None,
-                        shapefile_kwargs={},
-                        time_dim='time',
-                        x_dim='x',
-                        y_dim='y'):
-    """
-    ------------------------------------------------------------------
-    APRIL 2020 UPDATE: The `animated_timeseries` function is being 
-    depreciated, and will soon be replaced with the more powerful 
-    and easier-to-use `xr_animation` function from 
-    `Scripts/dea_plotting`. Please update your code to use 
-    `xr_animation` instead.
-    ------------------------------------------------------------------
-    
-    Takes an xarray time series and animates the data as either a 
-    three-band (e.g. true or false colour) or single-band animation, 
-    allowing changes in the landscape to be compared across time.
-    
-    Animations can be exported as .mp4 (ideal for Twitter/social media)
-    and .gif (ideal for all purposes, but can have large file sizes) 
-    format files, and customised to include titles and date annotations 
-    or use specific combinations of input bands.
-    
-    A shapefile boundary can be added to the output animation by 
-    providing a path to the shapefile.
-    
-    This function can be used to produce visually appealing 
-    cloud-free animations when used in combination with the `load_ard` 
-    function from `dea-notebooks/Scripts/dea_datahandling`.
-    
-    Last modified: October 2019
-    
-    Parameters
-    ----------  
-    ds : xarray.Dataset
-        An xarray dataset with multiple time steps (i.e. multiple 
-        observations along the `time` dimension).        
-    output_path : str
-        A string giving the output location and filename of the 
-        resulting animation. File extensions of '.mp4' and '.gif' are 
-        accepted.    
-    width_pixels : int, optional
-        An integer defining the output width in pixels for the resulting 
-        animation. The height of the animation is set automatically 
-        based on the dimensions/ratio of the input xarray dataset. 
-        Defaults to 500 pixels wide.        
-    interval : int, optional
-        An integer defining the milliseconds between each animation 
-        frame used to control the speed of the output animation. Higher 
-        values result in a slower animation. Defaults to 200 
-        milliseconds between each frame.         
-    bands : list of strings, optional
-        An optional list of either one or three bands to be plotted, 
-        all of which must exist in `ds`. Defaults to 
-        `['nbart_red', 'nbart_green', 'nbart_blue']`.         
-    percentile_stretch : tuple of floats, optional
-        An optional tuple of two floats that can be used to clip one or 
-        three-band arrays by percentiles to produce a more vibrant, 
-        visually attractive image that is not affected by outliers/
-        extreme values. The default is `(0.02, 0.98)` which is 
-        equivalent to xarray's `robust=True`.        
-    image_proc_func : func, optional
-        An optional function can be passed to modify three-band arrays 
-        for each timestep prior to animating. This could include image 
-        processing functions such as increasing contrast, unsharp 
-        masking, saturation etc. The function should take AND return a 
-        three-band numpy array with shape [:, :, 3]. If your function 
-        has parameters, you can pass in custom values using `partial` 
-        from `functools`: 
-        `image_proc_func=partial(custom_func, param1=10)`.
-    title : str or list of strings, optional
-        An optional string or list of strings with a length equal to the
-        number of timesteps in ds. This can be used to display a static 
-        title (using a string), or a dynamic title (using a list) that 
-        displays different text for each timestep. Defaults to False, 
-        which plots no title.        
-    show_date : bool, optional
-        An optional boolean that defines whether or not to plot date 
-        annotations for each animation frame. Defaults to True, which 
-        plots date annotations based on ds.        
-    annotation_kwargs : dict, optional
-        An optional dict of kwargs for controlling the appearance of 
-        text annotations to pass to the matplotlib `plt.annotate` 
-        function (see https://matplotlib.org/api/_as_gen/matplotlib.pyplot.annotate.html 
-        for options). For example, `annotation_kwargs={'fontsize':20, 
-        'color':'red', 'family':'serif'}. By default, text annotations 
-        are plotted as white, size 20 mono-spaced font with a 2.5pt 
-        black outline in the top-right of the animation.         
-    onebandplot_cbar : bool, iptional
-        An optional boolean indicating whether to include a colourbar 
-        for one-band arrays. Defaults to True.        
-    onebandplot_kwargs : dict, optional
-        An optional dict of kwargs for controlling the appearance of 
-        one-band image arrays to pass to matplotlib `plt.imshow` 
-        (see https://matplotlib.org/api/_as_gen/matplotlib.pyplot.imshow.html 
-        for options). This only applies if an xarray with a single band 
-        is passed to `ds`. For example, a green colour scheme and custom 
-        stretch could be specified using: 
-        `onebandplot_kwargs={'cmap':'Greens`, 'vmin':0.2, 'vmax':0.9}`. 
-        By default, one-band arrays are plotted using the 'Greys' cmap 
-        with bilinear interpolation.
-        
-        Two special kwargs (`tick_fontsize`, `tick_colour`) can also be 
-        passed to control the tick labels on the colourbar. This can be 
-        useful for example when the tick labels are difficult to see 
-        against a dark background.       
-    shapefile_path : str or list of strings, optional
-        An optional string or list of strings giving the file paths of 
-        one or multiple shapefiles to overlay on the output animation. 
-        The shapefiles must be in the same projection as the input 
-        xarray dataset.        
-    shapefile_kwargs : dict or list of dicts, optional
-        An optional dictionary of kwargs or list of dictionaries to 
-        specify the appearance of the shapefile overlay by passing to 
-        `GeoSeries.plot` (see http://geopandas.org/reference.html#geopandas.GeoSeries.plot). 
-        For example: `shapefile_kwargs = {'linewidth':2, 
-        'edgecolor':'black', 'facecolor':"#00000000"}`. If multiple 
-        shapefiles were provided to `shapefile_path`, each shapefile can 
-        be plotted with a different colour style by passing in a list of
-        kwarg dicts of the same length as `shapefile_path`.        
-    time_dim : str, optional
-        An optional string allowing you to override the xarray dimension 
-        used for time. Defaults to 'time'.
-    x_dim : str, optional
-        An optional string allowing you to override the xarray dimension 
-        used for x coordinates. Defaults to 'x'.    
-    y_dim : str, optional
-        An optional string allowing you to override the xarray dimension 
-        used for y coordinates. Defaults to 'y'.
-        
-    """
-    
-    warnings.warn("The `animated_timeseries` function is being depreciated, "
-                  "and will soon be replaced with the more powerful and "
-                  "easier-to-use `xr_animation` function from "
-                  "`Scripts/dea_plotting`. Please update your code to use "
-                  "`xr_animation` instead.", 
-                  DeprecationWarning, stacklevel=2)
-
-    ###############
-    # Setup steps #
-    ###############
-
-    # Test if all dimensions exist in dataset
-    if time_dim in ds and x_dim in ds and y_dim in ds:
-
-        # First test if there are three bands, and that all exist in both datasets:
-        if ((len(bands) == 3) |
-            (len(bands) == 1)) & all([(b in ds.data_vars) for b in bands]):
-
-            # Import xarrays as lists of three band numpy arrays
-            imagelist, vmin, vmax = _ds_to_arrraylist(
-                ds,
-                bands=bands,
-                time_dim=time_dim,
-                x_dim=x_dim,
-                y_dim=y_dim,
-                percentile_stretch=percentile_stretch,
-                image_proc_func=image_proc_func)
-
-            # Get time, x and y dimensions of dataset and calculate 
-            # width vs height of plot
-            timesteps = len(ds[time_dim])
-            width = len(ds[x_dim])
-            height = len(ds[y_dim])
-            scale = (width_pixels / width)
-
-            # If title is supplied as a string, multiply out to a list 
-            # with one string per timestep. Otherwise, use supplied list
-            # for plot titles.
-            if isinstance(title, str) or isinstance(title, bool):
-                title_list = [title] * timesteps
-            else:
-                title_list = title
-
-            # Set up annotation parameters that plt.imshow plotting for 
-            # single band array images. The nested dict structure sets 
-            # default values which can be overwritten/customised by the
-            # manually specified `onebandplot_kwargs`
-            onebandplot_kwargs = dict({'cmap': 'Greys',
-                                       'interpolation': 'bilinear',
-                                       'vmin': vmin,
-                                       'vmax': vmax,
-                                       'tick_colour': 'black',
-                                       'tick_fontsize': 12}, 
-                                      **onebandplot_kwargs)
-
-            # Use pop to remove the two special tick kwargs from the 
-            # onebandplot_kwargs dict, and save individually
-            onebandplot_tick_colour = onebandplot_kwargs.pop('tick_colour')
-            onebandplot_tick_fontsize = onebandplot_kwargs.pop('tick_fontsize')
-
-            # Set up annotation parameters that control font etc. The 
-            # nested dict structure sets default values which can be 
-            # overwritten/customised by the manually specified 
-            #`annotation_kwargs`
-            annotation_kwargs = dict(
-                {
-                    'xy': (1, 1),
-                    'xycoords': 'axes fraction',
-                    'xytext': (-5, -5),
-                    'textcoords': 'offset points',
-                    'horizontalalignment': 'right',
-                    'verticalalignment': 'top',
-                    'fontsize': 20,
-                    'color': 'white',
-                    'path_effects': [PathEffects.withStroke(linewidth=2.5, 
-                                                            foreground='black')]
-                }, **annotation_kwargs)
-
-            ###################
-            # Initialise plot #
-            ###################
-
-            # Set up figure
-            fig, ax1 = plt.subplots(ncols=1)
-            fig.subplots_adjust(left=0,
-                                bottom=0,
-                                right=1,
-                                top=1,
-                                wspace=0,
-                                hspace=0)
-            
-            fig.set_size_inches(width * scale / 72, 
-                                height * scale / 72, 
-                                forward=True)
-            ax1.axis('off')
-
-            # Initialise axesimage objects to be updated during 
-            # animation, setting extent from dims
-            extents = [float(ds[x_dim].min()),
-                       float(ds[x_dim].max()),
-                       float(ds[y_dim].min()),
-                       float(ds[y_dim].max())]
-            
-            im = ax1.imshow(imagelist[0], 
-                            extent=extents, 
-                            **onebandplot_kwargs)
-
-            # Initialise annotation objects to be updated during 
-            # animation
-            t = ax1.annotate('', **annotation_kwargs)
-
-            #########################
-            # Add optional overlays #
-            #########################
-
-            # Optionally add shapefile overlay(s) from either string 
-            # path or list of string paths
-            if isinstance(shapefile_path, str):
-
-                # Define default plotting parameters for the overlaying 
-                # shapefile(s). The nested dict structure sets default 
-                # values which can be overwritten/customised by the 
-                # manually specified `shapefile_kwargs`
-                shapefile_kwargs = dict({'linewidth': 2,
-                                         'edgecolor': 'black',
-                                         'facecolor': "#00000000"}, 
-                                        **shapefile_kwargs)
-
-                shapefile = gpd.read_file(shapefile_path)
-                shapefile.plot(**shapefile_kwargs, ax=ax1)
-
-            elif isinstance(shapefile_path, list):
-
-                # Iterate through list of string paths
-                for i, shapefile in enumerate(shapefile_path):
-
-                    if isinstance(shapefile_kwargs, list):
-
-                        # If a list of shapefile_kwargs is supplied, use
-                        # one for each shapefile
-                        shapefile_kwargs_i = dict({'linewidth': 2,
-                                                   'edgecolor': 'black',
-                                                   'facecolor': "#00000000"}, 
-                                                  **shapefile_kwargs[i])
-
-                        shapefile = gpd.read_file(shapefile)
-                        shapefile.plot(**shapefile_kwargs_i, ax=ax1)
-
-                    else:
-
-                        # If one shapefile_kwargs is provided, use for 
-                        # all shapefiles
-                        shapefile_kwargs = dict({'linewidth': 2,
-                                                 'edgecolor': 'black',
-                                                 'facecolor': "#00000000"}, 
-                                                **shapefile_kwargs)
-
-                        shapefile = gpd.read_file(shapefile)
-                        shapefile.plot(**shapefile_kwargs, ax=ax1)
-
-            # After adding shapefile, fix extents of plot
-            ax1.set_xlim(extents[0], extents[1])
-            ax1.set_ylim(extents[2], extents[3])
-
-            # Optionally add colourbar for one band images
-            if (len(bands) == 1) & onebandplot_cbar:
-
-                _add_colourbar(ax1,
-                               im,
-                               tick_fontsize=onebandplot_tick_fontsize,
-                               tick_colour=onebandplot_tick_colour,
-                               vmin=onebandplot_kwargs['vmin'],
-                               vmax=onebandplot_kwargs['vmax'],
-                               cmap=onebandplot_kwargs['cmap'])
-
-            ########################################
-            # Create function to update each frame #
-            ########################################
-
-            # Function to update figure
-            def update_figure(frame_i):
-
-                # If possible, extract dates from time dimension
-                try:
-
-                    # Get human-readable date info (e.g. "16 May 1990")
-                    ts = ds[time_dim][{time_dim: frame_i}].dt
-                    year = ts.year.item()
-                    month = ts.month.item()
-                    day = ts.day.item()
-                    date_string = '{} {} {}'.format(day,
-                                                    calendar.month_abbr[month],
-                                                    year)
-
-                except:
-
-                    date_string = ds[time_dim][{time_dim: frame_i}].values.item()
-
-                # Create annotation string based on title and date 
-                # specifications:
-                title = title_list[frame_i]
-                if title and show_date:
-                    title_date = '{}\n{}'.format(date_string, title)
-                elif title and not show_date:
-                    title_date = '{}'.format(title)
-                elif show_date and not title:
-                    title_date = '{}'.format(date_string)
-                else:
-                    title_date = ''
-
-                # Update figure for frame
-                im.set_array(imagelist[frame_i])
-                t.set_text(title_date)
-
-                # Return the artists set
-                return [im, t]
-
-            ##############################
-            # Generate and run animation #
-            ##############################
-
-            # Generate animation
-            print('Generating {} frame animation'.format(timesteps))
-            ani = animation.FuncAnimation(fig,
-                                          update_figure,
-                                          frames=timesteps,
-                                          interval=interval,
-                                          blit=True)
-
-            # Export as either MP4 or GIF
-            if output_path[-3:] == 'mp4':
-                print('    Exporting animation to {}'.format(output_path))
-                ani.save(output_path, dpi=72)
-
-            elif output_path[-3:] == 'gif':
-                print('    Exporting animation to {}'.format(output_path))
-                ani.save(output_path,
-                         writer='pillow') 
-
-            else:
-                print('    Output file type must be either .mp4 or .gif')
-
-        else:
-            print(
-                'Please select either one or three bands that all exist in the input dataset'
-            )
-
-    else:
-        print('At least one x, y or time dimension does not exist in the input dataset. Please use the `time_dim`,' \
-              '`x_dim` or `y_dim` parameters to override the default dimension names used for plotting')
-
-
-# Define function to convert xarray dataset to list of one or three band numpy arrays
-def _ds_to_arrraylist(ds, bands, time_dim, x_dim, y_dim, percentile_stretch, image_proc_func=None): 
-
-    """
-    Converts an xarray dataset to a list of numpy arrays for plt.imshow plotting
-    """
-
-    # Compute percents
-    p_low, p_high = ds[bands].to_array().quantile(percentile_stretch).values
-
-    array_list = []
-    for i, timestep in enumerate(ds[time_dim]):
-
-        # Select single timestep from the data array
-        ds_i = ds[{time_dim: i}]
-
-        # Get shape of array
-        x = len(ds[x_dim])
-        y = len(ds[y_dim])
-
-        if len(bands) == 1:    
-
-            # Create new one band array
-            img_toshow = exposure.rescale_intensity(ds_i[bands[0]].values, 
-                                                    in_range=(p_low, p_high),
-                                                    out_range='image')
-
-        else:
-
-            # Create new three band array                
-            rawimg = np.zeros((y, x, 3), dtype=np.float32)
-
-            # Add xarray bands into three dimensional numpy array
-            for band, colour in enumerate(bands):
-
-                rawimg[:, :, band] = ds_i[colour].values
-
-            # Stretch contrast using percentile values
-            img_toshow = exposure.rescale_intensity(rawimg, 
-                                                    in_range=(p_low, p_high),
-                                                    out_range=(0, 1.0))
-
-            # Optionally image processing
-            if image_proc_func:
-                
-                img_toshow = image_proc_func(img_toshow).clip(0, 1)
-
-        array_list.append(img_toshow)
-
-    return array_list, p_low, p_high
-
-
-def _add_colourbar(ax, im, vmin, vmax, cmap='Greys', tick_fontsize=15, tick_colour='black'):
-
-    """
-    Add a nicely formatted colourbar to an animation panel
-    """
-
-    # Add colourbar
-    axins2 = inset_axes(ax, width='97%', height='4%', loc=8, borderpad=1) 
-    plt.gcf().colorbar(im, cax=axins2, orientation='horizontal', ticks=np.linspace(vmin, vmax, 3)) 
-    axins2.xaxis.set_ticks_position('top')
-    axins2.tick_params(axis='x', colors=tick_colour, labelsize=tick_fontsize) 
-    
-    # Justify left and right labels to edge of plot
-    axins2.get_xticklabels()[0].set_horizontalalignment('left')
-    axins2.get_xticklabels()[-1].set_horizontalalignment('right')
-    labels = [item.get_text() for item in axins2.get_xticklabels()]
-    labels[0] = '  ' + labels[0]
-    labels[-1] = labels[-1] + '  '
-    
-        
 def _degree_to_zoom_level(l1, l2, margin=0.0):
     
     """


### PR DESCRIPTION
### Proposed changes
Lan-Wei encountered a nasty issue where one-band animations were being plotted with unexpected colours that did not match the underlying data when using the default `percentile_clip`. This revealed that the animation code was inadvertently plotting colour stretches for each frame independently, which meant strictly that animation frames could not be compared fairly across time. This was not noticed up to now as most animations are based on multi-band satellite data with approximately similar distributions in each frame - Lan-Wei's example involved plotting single-band timesteps with a single unique value in each frame, which made the scaling issue much more obvious.

A secondary issue involved a scenario where the user manually specifies a `vmin` and `vmax` used to scale colours. As part of the underlying code, those values are also used to scale all array values to between 0 and 1.0 before plotting the data. These 0-1.0 rescaled values are then passed to `plt.imshow` - however, the code accidently also passed the original `vmin` and `vmax` values and used those to set the colour stretch. This is incorrect: once the data has been rescaled to between 0 and 1.0, the original `vmin` and `vmax` values no longer apply. Instead, each frame should always be plotted with a colour stretch between 0 and 1.0.

I've fixed both of these bugs by "popping" the original `vmin` and `vmax` out of the dictionary of kwargs that are used to customise `plt.imshow`, and forcing `plt.imshow` to always use a `vmin` of 0.0 and a `vmax` of 1.0. This ensures that the colours match the rescaled data, and are consistent across all animation frames. 

## Additional changes
Since the outdated `animated_timeseries` has now been depreciated for almost a year, I've also finally removed these funcs from the script. If users complain about this removal, we can point them to the `xr_animation` function and accompanying notebook.