### PR TITLE
Remove requirements installation from publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Build dea-tools
         run: |
             cd Tools
-            pip install -r requirements.txt
             pip install . --use-feature=in-tree-build
             python -c "import dea_tools; print(dea_tools.__version__)"
 


### PR DESCRIPTION
Forgot that there's no requirements file for tools... whoops.