### PR TITLE
Remove reference to non-existent func

### DIFF
--- a/Scripts/dea_datahandling.py
+++ b/Scripts/dea_datahandling.py
@@ -26,7 +26,6 @@ Functions included:
     dilate
     pan_sharpen_brovey
     paths_to_datetimeindex
-    calc_geomedian
     _select_along_axis
     nearest
     last


### PR DESCRIPTION
### Proposed changes
`calc_geomedian` does not exist in `dea_datahandling`, despite the docstring's lies. Removed!