### PR TITLE
Add try to account for different param names in different versions of `pyTMD`

### DIFF
--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -809,7 +809,8 @@ def model_tides(
     tide = np.ma.zeros((npts), fill_value=np.nan)
     tide.mask = np.any(hc.mask, axis=1)
     
-    # Depending on pyTMD version (<=1.06 vs > 1.06), use different params:
+    # Depending on pyTMD version (<=1.06 vs > 1.06), use different params
+    # TODO: Remove once Sandbox is updated to use pyTMD version 1.0.9
     try:
         tide.data[:] = predict_tide_drift(t, hc, c, deltat=deltat, corrections=model.format)
         minor = infer_minor_corrections(t, hc, c, deltat=deltat, corrections=model.format)

--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -808,8 +808,14 @@ def model_tides(
     npts = len(t)
     tide = np.ma.zeros((npts), fill_value=np.nan)
     tide.mask = np.any(hc.mask, axis=1)
-    tide.data[:] = predict_tide_drift(t, hc, c, DELTAT=deltat, CORRECTIONS=model.format)
-    minor = infer_minor_corrections(t, hc, c, DELTAT=deltat, CORRECTIONS=model.format)
+    
+    # Depending on pyTMD version (<=1.06 vs > 1.06), use different params:
+    try:
+        tide.data[:] = predict_tide_drift(t, hc, c, deltat=deltat, corrections=model.format)
+        minor = infer_minor_corrections(t, hc, c, deltat=deltat, corrections=model.format)
+    except:
+        tide.data[:] = predict_tide_drift(t, hc, c, DELTAT=deltat, CORRECTIONS=model.format)
+        minor = infer_minor_corrections(t, hc, c, DELTAT=deltat, CORRECTIONS=model.format)
     tide.data[:] += minor.data[:]
 
     # Replace invalid values with fill value


### PR DESCRIPTION
Recent changes to the `pyTMD` tide modelling function have changed the parameter format of certain functions from CAPITAL CASE to lower_case params.


### Proposed changes
This PR accounts for this by adding a try/except to the `model_tides` function.



