### PR TITLE
Fix image export for Sentinel-2 NRT

### DIFF
--- a/Supplementary_data/notebookapp_imageexport.py
+++ b/Supplementary_data/notebookapp_imageexport.py
@@ -267,9 +267,14 @@ def export_image_app(geopolygon,
     ]
     dss = list(itertools.chain.from_iterable(dss))
 
-    # Get CRS and sensor
+    # Get CRS
     crs = str(dss[0].crs)
-    sensor = dss[0].metadata_doc['properties']['eo:platform'].capitalize()
+    
+    # Get sensor (try/except to account for different S2 NRT metadata)
+    try:
+        sensor = dss[0].metadata_doc['properties']['eo:platform'].capitalize()
+    except: 
+        sensor = dss[0].metadata_doc['platform']['code'].capitalize()
     sensor = sensor[0:-1].replace('_', '-') + sensor[-1].capitalize()
 
     # Meets pansharpening requirements


### PR DESCRIPTION
### Proposed changes
Sentinel-2 NRT uses a different metadata format than Sentinel-2 Definitive, so the tool currently breaks with `satellites='Sentinel-2 NRT'`. This fixes this bug using a try/except to catch the different metadata fields.
