### PR TITLE
Split Spectral bands cell and fix broken Figure 1 link

### DIFF
--- a/Beginners_guide/02_DEA.ipynb
+++ b/Beginners_guide/02_DEA.ipynb
@@ -91,15 +91,20 @@
     "\n",
     "Landsat missions are jointly operated by the United States Geological Survey (USGS) and National Aeronautics and Space Administration (NASA).\n",
     "Sentinel missions are operated by the European Space Agency (ESA).\n",
-    "One major difference between the two programs is the spatial resolution: each Landsat pixel represents 30 x 30 m on the ground while each Sentinel-2 pixel represents 10 x 10 m to 60 x 60 m depending on the spectral band.\n",
-    "\n",
+    "One major difference between the two programs is the spatial resolution: each Landsat pixel represents 30 x 30 m on the ground while each Sentinel-2 pixel represents 10 x 10 m to 60 x 60 m depending on the spectral band."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Spectral bands\n",
     "All of the datasets listed above are captured by multispectral satellites.\n",
     "This means that the satellites measure primarily light that is reflected from the Earth's surface in discrete sections of the electromagnetic spectrum, known as *spectral bands*. \n",
     "Figure 1 shows the spectral bands for recent Landsat and Sentinel-2 sensors, allowing a direct comparison of how each sensor samples the overall electromagnetic spectrum.\n",
     "Landsat 5 TM is not displayed in this image; for reference, it measured light in seven bands that covered the same regions as bands 1 to 7 on Landsat 7 ETM+.\n",
     "\n",
-    "![Image](https://prd-wret.s3-us-west-2.amazonaws.com/assets/palladium/production/s3fs-public/styles/full_width/public/thumbnails/image/dmidS2LS7Comparison.png)\n",
+    "![Image](https://www.eoportal.org/ftp/satellite-missions/l/Landsat9_180722/Landsat9_Auto2E.jpeg)\n",
     "\n",
     "> **Figure 1:** The bands that are detected by each of the satellites are shown in the numbered boxes and the width of each box represents the spectral range that band detects.\n",
     "The bands are overlaid on the percentage transmission of each wavelength returned to the atmosphere from the Earth relative to the amount of incoming solar radiation. \n",
@@ -336,7 +341,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
### Proposed changes
1. I split the 'Spectral bands' cell into a separate cell to improve readability through better segregation by topic.
2. I added a new link for Figure 1 as the old link was broken for me.

### Checklist (replace `[ ]` with `[x]` to check off)
- [N/A] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [N/A] Remove any unused Python packages from `Load packages`
- [N/A] Remove any unused/empty code cells
- [N/A] Remove any guidance cells (e.g. `General advice`)
- [N/A] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [N/A] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [N/A] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [N/A] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with