### PR TITLE
Update of tide model paths to match new EFS location

### DIFF
--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -581,7 +581,7 @@ def model_tides(
     y,
     time,
     model="FES2014",
-    directory="~/tide_models",
+    directory="/var/share/tide_models",
     epsg=4326,
     method="bilinear",
     extrapolate=True,
@@ -840,7 +840,7 @@ def pixel_tides(
     buffer=12000,
     resample_method="bilinear",
     model="FES2014",
-    directory="~/tide_models",
+    directory="/var/share/tide_models",
 ):
     """
     Obtain tide heights for each pixel in a dataset by modelling


### PR DESCRIPTION
### Proposed changes
Another update of the tide modelling file path in `model_tides` and `pixel_tides` to account for the new location of tide modelling files on the EFS path `/var/shared/tide_models`.

Have tested this on the dev Sandbox and the code works correctly.
