### PR TITLE
remove unused import of write_geotiff

### DIFF
--- a/Tools/dea_tools/spatial.py
+++ b/Tools/dea_tools/spatial.py
@@ -45,7 +45,6 @@ from rasterstats import zonal_stats
 from skimage.measure import find_contours
 from geopy.geocoders import Nominatim
 from datacube.utils.cog import write_cog
-from datacube.helpers import write_geotiff
 from datacube.utils.geometry import assign_crs
 from datacube.utils.geometry import CRS, Geometry
 from shapely.geometry import LineString, MultiLineString, shape


### PR DESCRIPTION
Fix import error introduced by recent commit in datacube-core/develop [https://github.com/opendatacube/datacube-core/commit/c84da04e0a81a32d269c1bece19ae649d11b2d44] .

### Proposed changes
Import of dea_tools.spatial raises "ImportError: cannot import name 'write_geotiff' from'datacube.helpers'".
Exception introduced by recent [commit](https://github.com/opendatacube/datacube-core/commit/c84da04e0a81a32d269c1bece19ae649d11b2d44) in datacube-core/develop. 

**_May_** depend on which branch of datacube-core an environment is using. 
For us on CSIRO EASI we are on datacube-core/develop. Package 1.8.7.dev0

### Closes issues (optional)
- Closes Issue #929

### Checklist (replace `[ ]` with `[x]` to check off)
N/A - no notebook edits. Only changes to dea_tools module source. 


