### PR TITLE
Skip broken provisional datasets

### DIFF
--- a/Tools/dea_tools/app/animations.py
+++ b/Tools/dea_tools/app/animations.py
@@ -163,6 +163,7 @@ def extract_data(self):
             "group_by": "solar_day",
             "dask_chunks": {"time": 1, "x": 2048, "y": 2048},
             "resampling": {"*": "cubic", "oa_fmask": "nearest", "fmask": "nearest"},
+            "skip_broken_datasets": True,
         }
 
         # Load data

--- a/Tools/dea_tools/app/imageexport.py
+++ b/Tools/dea_tools/app/imageexport.py
@@ -203,8 +203,8 @@ def extract_data(self):
                 'measurements':
                     sat_params[self.dealayer]['styles'][self.style][1],
                 'resolution': (-self.resolution, self.resolution),
-                'output_crs':
-                    crs
+                'output_crs': crs,
+                'skip_broken_datasets': True,
             }
 
         # Load data from datasets


### PR DESCRIPTION
### Proposed changes
Our Sentinel-2 provisional data currently fails to load for certain queries on the Sandbox due to the source data being deleted on s3 at 90 days, before the actual datacube datasets themselves are archived. This produces a
```
Error opening source dataset: s3://dea-public-data/baseline/ga_s2bm_ard_provisional_3/53/LPG/2022/08/06_nrt/20220806T022157/ga_s2bm_oa_provisional_3-2-1_53LPG_2022-08-06_nrt_fmask.tif
```
error which causes the data load to fail.

This is apparently being fixed with the maturity concept, but in the meantime, this PR implements a band-aid fix of adding `'skip_broken_datasets': True` to our `dc.load` calls when accessing provisional data. 
