### PR TITLE
Remove defunct practice exercises folder

### DIFF
--- a/Real_world_examples/Practice_exercises/README.rst
+++ b/Real_world_examples/Practice_exercises/README.rst
@@ -1,4 +1,0 @@
-Practice exercises
-==================
-
-These notebooks are designed as interactive exercises that require modification by user.


### PR DESCRIPTION
### Proposed changes
This folder was never used, and has now been superseded by the ODC workshop material. It can be removed.