### PR TITLE
Add C3 data to and remove C1 data from test datacube

### DIFF
--- a/Tests/setup_test_datacube.sh
+++ b/Tests/setup_test_datacube.sh
@@ -13,7 +13,7 @@ for metadata_yaml in $(find ./dea-config/product_metadata -name '*.yaml'); do
 done
 
 # Index products we care about for dea-notebooks
-for prod_def_yaml in $(find ./dea-config/products -name '*.yaml' -regex '.*\(ga_ls7e_nbart_gm_cyear_3\|ga_ls8c_nbart_gm_cyear_3\|ga_ls_wo_3\|s2a_ard_granule\|s2b_ard_granule\|ga_ls5t_ard_3\|ga_ls7e_ard_3\|ga_ls8c_ard_3\|ga_ls_wo_fq_cyear_3\).*'); do
+for prod_def_yaml in $(find ./dea-config/products -name '*.yaml' -regex '.*\(ga_ls7e_nbart_gm_cyear_3\|ga_ls8c_nbart_gm_cyear_3\|ga_ls_wo_3\|ga_s2am_ard_3\|ga_s2bm_ard_3\|ga_ls5t_ard_3\|ga_ls7e_ard_3\|ga_ls8c_ard_3\|ga_ls_wo_fq_cyear_3\).*'); do
         datacube product add $prod_def_yaml
 done
 
@@ -29,25 +29,25 @@ s3-to-dc 's3://dea-public-data/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x49/y24
 s3-to-dc 's3://dea-public-data/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x49/y24/2014--P1Y/*.odc-metadata.yaml' --no-sign-request --skip-lineage 'ga_ls8c_nbart_gm_cyear_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x49/y24/2015--P1Y/*.odc-metadata.yaml' --no-sign-request --skip-lineage 'ga_ls8c_nbart_gm_cyear_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x49/y24/2016--P1Y/*.odc-metadata.yaml' --no-sign-request --skip-lineage 'ga_ls8c_nbart_gm_cyear_3'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2018-09-09/S2A_OPER_MSI_ARD_TL_EPAE_20180909T020622_A016787_T55LBD_N02.06/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2018-09-19/S2A_OPER_MSI_ARD_TL_EPAE_20180919T021041_A016930_T55LBD_N02.06/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2018-09-29/S2A_OPER_MSI_ARD_TL_EPAE_20180929T020742_A017073_T55LBD_N02.06/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2018-10-09/S2A_OPER_MSI_ARD_TL_EPAE_20181009T021157_A017216_T55LBD_N02.06/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2018-10-19/S2A_OPER_MSI_ARD_TL_EPAE_20181019T021416_A017359_T55LBD_N02.06/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2018-10-29/S2A_OPER_MSI_ARD_TL_EPAE_20181029T021107_A017502_T55LBD_N02.06/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2018-11-08/S2A_OPER_MSI_ARD_TL_EPAE_20181108T021044_A017645_T55LBD_N02.07/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2018-11-18/S2A_OPER_MSI_ARD_TL_EPAE_20181118T021103_A017788_T55LBD_N02.07/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2018-11-28/S2A_OPER_MSI_ARD_TL_EPAE_20181128T020701_A017931_T55LBD_N02.07/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-09-06/S2A_OPER_MSI_ARD_TL_EPAE_20200906T012214_A027197_T55HFA_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-09-06/S2A_OPER_MSI_ARD_TL_EPAE_20200906T012214_A027197_T55HFB_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-09-16/S2A_OPER_MSI_ARD_TL_EPAE_20200916T012052_A027340_T55HFA_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-09-16/S2A_OPER_MSI_ARD_TL_EPAE_20200916T012052_A027340_T55HFB_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-09-26/S2A_OPER_MSI_ARD_TL_EPAE_20200926T011940_A027483_T55HFA_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-09-26/S2A_OPER_MSI_ARD_TL_EPAE_20200926T011940_A027483_T55HFB_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-10-16/S2A_OPER_MSI_ARD_TL_EPAE_20201016T013401_A027769_T55HFA_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-10-16/S2A_OPER_MSI_ARD_TL_EPAE_20201016T013401_A027769_T55HFB_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-10-26/S2A_OPER_MSI_ARD_TL_EPAE_20201026T013415_A027912_T55HFA_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
-s3-to-dc 's3://dea-public-data/baseline/s2a_ard_granule/2020-10-26/S2A_OPER_MSI_ARD_TL_EPAE_20201026T013415_A027912_T55HFB_N02.09/*.odc-metadata.yaml' --no-sign-request --skip-lineage 's2a_ard_granule'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/LBD/2018/09/09/20180909T020622/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/LBD/2018/09/19/20180919T021041/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/LBD/2018/09/29/20180929T020742/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/LBD/2018/10/09/20181009T021157/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/LBD/2018/10/19/20181019T021416/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/LBD/2018/10/29/20181029T021107/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/LBD/2018/11/08/20181108T021044/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/LBD/2018/11/18/20181118T021103/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/LBD/2018/11/28/20181128T020701/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFA/2020/09/06/20200906T012214/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFB/2020/09/06/20200906T012214/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFA/2020/09/16/20200916T012052/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFB/2020/09/16/20200916T012052/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFA/2020/09/26/20200926T011940/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFB/2020/09/26/20200926T011940/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFA/2020/10/16/20201016T013401/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFB/2020/10/16/20201016T013401/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFA/2020/10/26/20201026T013415/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
+s3-to-dc 's3://dea-public-data/baseline/ga_s2am_ard_3/55/HFB/2020/10/26/20201026T013415/*.json' --no-sign-request --skip-lineage --stac 'ga_s2am_ard_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_fq_cyear_3/1-6-0/x37/y19/2000--P1Y/*.odc-metadata.yaml' --no-sign-request --skip-lineage 'ga_ls_wo_fq_cyear_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_fq_cyear_3/1-6-0/x37/y20/2000--P1Y/*.odc-metadata.yaml' --no-sign-request --skip-lineage 'ga_ls_wo_fq_cyear_3'
 s3-to-dc 's3://dea-public-data/derivative/ga_ls_wo_fq_cyear_3/1-6-0/x38/y19/2000--P1Y/*.odc-metadata.yaml' --no-sign-request --skip-lineage 'ga_ls_wo_fq_cyear_3'


### PR DESCRIPTION
The test datacube needs to index C3 data to test the notebooks update to C3 data ([PR #972](https://github.com/GeoscienceAustralia/dea-notebooks/pull/972)). I have confirmed that the new indexed scenes exist.


