### PR TITLE
Update spatial.py to add missing imports

### DIFF
--- a/Tools/dea_tools/spatial.py
+++ b/Tools/dea_tools/spatial.py
@@ -35,12 +35,14 @@ Last modified: August 2022
 '''
 
 # Import required packages
+import fiona
 import collections
 import numpy as np
 import xarray as xr
 import geopandas as gpd
 import rasterio.features
 import scipy.interpolate
+import multiprocessing as mp
 from scipy import ndimage as nd
 from skimage.measure import label
 from rasterstats import zonal_stats
@@ -49,7 +51,7 @@ from geopy.geocoders import Nominatim
 from datacube.utils.cog import write_cog
 from datacube.utils.geometry import assign_crs
 from datacube.utils.geometry import CRS, Geometry
-from shapely.geometry import LineString, MultiLineString, shape
+from shapely.geometry import LineString, MultiLineString, shape, mapping
 
 def xr_vectorize(da, 
                  attribute_col='attribute', 


### PR DESCRIPTION
### Proposed changes
`pylint` suggests we are missing the following imports from `dea_tools.spatial:`

```
Tools/dea_tools/.ipynb_checkpoints/spatial-checkpoint.py:838:13: E0602: Undefined variable 'fiona' (undefined-variable)
Tools/dea_tools/.ipynb_checkpoints/spatial-checkpoint.py:842:74: E0602: Undefined variable 'mapping' (undefined-variable)
Tools/dea_tools/.ipynb_checkpoints/spatial-checkpoint.py:844:9: E0602: Undefined variable 'fiona' (undefined-variable)
Tools/dea_tools/.ipynb_checkpoints/spatial-checkpoint.py:849:14: E0602: Undefined variable 'mp' (undefined-variable)
Tools/dea_tools/.ipynb_checkpoints/spatial-checkpoint.py:850:8: C0103: Variable name "d" doesn't conform to snake_case naming style (invalid-name)
Tools/dea_tools/.ipynb_checkpoints/spatial-checkpoint.py:855:12: C0103: Variable name "z" doesn't conform to snake_case naming style (invalid-name)
Tools/dea_tools/.ipynb_checkpoints/spatial-checkpoint.py:856:12: C0103: Variable name "p" doesn't conform to snake_case naming style (invalid-name)
Tools/dea_tools/.ipynb_checkpoints/spatial-checkpoint.py:856:16: E0602: Undefined variable 'mp' (undefined-variable)
```

This PR adds them to see if they help building the docs.
