### PR TITLE
Change how to compute inundation metrics in wit

### DIFF
--- a/Scientific_workflows/Wetlands_Insight_Tool/metrics/wit_metrics.ipynb
+++ b/Scientific_workflows/Wetlands_Insight_Tool/metrics/wit_metrics.ipynb
@@ -121,7 +121,6 @@
     "            if count <= 0:\n",
     "                break\n",
     "    \n",
-    "#def get_areas(features, pkey='SYSID'):\n",
     "def get_areas(features, pkey='SYSID'):\n",
     "    \"\"\"\n",
     "        Calculate the area of a list/generator of shapes\n",
@@ -501,7 +500,7 @@
     "# set the output file to your own path\n",
     "\n",
     "wit_im =inundation_metrics(wit_data, wit_area, threshold_list, pkey=pkey)\n",
-    "ofn = 'ANAE_inudation_metrics.csv'\n",
+    "ofn = 'ANAE_inundation_metrics.csv'\n",
     "wit_im.to_csv(ofn)\n",
     "    \n",
     "#*********************** START ADDED BY SHANE ***********************\n",
@@ -570,6 +569,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/Scientific_workflows/Wetlands_Insight_Tool/metrics/wit_metrics.ipynb
+++ b/Scientific_workflows/Wetlands_Insight_Tool/metrics/wit_metrics.ipynb
@@ -248,18 +248,23 @@
     "        output:\n",
     "            dateframe of inundation event time\n",
     "    \"\"\"\n",
-    "    i_start = wit_ww[wit_ww['WW'] >= threshold]['TIME'].min()\n",
+    "    if isinstance(threshold, pd.DataFrame):\n",
+    "        gid = wit_ww.index.unique()[0]\n",
+    "        poly_threshold = threshold.loc[gid].to_numpy()[0]\n",
+    "    else:\n",
+    "        poly_threshold = threshold\n",
+    "    i_start = wit_ww[wit_ww['WW'] >= poly_threshold]['TIME'].min()\n",
     "    if pd.isnull(i_start):\n",
     "        re = pd.DataFrame([[np.nan] * 4], columns=['start_time', 'end_time', 'duration', 'gap'], index=wit_ww.index.unique())\n",
     "        re.index.name = pkey\n",
     "        return re\n",
-    "    re_idx = np.searchsorted(wit_ww[(wit_ww['WW'] < threshold)]['TIME'].values, \n",
-    "                             wit_ww[(wit_ww['WW'] >= threshold)]['TIME'].values)\n",
+    "    re_idx = np.searchsorted(wit_ww[(wit_ww['WW'] < poly_threshold)]['TIME'].values, \n",
+    "                             wit_ww[(wit_ww['WW'] >= poly_threshold)]['TIME'].values)\n",
     "    re_idx, count = np.unique(re_idx, return_counts=True)\n",
     "    start_idx = np.zeros(len(count)+1, dtype='int')\n",
     "    start_idx[1:] = np.cumsum(count)\n",
-    "    re_start = wit_ww[(wit_ww['WW'] >= threshold)].iloc[start_idx[:-1]][['TIME']].rename(columns={'TIME': 'start_time'})\n",
-    "    re_end = wit_ww[(wit_ww['WW'] >= threshold)].iloc[start_idx[1:] - 1][['TIME']].rename(columns={'TIME': 'end_time'})\n",
+    "    re_start = wit_ww[(wit_ww['WW'] >= poly_threshold)].iloc[start_idx[:-1]][['TIME']].rename(columns={'TIME': 'start_time'})\n",
+    "    re_end = wit_ww[(wit_ww['WW'] >= poly_threshold)].iloc[start_idx[1:] - 1][['TIME']].rename(columns={'TIME': 'end_time'})\n",
     "    re = pd.concat([re_start, re_end], axis=1)\n",
     "    re.insert(2, 'duration', \n",
     "              (re['end_time'] - re['start_time'] + np.timedelta64(1, 'D')).astype('timedelta64[D]').astype('timedelta64[D]'))\n",
@@ -372,7 +377,7 @@
    "outputs": [],
    "source": [
     "def all_time_median(wit_data, members=[['WATER', 'WET']], pkey='SYSID'):\n",
-    "        \"\"\"\n",
+    "    \"\"\"\n",
     "        Compute the all time median\n",
     "        input:\n",
     "            wit_data: dataframe of WIT\n",
@@ -386,6 +391,7 @@
     "    for m in members:\n",
     "        if isinstance(m, list):\n",
     "            wit_df.insert(wit_df.columns.size+i, '+'.join(m), wit_df[m].sum(axis=1))\n",
+    "        i += 1\n",
     "    return wit_df.groupby(pkey).median()"
    ]
   },
@@ -493,11 +499,8 @@
     "\n",
     "# compute event metrics with threshold_list then save the results to a csv\n",
     "# set the output file to your own path\n",
-    "wit_group = wit_data.groupby(pkey)\n",
-    "wit_im = pd.DataFrame()\n",
-    "for a, b in wit_group:\n",
-    "    tr = threshold_list.loc[a]\n",
-    "    wit_im = wit_im.append(inundation_metrics(b, wit_area, tr.to_numpy()[0], pkey=pkey), sort=False)\n",
+    "\n",
+    "wit_im =inundation_metrics(wit_data, wit_area, threshold_list, pkey=pkey)\n",
     "ofn = 'ANAE_inudation_metrics.csv'\n",
     "wit_im.to_csv(ofn)\n",
     "    \n",
@@ -532,7 +535,7 @@
     "**Contact:** If you need assistance, please post a question on the [Open Data Cube Slack channel](http://slack.opendatacube.org/) or on the [GIS Stack Exchange](https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions [here](https://gis.stackexchange.com/questions/tagged/open-data-cube)).\n",
     "If you would like to report an issue with this notebook, you can file one on [Github](https://github.com/GeoscienceAustralia/dea-notebooks).\n",
     "\n",
-    "**Last modified:** March 2021\n",
+    "**Last modified:** June 2021\n",
     "\n",
     "**Compatible datacube version:** "
    ]
@@ -567,18 +570,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/Scientific_workflows/Wetlands_Insight_Tool/metrics/wit_metrics.ipynb
+++ b/Scientific_workflows/Wetlands_Insight_Tool/metrics/wit_metrics.ipynb
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,6 +121,7 @@
     "            if count <= 0:\n",
     "                break\n",
     "    \n",
+    "#def get_areas(features, pkey='SYSID'):\n",
     "def get_areas(features, pkey='SYSID'):\n",
     "    \"\"\"\n",
     "        Calculate the area of a list/generator of shapes\n",
@@ -133,7 +134,6 @@
     "    for f in features:\n",
     "        va = pd.DataFrame([[f[0], geometry.shape(f[1]['geometry']).area/1e4]], columns=[pkey, 'area'])\n",
     "        re = re.append(va, sort=False)\n",
-    "    print(re)\n",
     "    return re.set_index(pkey)\n",
     "\n",
     "def dump_wit_data(key, feature_list, output):\n",
@@ -147,8 +147,6 @@
     "    \"\"\"\n",
     "    for f_id, f in feature_list:\n",
     "        _, wit_data = query_wit_data(f)\n",
-    "        if len(wit_data) == 0:\n",
-    "            continue\n",
     "        csv_buf = io.StringIO()\n",
     "        wit_df = pd.DataFrame(data=wit_data, columns=['TIME', 'BS', 'NPV', 'PV', 'WET', 'WATER'])\n",
     "        wit_df.insert(0, key, f_id)\n",
@@ -162,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +185,8 @@
     "            wit_df.insert(wit_df.columns.size+i, '+'.join(m), wit_df[m].sum(axis=1))\n",
     "    years = pd.DatetimeIndex(wit_df['TIME']).year.unique()\n",
     "    shape_id_list = wit_df[pkey].unique()\n",
-    "    wit_metrics = [pd.DataFrame()] * 4\n",
+    "    #shane changed 4 to 5 to accomodate median added below \n",
+    "    wit_metrics = [pd.DataFrame()] * 5\n",
     "    for y in years:\n",
     "        wit_yearly = wit_df[pd.DatetimeIndex(wit_df['TIME']).year==y].drop(columns=['TIME']).groupby(pkey).max()\n",
     "        wit_yearly.insert(0, 'YEAR', y)\n",
@@ -203,11 +202,21 @@
     "        wit_yearly.insert(0, 'YEAR', y)\n",
     "        wit_yearly = wit_yearly.rename(columns={n: n+'_mean' for n in wit_yearly.columns[1:]})\n",
     "        wit_metrics[2] = wit_metrics[2].append(wit_yearly, sort=False)\n",
+    "        \n",
+    "    #*********************** START ADDED BY SHANE ***********************\n",
+    "    #adding median\n",
+    "    for y in years:\n",
+    "        wit_yearly = wit_df[pd.DatetimeIndex(wit_df['TIME']).year==y].drop(columns=['TIME']).groupby(pkey).median()\n",
+    "        wit_yearly.insert(0, 'YEAR', y)\n",
+    "        wit_yearly = wit_yearly.rename(columns={n: n+'_median' for n in wit_yearly.columns[1:]})\n",
+    "        wit_metrics[3] = wit_metrics[3].append(wit_yearly, sort=False)\n",
+    "    #*********************** END ADDED BY SHANE ***********************      \n",
     "    for y in years:\n",
     "        wit_yearly = wit_df[pd.DatetimeIndex(wit_df['TIME']).year==y][[pkey, 'BS']].groupby(pkey).count()\n",
     "        wit_yearly.insert(0, 'YEAR', y)\n",
     "        wit_yearly = wit_yearly.rename(columns={n: 'count' for n in wit_yearly.columns[1:]})\n",
-    "        wit_metrics[3] = wit_metrics[3].append(wit_yearly, sort=False)\n",
+    "        #shane changed index from 3 to 4 to accomodate median added above \n",
+    "        wit_metrics[4] = wit_metrics[4].append(wit_yearly, sort=False)\n",
     "    for t in threshold:\n",
     "        wit_df_ts = wit_df.copy(deep=True)\n",
     "        wit_metrics += [pd.DataFrame()]\n",
@@ -226,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,6 +363,30 @@
     "    daily_wit.loc[nidx, [\"BS\",\"NPV\",\"PV\",\"WET\",\"WATER\"]]  = grouped_wit[[\"BS\",\"NPV\",\"PV\",\"WET\",\"WATER\"]].iloc[oidx].to_numpy()\n",
     "    daily_wit = daily_wit.interpolate(axis=0)\n",
     "    return daily_wit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def all_time_median(wit_data, members=[['WATER', 'WET']], pkey='SYSID'):\n",
+    "        \"\"\"\n",
+    "        Compute the all time median\n",
+    "        input:\n",
+    "            wit_data: dataframe of WIT\n",
+    "            members: the elements which the metrics are computed against, can be a column from wit_data, e.g. 'PV'\n",
+    "                         or the sum of wit columns, e.g. ['WATER', 'WET']\n",
+    "        output:\n",
+    "            dataframe of median indexed by pkey\n",
+    "    \"\"\"\n",
+    "    wit_df = wit_data.copy(deep=True)\n",
+    "    i = 0\n",
+    "    for m in members:\n",
+    "        if isinstance(m, list):\n",
+    "            wit_df.insert(wit_df.columns.size+i, '+'.join(m), wit_df[m].sum(axis=1))\n",
+    "    return wit_df.groupby(pkey).median()"
    ]
   },
   {
@@ -374,9 +407,9 @@
     "# fid_file: a file with all the ids needed to locate polygons in the shape file\n",
     "# shapefile: the shape file mentioned above to find the polygons\n",
     "# wit_data_file: a csv with wit data dumped from the database\n",
-    "fid_file = \"/g/data/u46/users/ea6141/wlinsight/ANAE_test_SYSID.csv\"\n",
-    "shapefile = '/g/data/r78/DEA_Wetlands/shapefiles/MDB_ANAE_Aug2017_modified_2019_SB_3577.shp'\n",
-    "wit_data_file = '/g/data/u46/users/ea6141/wlinsight/ANAE_test_wit.csv'"
+    "fid_file = './example_data/ramsar_REFCODE.csv'\n",
+    "shapefile = './example_data/ramsar_wetlands_3577_20190403.shp'\n",
+    "wit_data_file = './example_data/ramsar_wit.csv'"
    ]
   },
   {
@@ -387,7 +420,8 @@
    "source": [
     "# change pkey to match the key of iding polygon\n",
     "# e.g. pkey = 'REFCODE' if using the files in example_data\n",
-    "pkey = 'SYSID'\n",
+    "#pkey = 'SYSID'\n",
+    "pkey = 'REFCODE'\n",
     "features = shape_list(pkey, pd.read_csv(fid_file, header=None).values, shapefile)\n",
     "####################################################################################\n",
     "# This section is to dump the WIT data from database to a csv, DO NOT do this unless:\n",
@@ -398,13 +432,13 @@
     "# load all the wit data required from the database and save them to a csv file\n",
     "if load_from_db:\n",
     "    dump_wit_data(pkey, features, wit_data_file)\n",
-    "    features = shape_list(pkey, pd.read_csv(fid_file, header=None).values, shapefile)\n",
     "####################################################################################\n",
     "# get the area of polygons\n",
     "wit_area = get_areas(features, pkey=pkey)\n",
     "# load wit data into a pandas dataframe\n",
     "wit_data = pd.read_csv(wit_data_file, header=None, skipfooter=1, \n",
-    "                       names=[pkey,\"TIME\",\"BS\",\"NPV\",\"PV\",\"WET\",\"WATER\"])"
+    "                       names=[pkey,\"TIME\",\"BS\",\"NPV\",\"PV\",\"WET\",\"WATER\"]\n",
+    "                      )"
    ]
   },
   {
@@ -416,8 +450,22 @@
     "# compute yearly metrics and save the results to a csv\n",
     "# set the output file to your own path\n",
     "wit_yearly_metrics = annual_metrics(wit_data, pkey=pkey)\n",
-    "ofn = \"/g/data/u46/users/ea6141/wlinsight/Barmah_Ramsar_yearly_metrics.csv\" \n",
+    "ofn = \"ANAE_yearly_metrics.csv\"\n",
     "wit_yearly_metrics.to_csv(ofn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute all time median, serve as the threshold\n",
+    "# save the threshold in a csv, set the output file to your own path\n",
+    "wit_median = all_time_median(wit_data, pkey=pkey)\n",
+    "threshold_list = wit_median[['WATER+WET']]\n",
+    "ofn = \"ANAE_event_threshold.csv\"\n",
+    "threshold_list.to_csv(ofn)"
    ]
   },
   {
@@ -428,18 +476,45 @@
    },
    "outputs": [],
    "source": [
-    "# compute inundation metrics with given metrics\n",
-    "# change the element in threshold_list if after the inundation event defined by different threshold\n",
-    "threshold_list = [0.01, 0.25, 0.75]\n",
-    "# interpolate wit data in daily frequency\n",
-    "wit_data = wit_data.groupby(pkey).apply(interpolate_wit, pkey=pkey).droplevel(0)\n",
-    "for tr in threshold_list:\n",
-    "    print(\"compute threshold\", tr)\n",
-    "    wit_im = inundation_metrics(wit_data, wit_area, tr, pkey=pkey)\n",
-    "    # save the metrics into a csv file\n",
-    "    # set the file to your own path\n",
-    "    ofn = '/g/data/u46/users/ea6141/wlinsight/Barmah_Ramsar_inundation_metrics_T' + \"%d\"%(tr*100) + '.csv'    \n",
-    "    wit_im.to_csv(ofn)\n",
+    "maxdate = pd.pivot_table(wit_data, index=pkey, values=['TIME'], aggfunc=np.max)\n",
+    "maxdate['TIME'] = maxdate['TIME'].astype('datetime64')\n",
+    "\n",
+    "# optional read in threshold_list had it been changed outside of the notebook\n",
+    "# threshold_list = pd.read_csv('ANAE_event_threshold.csv', index_col=0)\n",
+    "# here we'll use the threshold_list computed in the cell above\n",
+    "\n",
+    "\"\"\" \n",
+    "    interpolate wit data in daily frequency\n",
+    "    comment this out for now as data volume crashes sandbox\n",
+    "    note should be able to adjust event metrics calculations\n",
+    "    to use linear estimation of time pre- and post- events.\n",
+    "\"\"\"\n",
+    "#wit_data = wit_data.groupby(pkey).apply(interpolate_wit, pkey=pkey).droplevel(0)\n",
+    "\n",
+    "# compute event metrics with threshold_list then save the results to a csv\n",
+    "# set the output file to your own path\n",
+    "wit_group = wit_data.groupby(pkey)\n",
+    "wit_im = pd.DataFrame()\n",
+    "for a, b in wit_group:\n",
+    "    tr = threshold_list.loc[a]\n",
+    "    wit_im = wit_im.append(inundation_metrics(b, wit_area, tr.to_numpy()[0], pkey=pkey), sort=False)\n",
+    "ofn = 'ANAE_inudation_metrics.csv'\n",
+    "wit_im.to_csv(ofn)\n",
+    "    \n",
+    "#*********************** START ADDED BY SHANE ***********************\n",
+    "# create a pivot table to gather the time since last inundation using the event metrics\n",
+    "# and export as csv\n",
+    "# timesincelast = number of days from last event end-date to final date in WIT record\n",
+    "lastevent = pd.pivot_table(wit_im, index=pkey, values=['end_time'], aggfunc=np.max)\n",
+    "#lastevent['end_time']=lastevent['end_time'].astype('datetime64')\n",
+    "time_since_last = pd.merge(maxdate, lastevent, on=[pkey], how='inner')\n",
+    "time_since_last.insert(2, 'timesincelast', \n",
+    "          (time_since_last['TIME'] - time_since_last['end_time']).astype('timedelta64[D]'))\n",
+    "ofn = 'ANAE_time_since_last_inundation.csv'\n",
+    "time_since_last.to_csv(ofn)\n",
+    "#*********************** END ADDED BY SHANE ***********************\n",
+    "    \n",
+    "    \n",
     "print(\"all done!!!\")"
    ]
   },
@@ -457,7 +532,7 @@
     "**Contact:** If you need assistance, please post a question on the [Open Data Cube Slack channel](http://slack.opendatacube.org/) or on the [GIS Stack Exchange](https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions [here](https://gis.stackexchange.com/questions/tagged/open-data-cube)).\n",
     "If you would like to report an issue with this notebook, you can file one on [Github](https://github.com/GeoscienceAustralia/dea-notebooks).\n",
     "\n",
-    "**Last modified:** April 2021\n",
+    "**Last modified:** March 2021\n",
     "\n",
     "**Compatible datacube version:** "
    ]
@@ -503,7 +578,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.4"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
### Proposed changes
Individually threshold the inundation event in wit metrics

### Closes issues (optional)
N/A

### Checklist (replace `[ ]` with `[x]` to check off)
- [x] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [x] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [x] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


