### PR TITLE
Move Scalable Machine Learning notebooks to subfolder in user guide

### DIFF
--- a/Real_world_examples/README.rst
+++ b/Real_world_examples/README.rst
@@ -22,6 +22,7 @@ More complex case study-based workflows demonstrating how DEA can be used to add
    Urban_change_detection.ipynb
    Vegetation_phenology.ipynb
    Wetness_stream_gauge_correlations.ipynb
+   Scalable_machine_learning/README.rst
 
    
 Citing DEA Notebooks

--- a/Real_world_examples/README.rst
+++ b/Real_world_examples/README.rst
@@ -23,17 +23,6 @@ More complex case study-based workflows demonstrating how DEA can be used to add
    Vegetation_phenology.ipynb
    Wetness_stream_gauge_correlations.ipynb
 
-Scalable Supervised Machine Learning on the Open Data Cube:
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Scalable machine learning
-   
-   Scalable_machine_learning/1_Extract_training_data.ipynb
-   Scalable_machine_learning/2_Inspect_training_data.ipynb
-   Scalable_machine_learning/3_Evaluate_optimize_fit_classifier.ipynb
-   Scalable_machine_learning/4_Classify_satellite_data.ipynb
-   Scalable_machine_learning/5_Object-based_filtering.ipynb
    
 Citing DEA Notebooks
 --------------------

--- a/Real_world_examples/Scalable_machine_learning/README.rst
+++ b/Real_world_examples/Scalable_machine_learning/README.rst
@@ -1,0 +1,8 @@
+Scalable Supervised Machine Learning on the Open Data Cube
+==========================================================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Scalable machine learning
+   
+   *.ipynb


### PR DESCRIPTION
### Proposed changes
Update readmes to move Scalable Machine Learning notebooks to subfolder in user guide.

Have added a new .rst file into the Scalable Machine Learning folder to test if this works - if it does, I'll raise another PR to combine the current .md and .rst readmes into a single one (otherwise we'd have three readmes in the same location).