### PR TITLE
Add `GDAL_HTTP_MAX_RETRY` to DEA Notebooks tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
        - AWS_ACCESS_KEY_ID=fake_id
        - AWS_SECRET_ACCESS_KEY=fake_key
        - AWS_NO_SIGN_REQUEST=YES
+       - GDAL_HTTP_MAX_RETRY=3
      depends_on:
         - postgres
      entrypoint: bash -c 'sleep infinity'


### PR DESCRIPTION
### Proposed changes
Based on advice from @emmaai, this adds an automatic retry to the `docker-compose` file that sets up our DEA Notebooks tests. This should help prevent our entire test suite from failing due to sporadic/unpredictable errors caused by making too many requests to S3.