### PR TITLE
Add ValueError to `_get_training_data_for_shp`

### DIFF
--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -503,7 +503,17 @@ def _get_training_data_for_shp(gdf,
         with HiddenPrints():
             data = custom_func(ds)
             data = data.where(mask)
-
+        
+        #Check that custom_func has removed time
+        if 'time' in data.dims:
+            t = data.dims['time']
+            if t > 1:
+                raise ValueError(
+                    "After running the custom_func, the dataset still has "+
+                     str(t) + " time-steps, dataset must only have"+
+                    " x and y dimensions."
+                    )
+                
     else:
         # mask dataset
         ds = ds.where(mask)


### PR DESCRIPTION
### Proposed changes
If a user passed a `custom_func` to `collect_training_data`, and the function didn't reduce the time dimension, the code would still run without complaint, resulting in unexpected results. This PR adds a test for the length of the time dimension on the output from the custom_func.