### PR TITLE
Pin pip to allow build Action to work

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
             python3 -m pip install setuptools_scm build
             python3 -m setuptools_scm
             cd Tools
-            python3 -m pip install --upgrade pip
+            python3 -m pip install pip==22.0.4
             python3 -m pip install --use-feature=in-tree-build --no-deps .
             python3 -c "import dea_tools; print(dea_tools.__version__)"
             python3 -m build


### PR DESCRIPTION
### Proposed changes
The `publish` workflow has recently started failing with error: 
```
option --use-feature: invalid choice: 'in-tree-build' (choose from '2020-resolver', 'fast-deps')
Error: Process completed with exit code 2.
```

This appears to be because the workflow [upgrades Pip to the latest version](https://github.com/GeoscienceAustralia/dea-notebooks/blob/develop/.github/workflows/publish.yml#L31), which has deprecated `in-tree-build` ([see here](https://pip.pypa.io/en/stable/news/#deprecations-and-removals)).

Testing a simple solution to pin Pip to an earlier version.
