### PR TITLE
Add Non-linear Normalised Difference Vegation Index to calculate_indices

### DIFF
--- a/Tools/dea_tools/bandindices.py
+++ b/Tools/dea_tools/bandindices.py
@@ -17,12 +17,13 @@ here: https://gis.stackexchange.com/questions/tagged/open-data-cube).
 If you would like to report an issue with this script, you can file one
 on Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 
-Last modified: September 2020
+Last modified: March 2021
 
 '''
 
 # Import required packages
 import warnings
+import numpy as np
 
 # Define custom functions
 def calculate_indices(ds,
@@ -41,7 +42,7 @@ def calculate_indices(ds,
     in memory. This can be a memory-expensive operation, so to avoid
     this, set `inplace=True`.
 
-    Last modified: September 2020
+    Last modified: March 2021
     
     Parameters
     ----------
@@ -83,7 +84,9 @@ def calculate_indices(ds,
         'TCB' (Tasseled Cap Brightness, Crist 1985)
         'TCG' (Tasseled Cap Greeness, Crist 1985)
         'TCW' (Tasseled Cap Wetness, Crist 1985)
-        'WI' (Water Index, Fisher 2016) 
+        'WI' (Water Index, Fisher 2016)
+        'zNDVI' (Non-linear Normalised Difference Vegation Index,
+                 Camps-Valls et al. 2021)
     collection : str
         An string that tells the function what data collection is 
         being used to calculate the index. This is necessary because 
@@ -138,6 +141,11 @@ def calculate_indices(ds,
                   # Normalised Difference Vegation Index, Rouse 1973
                   'NDVI': lambda ds: (ds.nir - ds.red) /
                                      (ds.nir + ds.red),
+        
+                  # Non-linear Normalised Difference Vegation Index,
+                  # Camps-Valls et al. 2021
+                  'zNDVI': lambda ds: np.tanh(((ds.nir - ds.red) /
+                                               (ds.nir + ds.red)) ** 2),
 
                   # Enhanced Vegetation Index, Huete 2002
                   'EVI': lambda ds: ((2.5 * (ds.nir - ds.red)) /

--- a/Tools/dea_tools/bandindices.py
+++ b/Tools/dea_tools/bandindices.py
@@ -85,7 +85,7 @@ def calculate_indices(ds,
         'TCG' (Tasseled Cap Greeness, Crist 1985)
         'TCW' (Tasseled Cap Wetness, Crist 1985)
         'WI' (Water Index, Fisher 2016)
-        'zNDVI' (Non-linear Normalised Difference Vegation Index,
+        'kNDVI' (Non-linear Normalised Difference Vegation Index,
                  Camps-Valls et al. 2021)
     collection : str
         An string that tells the function what data collection is 
@@ -144,7 +144,7 @@ def calculate_indices(ds,
         
                   # Non-linear Normalised Difference Vegation Index,
                   # Camps-Valls et al. 2021
-                  'zNDVI': lambda ds: np.tanh(((ds.nir - ds.red) /
+                  'kNDVI': lambda ds: np.tanh(((ds.nir - ds.red) /
                                                (ds.nir + ds.red)) ** 2),
 
                   # Enhanced Vegetation Index, Huete 2002


### PR DESCRIPTION
### Proposed changes
This PR adds the new Non-linear Normalised Difference Vegation Index ("kNDVI") from [Camps-Valls et al. 2021](https://advances.sciencemag.org/content/7/9/eabc7447.full) to `calculate_indices`.

To keep things simple, I've included the simplest form of the index which fixes the length-scale parameter σ equal to the mean distance between the NIR and red bands, i.e. σ = 0.5(n + r). See Formula 3 in [Camps-Valls et al. 2021](https://advances.sciencemag.org/content/7/9/eabc7447.full).

> Camps-Valls, G., Campos-Taberner, M., Moreno-Martínez, Á., Walther, S., Duveiller, G., Cescatti, A., Mahecha, M.D., Muñoz-Marí, J., García-Haro, F.J., Guanter, L. and Jung, M., 2021. A unified vegetation index for quantifying the terrestrial biosphere. Science Advances, 7(9), p.eabc7447.