### PR TITLE
Trigger docs builds from notebooks repo

### DIFF
--- a/.github/workflows/trigger_docs.yaml
+++ b/.github/workflows/trigger_docs.yaml
@@ -1,0 +1,18 @@
+
+name: Trigger DEA Docs Build
+
+on:
+  push:
+    branches:
+      - stable
+
+jobs:
+  trigger_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_PAT }}
+          repository: GeoscienceAustralia/dea-docs
+          event-type: republish-docs


### PR DESCRIPTION
### Proposed changes
When changes are pushed to the `stable` branch, automatically trigger a re-publish of DEA Docs in the [dea-docs repository](https://github.com/GeoscienceAustralia/dea-docs/)

