### PR TITLE
Update DEA Tools to support autodocs generation in the User Guide

### DIFF
--- a/Tools/dea_tools/bandindices.py
+++ b/Tools/dea_tools/bandindices.py
@@ -1,8 +1,8 @@
-## dea_bandindices.py
 '''
-Description: This file contains a set of python functions for computing
-remote sensing band indices on Digital Earth Australia data.
+Calculating remote sensing band indices (e.g. NDVI, NDWI)
+'''
 
+'''
 License: The code in this notebook is licensed under the Apache License,
 Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth
 Australia data is licensed under the Creative Commons by Attribution 4.0
@@ -18,7 +18,6 @@ If you would like to report an issue with this script, you can file one
 on Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 
 Last modified: March 2021
-
 '''
 
 # Import required packages

--- a/Tools/dea_tools/bandindices.py
+++ b/Tools/dea_tools/bandindices.py
@@ -1,8 +1,6 @@
 '''
-Calculating remote sensing band indices (e.g. NDVI, NDWI)
-'''
+Calculating band indices from remote sensing data (NDVI, NDWI etc).
 
-'''
 License: The code in this notebook is licensed under the Apache License,
 Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth
 Australia data is licensed under the Creative Commons by Attribution 4.0

--- a/Tools/index.rst
+++ b/Tools/index.rst
@@ -22,7 +22,6 @@ Core modules
    dea_tools.datahandling
    dea_tools.landcover
    dea_tools.plotting
-   dea_tools.segmentation
    dea_tools.spatial
    dea_tools.temporal
    dea_tools.waterbodies

--- a/Tools/index.rst
+++ b/Tools/index.rst
@@ -7,12 +7,41 @@ Australia Sandbox environment. More information on installing this package can b
 <https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop/Tools/>`_ section of the GitHub repository.
 
 Core modules
------------------
+------------
 
 .. autosummary::
    :toctree: gen
 
    dea_tools.datahandling
+   dea_tools.bandindices
+   dea_tools.bom
+   dea_tools.classification
+   dea_tools.climate
+   dea_tools.coastal
+   dea_tools.dask
+   dea_tools.datahandling
+   dea_tools.landcover
+   dea_tools.plotting
+   dea_tools.segmentation
+   dea_tools.spatial
+   dea_tools.temporal
+   dea_tools.waterbodies
+   
+Apps and widgets
+-----------------
+
+``dea_tools`` interactive app sub-packages can be accessed through ``dea_tools.app``.
+
+.. autosummary::
+   :toctree: gen
+   
+   dea_tools.app.animations
+   dea_tools.app.changefilmstrips
+   dea_tools.app.crophealth
+   dea_tools.app.deacoastlines
+   dea_tools.app.imageexport
+   dea_tools.app.miningrehab
+   dea_tools.app.widgetconstructors
 
 License
 -------


### PR DESCRIPTION
### Proposed changes
The PR here (https://github.com/GeoscienceAustralia/dea-docs/pull/30) will enable us to render functions and modules from DEA Tools into the DEA User Guide as a read-the-docs API, e.g.:

![image](https://user-images.githubusercontent.com/17680388/185333680-76f9c1b2-baa0-45fe-acd5-0d042bdd8968.png)
![image](https://user-images.githubusercontent.com/17680388/185333726-62750492-6b4f-4269-856d-68851b416979.png)

This PR expands the current placeholder index file in DEA Tools to add additional modules to the read-the-docs, copying [a similar approach to DEA Africa here](https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/blob/main/Tools/index.rst). This should add all our functions to the User Guide when it's merged.

Next steps after this might be to browse the automatically generated docs and check if there's any docstrings in DEA Tools that we want to fix up to improve how it's rendered in the User Guide!

