### PR TITLE
Fix missing function import in `pixel_tides`

### DIFF
--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -38,10 +38,12 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 from scipy import stats
-import odc.algo
-from datacube.utils.geometry import CRS
 from shapely.geometry import box, shape
 from owslib.wfs import WebFeatureService
+
+import odc.algo
+from datacube.utils.geometry import CRS
+from dea_tools.datahandling import parallel_apply
 
 try:
     from otps import TimePoint


### PR DESCRIPTION
### Proposed changes
This PR fixes a missing import of the `parallel_apply` function from `dea_tools.datahandling`, which is currently needed for the `pixel_tides` function to work.

Once merged I'll have to release a quick new package version and do another `develop` to `stable` PR.


