### PR TITLE
Update image export code to use correct S2 provisional product name

### DIFF
--- a/Real_world_examples/Exporting_satellite_images.ipynb
+++ b/Real_world_examples/Exporting_satellite_images.ipynb
@@ -124,7 +124,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7de962ded78c44b2afe383aba548cd13",
+       "model_id": "b15cda0e1fb043dfa9ad7ed8f20bb910",
        "version_major": 2,
        "version_minor": 0
       },
@@ -207,7 +207,7 @@
     "**Contact:** If you need assistance, please post a question on the [Open Data Cube Slack channel](http://slack.opendatacube.org/) or on the [GIS Stack Exchange](https://gis.stackexchange.com/questions/ask?tags=open-data-cube) using the `open-data-cube` tag (you can view previously asked questions [here](https://gis.stackexchange.com/questions/tagged/open-data-cube)).\n",
     "If you would like to report an issue with this notebook, you can file one on [Github](https://github.com/GeoscienceAustralia/dea-notebooks).\n",
     "\n",
-    "**Last modified:** February 2022\n",
+    "**Last modified:** October 2022\n",
     "\n",
     "**Compatible datacube version:** "
    ]

--- a/Tools/dea_tools/app/imageexport.py
+++ b/Tools/dea_tools/app/imageexport.py
@@ -70,7 +70,7 @@ sat_params = {
                              ['nbart_swir_2', 'nbart_nir_1', 'nbart_green'])
         }
     },
-    'ga_s2m_ard_provisional_3_nbar_t': {
+    's2_nrt_provisional_granule_nbar_t': {
         'products': ['ga_s2am_ard_provisional_3', 'ga_s2bm_ard_provisional_3'],
         'styles': {
             'True colour':
@@ -365,7 +365,7 @@ class imageexport_app(HBox):
         self.dealayer_list = [
             ("Landsat", 'ga_ls_ard_3'),
             ("Sentinel-2", 's2_ard_granule_nbar_t'),
-            ("Sentinel-2 NRT", 'ga_s2m_ard_provisional_3_nbar_t'),
+            ("Sentinel-2 NRT", 's2_nrt_provisional_granule_nbar_t'),
         ]
         self.dealayer = self.dealayer_list[0][1]
 


### PR DESCRIPTION
### Proposed changes
This PR makes a simple fix to update the Sentinel-2 provisional OWS product name to its correct value, in order to make the data appear on the interactive map in the `Exporting_satellite_imagery.ipynb` notebook.

To test, run the `Exporting_satellite_imagery.ipynb` notebook, then select "Sentinel-2 NRT" and the 17th October 2022 from the date dropdown in the interactive app. Provisional Sentinel-2 data should appear on the map.

### Closes issues (optional)
- Closes Issue #963 
