### PR TITLE
Update warnings

### DIFF
--- a/Tools/dea_tools/bandindices.py
+++ b/Tools/dea_tools/bandindices.py
@@ -302,8 +302,8 @@ def calculate_indices(ds,
                               "refer to the function \ndocumentation for a full "
                               "list of valid options for `index` (e.g. 'NDVI')")
 
-        elif (index in ['WI', 'BAEI', 'AWEI_ns', 'AWEI_sh', 'TCW', 
-                        'TCG', 'TCB', 'TCW_GSO', 'TCG_GSO', 'TCB_GSO', 
+        elif (index in ['WI', 'BAEI', 'AWEI_ns', 'AWEI_sh',
+                        'TCW_GSO', 'TCG_GSO', 'TCB_GSO', 
                         'EVI', 'LAI', 'SAVI', 'MSAVI'] 
               and not normalise):
 

--- a/Tools/dea_tools/bandindices.py
+++ b/Tools/dea_tools/bandindices.py
@@ -303,7 +303,6 @@ def calculate_indices(ds,
                               "list of valid options for `index` (e.g. 'NDVI')")
 
         elif (index in ['WI', 'BAEI', 'AWEI_ns', 'AWEI_sh',
-                        'TCW_GSO', 'TCG_GSO', 'TCB_GSO', 
                         'EVI', 'LAI', 'SAVI', 'MSAVI'] 
               and not normalise):
 


### PR DESCRIPTION
Remove warning where Tasselled cap indices for landsat are not normalised. This addresses issue #877

took the TCW, TCB and TCG out of the warning in bandindices.py

### Closes issues (optional)
- Closes Issue #877 