### PR TITLE
Fix double fmask load bug when using `load_ard`

### DIFF
--- a/Tools/dea_tools/datahandling.py
+++ b/Tools/dea_tools/datahandling.py
@@ -31,7 +31,7 @@ Functions included:
     last
     first
 
-Last modified: Jan 2021
+Last modified: March 2021
 
 '''
 
@@ -362,7 +362,7 @@ def load_ard(dc,
         print('Counting good quality pixels for each time step')
         data_perc = (pq_mask.sum(axis=[1, 2], dtype='int32') /
                      (pq_mask.shape[1] * pq_mask.shape[2]))
-        keep = data_perc >= min_gooddata
+        keep = (data_perc >= min_gooddata).compute()
 
         # Filter by `min_gooddata` to drop low quality observations
         total_obs = len(ds.time)

--- a/Tools/dea_tools/datahandling.py
+++ b/Tools/dea_tools/datahandling.py
@@ -362,7 +362,7 @@ def load_ard(dc,
         print('Counting good quality pixels for each time step')
         data_perc = (pq_mask.sum(axis=[1, 2], dtype='int32') /
                      (pq_mask.shape[1] * pq_mask.shape[2]))
-        keep = (data_perc >= min_gooddata).compute()
+        keep = (data_perc >= min_gooddata).persist()
 
         # Filter by `min_gooddata` to drop low quality observations
         total_obs = len(ds.time)


### PR DESCRIPTION
### Proposed changes
For a long time, `load_ard` has shown a curious behavior where the function appears to load Fmask cloud masking data twice when filtering by `min_gooddata` (i.e. the two discrete yellow sections below on the Dask status page below). This can add a large amount of time to all-of-time data loads, but hasn't ever been investigated in detail as Dask is a bit of a black box. 

![old](https://user-images.githubusercontent.com/17680388/109760740-54a9cf80-7c43-11eb-9f7b-670620b89a01.JPG)

It turns out that this is actually a super simple bug with major implications for load time. Essentially, [Line 365](https://github.com/GeoscienceAustralia/dea-notebooks/blob/develop/Tools/dea_tools/datahandling.py#L365) creates a boolean that indicates whether each timestep was too cloudy or not to load data for (based on `min_gooddata`). When using dask, this is not evaluated until [Lines 368-369](https://github.com/GeoscienceAustralia/dea-notebooks/blob/develop/Tools/dea_tools/datahandling.py#L368-L369). However, because each line is run independently, the boolean is evaluated separately each time, rather than being loaded only once and re-used.

The super simple solution is to simply `.compute()` Line 365 so it's evaluated only once, then used for both Line 368 and 369. This successfully removes an entire evaluation of the cloud mask layer:

![image](https://user-images.githubusercontent.com/17680388/109761357-401a0700-7c44-11eb-9574-bf491bc75af3.png)

A quick test on a tiny full stack of Landsat 5, 7 and 8 with `min_gooddata=0.99` cut total load time from 3 minutes 15 seconds to 1 minute 30 seconds. 🤯 

