### PR TITLE
Fix failed Dask worker pod launch due to invalid username characters

### DIFF
--- a/Tools/dea_tools/dask.py
+++ b/Tools/dea_tools/dask.py
@@ -21,7 +21,7 @@ Functions included:
     create_local_dask_cluster
     create_dask_gateway_cluster
 
-Last modified: March 2020
+Last modified: June 2022
 
 '''
 
@@ -111,6 +111,15 @@ try:
         """
         try:
             gateway = Gateway()
+            
+            # Close any existing clusters
+            cluster_names = gateway.list_clusters()
+            if len(cluster_names) > 0:
+                print("Cluster(s) still running:", cluster_names)
+                for n in cluster_names:
+                    cluster = gateway.connect(n.name)
+                    cluster.shutdown()            
+            
             options = gateway.cluster_options()
             options['profile'] = profile
 

--- a/Tools/dea_tools/dask.py
+++ b/Tools/dea_tools/dask.py
@@ -113,7 +113,11 @@ try:
             gateway = Gateway()
             options = gateway.cluster_options()
             options['profile'] = profile
-            options['jupyterhub_user'] = os.getenv('JUPYTERHUB_USER')
+
+            # limit username to alphanumeric characters
+            # kubernetes pods won't launch if labels contain anything other than [a-Z, -, _]
+            options['jupyterhub_user'] = ''.join(c if c.isalnum() else '-' for c in os.getenv('JUPYTERHUB_USER'))
+
             cluster = gateway.new_cluster(options)
             cluster.scale(workers)
             return cluster


### PR DESCRIPTION
Since we've moved to using email addresses in Cognito, this code is now passing `@` symbols into the Kubernetes worker pod and causing it to fail to create.

> Failed to create pod in namespace sandbox - Pod "dask-worker-935744a16ab74944bff079717a6a5ba0-ls628" is invalid: metadata.labels: Invalid value: "jonathan.mettes@ga.gov.au": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')

Restrict `jupyterhub_user` parameter to alphanumeric characters.