### PR TITLE
Fixed paths broken in #673

### DIFF
--- a/Frequently_used_code/Analyse_multiple_polygons.ipynb
+++ b/Frequently_used_code/Analyse_multiple_polygons.ipynb
@@ -77,7 +77,7 @@
     "from dea_datahandling import load_ard\n",
     "from dea_bandindices import calculate_indices\n",
     "from dea_plotting import rgb, map_shapefile\n",
-    "from dea_temporaltools import time_buffer\n",
+    "from dea_temporal import time_buffer\n",
     "from dea_spatialtools import xr_rasterize"
    ]
   },
@@ -553,7 +553,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "**Tags**: :index:`NCI compatible`, :index:`sandbox compatible`, :index:`landsat 8`, :index:`dea_plotting`, :index:`dea_datahandling`, :index:`xr_rasterize`, :index:`dea_bandindices`, :index:`dea_spatialtools`, :index:`dea_temporaltools`, :index:`time_buffer`, :index:`load_ard`, :index:`rgb`, :index:`calculate_indices`, :index:`NDVI`, :index:`GeoPandas`, :index:`shapefile`"
+    "**Tags**: :index:`NCI compatible`, :index:`sandbox compatible`, :index:`landsat 8`, :index:`dea_plotting`, :index:`dea_datahandling`, :index:`xr_rasterize`, :index:`dea_bandindices`, :index:`dea_spatialtools`, :index:`dea_temporal`, :index:`time_buffer`, :index:`load_ard`, :index:`rgb`, :index:`calculate_indices`, :index:`NDVI`, :index:`GeoPandas`, :index:`shapefile`"
    ]
   }
  ],

--- a/Real_world_examples/Surface_area_duration.ipynb
+++ b/Real_world_examples/Surface_area_duration.ipynb
@@ -63,7 +63,7 @@
     "# Import DEA modules.\n",
     "import sys\n",
     "sys.path.insert(1, '../Scripts')\n",
-    "from dea_temporaltools import calculate_vector_stat"
+    "from dea_temporal import calculate_vector_stat"
    ]
   },
   {


### PR DESCRIPTION
#673 renamed dea_temporaltools to dea_temporal; this PR fixes the two notebooks that this change broke.