### PR TITLE
simplify the test workflow

### DIFF
--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Set up Datacube and Test
       run: |
         sudo chown -R 1000:100 ./dea-notebooks
+        cd ./dea-notebooks 
         CURRENT_UID=1000:100 docker-compose up -d
         docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
         docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -11,28 +11,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Set up containers
+    - name: Set up Datacube and Test
       run: |
         docker-compose up -d
-    - name: Set up Datacube
-      run: |
-        docker-compose exec -T index setup_test_datacube.sh
-        docker-compose exec -T index datacube product list
-    - name: Test with pytest
-      run: |
-        # First copy DEA Notebooks into the home directory where it lives in the Sandbox
-        docker-compose exec -T sandbox cp -r /dea-notebooks /home/jovyan/dea-notebooks
-
-        # Pip install `dea_tools` from the local Tools directory
-        docker-compose exec -T sandbox pip install -e /home/jovyan/dea-notebooks/Tools
-
-        # Run pytest using `--nbval-lax` which tests if notebookks run sucessfully or error 
-        docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest --durations=10 --nbval-lax Beginners_guide DEA_datasets Frequently_used_code/Contour_extraction.ipynb Frequently_used_code/Calculating_band_indices.ipynb Frequently_used_code/Downloading_data_with_STAC.ipynb Frequently_used_code/Exporting_GeoTIFFs.ipynb Frequently_used_code/Generating_composites.ipynb Frequently_used_code/Image_segmentation.ipynb Frequently_used_code/Opening_GeoTIFFs_NetCDFs.ipynb Frequently_used_code/Pansharpening.ipynb Frequently_used_code/Polygon_drill.ipynb Frequently_used_code/Principal_component_analysis.ipynb Frequently_used_code/Rasterize_vectorize.ipynb Frequently_used_code/Using_load_ard.ipynb Frequently_used_code/Virtual_products.ipynb"
-
-        # Shut down docker
-        docker-compose down
+        docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
+        docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh
 
 #    - name: Setup upterm session
 #      uses: lhotari/action-upterm@v1

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Set up Datacube and Test
       run: |
         docker-compose up -d
-        docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
-        docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh
+        # docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
+        docker-compose exec -T sandbox /tmp/dea-notebooks/Tests/test_notebooks.sh
 
 #    - name: Setup upterm session
 #      uses: lhotari/action-upterm@v1

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -12,54 +12,12 @@ permissions:
   contents: read    # This is required for actions/checkout
 
 jobs:
-  build-wheels:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/cache@v3
-        id: wheels_cache
-        with:
-          path: ./wheels
-          key: wheels-${{ github.sha }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade \
-            setuptools \
-            setuptools-scm
-          python -m pip install --upgrade \
-           toml \
-           wheel \
-           twine \
-           packaging
-          python -m pip freeze
-
-      - name: Build Clean Packages
-        run: |
-          mkdir -p ./wheels/clean
-          python ./Tools/setup.py bdist_wheel --dist-dir ./wheels/clean/
-          find ./wheels/clean -type f
   test:
     runs-on: ubuntu-latest
-    needs:
-      - build-wheels
-
     steps:
     - uses: actions/checkout@v3
-
-    - name: Get Wheels from Cache
-      uses: actions/cache@v3
-      id: wheels_cache
       with:
-        path: ./wheels
-        key: wheels-${{ github.sha }}
+        path: dea-notebooks
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -73,7 +31,8 @@ jobs:
 
     - name: Set up Datacube and Test
       run: |
-        docker-compose up -d
+        sudo chown -R 1000:100 ./dea-notebooks
+        CURRENT_UID=1000:100 docker-compose up -d
         docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
         docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh
 

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -8,7 +8,7 @@ on:
     branches: [ develop, stable ]
 
 permissions:
-  id-token: write   # This is required for requesting the JWT
+  id-token: write   # This is required for requesting the JSON web token
   contents: read    # This is required for actions/checkout
 
 jobs:

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -7,11 +7,25 @@ on:
   pull_request:
     branches: [ develop, stable ]
 
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: arn:aws:iam::538673716275:role/github-actions-role-readonly
+        aws-region: ap-southeast-2
+
+    - name: Login to Amazon ECR Private
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
 
     - name: Set up Datacube and Test
       run: |

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -12,10 +12,54 @@ permissions:
   contents: read    # This is required for actions/checkout
 
 jobs:
-  test:
+  build-wheels:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        id: wheels_cache
+        with:
+          path: ./wheels
+          key: wheels-${{ github.sha }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade \
+            setuptools \
+            setuptools-scm
+          python -m pip install --upgrade \
+           toml \
+           wheel \
+           twine \
+           packaging
+          python -m pip freeze
+
+      - name: Build Clean Packages
+        run: |
+          mkdir -p ./wheels/clean
+          python ./Tools/setup.py bdist_wheel --dist-dir ./wheels/clean/
+          find ./wheels/clean -type f
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - build-wheels
+
+    steps:
     - uses: actions/checkout@v3
+
+    - name: Get Wheels from Cache
+      uses: actions/cache@v3
+      id: wheels_cache
+      with:
+        path: ./wheels
+        key: wheels-${{ github.sha }}
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -30,8 +74,8 @@ jobs:
     - name: Set up Datacube and Test
       run: |
         docker-compose up -d
-        # docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
-        docker-compose exec -T sandbox /tmp/dea-notebooks/Tests/test_notebooks.sh
+        docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
+        docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh
 
 #    - name: Setup upterm session
 #      uses: lhotari/action-upterm@v1

--- a/Tests/setup_test_datacube.sh
+++ b/Tests/setup_test_datacube.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -ex
+set -o pipefail
+
+# install indexing tool
+pip3 install --no-cache --upgrade odc-apps-dc-tools
 
 # Setup datacube
 datacube system init --no-init-users
 
 # clone dea-config
 git clone https://github.com/GeoscienceAustralia/dea-config.git
+
 
 # Setup metadata types
 for metadata_yaml in $(find ./dea-config/product_metadata -name '*.yaml'); do
@@ -16,6 +21,8 @@ done
 for prod_def_yaml in $(find ./dea-config/products -name '*.yaml' -regex '.*\(ga_ls7e_nbart_gm_cyear_3\|ga_ls8c_nbart_gm_cyear_3\|ga_ls_fc_3\|ga_ls_wo_3\|ga_ls_wo_fq_cyear_3\|ga_ls_landcover_class_cyear_2\|high_tide_comp_20p\|low_tide_comp_20p\|ga_s2am_ard_3\|ga_s2bm_ard_3\|ga_ls5t_ard_3\|ga_ls7e_ard_3\|ga_ls8c_ard_3\|ga_ls9c_ard_3\).*'); do
         datacube product add $prod_def_yaml
 done
+
+datacube product list
 
 # Index GeoMAD
 s3-to-dc 's3://dea-public-data/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0/x49/y24/2017--P1Y/*.odc-metadata.yaml' --no-sign-request --skip-lineage 'ga_ls8c_nbart_gm_cyear_3'

--- a/Tests/setup_test_datacube.sh
+++ b/Tests/setup_test_datacube.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+
+# pipe the exit code to the parent process
 set -ex
 set -o pipefail
 

--- a/Tests/test_notebooks.sh
+++ b/Tests/test_notebooks.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+
+# pipe the exit code to parent process
 set -ex
 set -o pipefail
 

--- a/Tests/test_notebooks.sh
+++ b/Tests/test_notebooks.sh
@@ -2,7 +2,7 @@
 set -ex
 set -o pipefail
 
-pip3 install -e ./dea-notebooks/Tools
+pip3 install ./dea-notebooks/Tools
 cd ./dea-notebooks
 
 pytest --durations=10 --nbval-lax Beginners_guide DEA_datasets Frequently_used_code/Contour_extraction.ipynb Frequently_used_code/Calculating_band_indices.ipynb Frequently_used_code/Downloading_data_with_STAC.ipynb Frequently_used_code/Exporting_GeoTIFFs.ipynb Frequently_used_code/Generating_composites.ipynb Frequently_used_code/Image_segmentation.ipynb Frequently_used_code/Opening_GeoTIFFs_NetCDFs.ipynb Frequently_used_code/Pansharpening.ipynb Frequently_used_code/Polygon_drill.ipynb Frequently_used_code/Principal_component_analysis.ipynb Frequently_used_code/Rasterize_vectorize.ipynb Frequently_used_code/Using_load_ard.ipynb Frequently_used_code/Virtual_products.ipynb

--- a/Tests/test_notebooks.sh
+++ b/Tests/test_notebooks.sh
@@ -2,8 +2,8 @@
 set -ex
 set -o pipefail
 
-pip3 install ./dea-notebooks/Tools
-cd ./dea-notebooks
+pip3 install -e /tmp/dea-notebooks/Tools
+cd /tmp/dea-notebooks
 
 pytest --durations=10 --nbval-lax Beginners_guide DEA_datasets Frequently_used_code/Contour_extraction.ipynb Frequently_used_code/Calculating_band_indices.ipynb Frequently_used_code/Downloading_data_with_STAC.ipynb Frequently_used_code/Exporting_GeoTIFFs.ipynb Frequently_used_code/Generating_composites.ipynb Frequently_used_code/Image_segmentation.ipynb Frequently_used_code/Opening_GeoTIFFs_NetCDFs.ipynb Frequently_used_code/Pansharpening.ipynb Frequently_used_code/Polygon_drill.ipynb Frequently_used_code/Principal_component_analysis.ipynb Frequently_used_code/Rasterize_vectorize.ipynb Frequently_used_code/Using_load_ard.ipynb Frequently_used_code/Virtual_products.ipynb
 

--- a/Tests/test_notebooks.sh
+++ b/Tests/test_notebooks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -ex
+set -o pipefail
+
+pip3 install -e ./dea-notebooks/Tools
+cd ./dea-notebooks
+
+pytest --durations=10 --nbval-lax Beginners_guide DEA_datasets Frequently_used_code/Contour_extraction.ipynb Frequently_used_code/Calculating_band_indices.ipynb Frequently_used_code/Downloading_data_with_STAC.ipynb Frequently_used_code/Exporting_GeoTIFFs.ipynb Frequently_used_code/Generating_composites.ipynb Frequently_used_code/Image_segmentation.ipynb Frequently_used_code/Opening_GeoTIFFs_NetCDFs.ipynb Frequently_used_code/Pansharpening.ipynb Frequently_used_code/Polygon_drill.ipynb Frequently_used_code/Principal_component_analysis.ipynb Frequently_used_code/Rasterize_vectorize.ipynb Frequently_used_code/Using_load_ard.ipynb Frequently_used_code/Virtual_products.ipynb
+
+

--- a/Tests/test_notebooks.sh
+++ b/Tests/test_notebooks.sh
@@ -2,8 +2,8 @@
 set -ex
 set -o pipefail
 
-pip3 install -e /tmp/dea-notebooks/Tools
-cd /tmp/dea-notebooks
+cd ./dea-notebooks
+pip3 install --no-deps --no-cache ./wheels/clean/*whl
 
 pytest --durations=10 --nbval-lax Beginners_guide DEA_datasets Frequently_used_code/Contour_extraction.ipynb Frequently_used_code/Calculating_band_indices.ipynb Frequently_used_code/Downloading_data_with_STAC.ipynb Frequently_used_code/Exporting_GeoTIFFs.ipynb Frequently_used_code/Generating_composites.ipynb Frequently_used_code/Image_segmentation.ipynb Frequently_used_code/Opening_GeoTIFFs_NetCDFs.ipynb Frequently_used_code/Pansharpening.ipynb Frequently_used_code/Polygon_drill.ipynb Frequently_used_code/Principal_component_analysis.ipynb Frequently_used_code/Rasterize_vectorize.ipynb Frequently_used_code/Using_load_ard.ipynb Frequently_used_code/Virtual_products.ipynb
 

--- a/Tests/test_notebooks.sh
+++ b/Tests/test_notebooks.sh
@@ -3,7 +3,7 @@ set -ex
 set -o pipefail
 
 cd ./dea-notebooks
-pip3 install --no-deps --no-cache ./wheels/clean/*whl
+pip3 install ./Tools
 
 pytest --durations=10 --nbval-lax Beginners_guide DEA_datasets Frequently_used_code/Contour_extraction.ipynb Frequently_used_code/Calculating_band_indices.ipynb Frequently_used_code/Downloading_data_with_STAC.ipynb Frequently_used_code/Exporting_GeoTIFFs.ipynb Frequently_used_code/Generating_composites.ipynb Frequently_used_code/Image_segmentation.ipynb Frequently_used_code/Opening_GeoTIFFs_NetCDFs.ipynb Frequently_used_code/Pansharpening.ipynb Frequently_used_code/Polygon_drill.ipynb Frequently_used_code/Principal_component_analysis.ipynb Frequently_used_code/Rasterize_vectorize.ipynb Frequently_used_code/Using_load_ard.ipynb Frequently_used_code/Virtual_products.ipynb
 

--- a/Tools/setup.py
+++ b/Tools/setup.py
@@ -123,31 +123,9 @@ class UploadCommand(Command):
 
         sys.exit()
 
-
-# Versioning magic.
-VERSION_FILE_PATH = Path('dea_tools/__version__.py')
-about = {}
-try:
-    version = setuptools_scm.get_version(
-        root='..',
-        write_to='Tools' / VERSION_FILE_PATH,
-        relative_to=__file__,
-        local_scheme=lambda _: '')
-except (LookupError, FileNotFoundError):
-    # python -m build will trip the FNFError
-    try:
-        # no .git folder, so read from __version__.py
-        with open(VERSION_FILE_PATH) as f_version:
-            exec(f_version.read(), about)
-            version = about['version']
-    except FileNotFoundError:
-        # No __version__.py, yikes
-        raise RuntimeError('Build in-place with --use-feature=in-tree-build.')
-
 # Where the magic happens:
 setup(
     name=NAME,
-    version=version,
     description=DESCRIPTION,
     long_description=long_description,
     long_description_content_type='text/x-rst',
@@ -160,6 +138,11 @@ setup(
     # entry_points={
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
+    use_scm_version = {
+        "root": '..',
+        "relative_to": __file__,
+        "local_scheme": "no-local-version",
+        },
     install_requires=REQUIRED if not IS_DEA else [],
     extras_require=EXTRAS if not IS_DEA else {k: [] for k in EXTRAS},
     include_package_data=True,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,4 +29,4 @@ services:
         - postgres
      entrypoint: bash -c 'sleep infinity'
      volumes:
-       - ${GITHUB_WORKSPACE}:/home/jovyan/dea-notebooks
+       - ${GITHUB_WORKSPACE}:/tmp/dea-notebooks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,6 @@ services:
      depends_on:
         - postgres
      entrypoint: bash -c 'sleep infinity'
+     user: ${CURRENT_UID}
      volumes:
-       - ${GITHUB_WORKSPACE}:/home/jovyan/dea-notebooks
+       - ${GITHUB_WORKSPACE}/dea-notebooks:/home/jovyan/dea-notebooks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,4 +29,4 @@ services:
         - postgres
      entrypoint: bash -c 'sleep infinity'
      volumes:
-       - ${GITHUB_WORKSPACE}:/tmp/dea-notebooks
+       - ${GITHUB_WORKSPACE}:/home/jovyan/dea-notebooks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,23 +13,8 @@ services:
       - 5432
     restart: always
 
-  index:
-     image: opendatacube/datacube-index:latest
-     environment:
-        - DB_HOSTNAME=postgres
-        - DB_USERNAME=postgres
-        - DB_PASSWORD=opendatacubepassword
-        - DB_DATABASE=postgres
-        - DB_PORT=5432
-        - AWS_DEFAULT_REGION=ap-southeast-2
-     volumes:
-        - ./Tests/setup_test_datacube.sh:/usr/local/bin/setup_test_datacube.sh
-     depends_on:
-        - postgres
-     entrypoint: bash -c 'sleep infinity'
-
   sandbox:
-     image: geoscienceaustralia/sandbox:latest
+     image: 538673716275.dkr.ecr.ap-southeast-2.amazonaws.com/geoscienceaustralia/sandbox:latest
      environment:
        - DB_HOSTNAME=postgres
        - DB_USERNAME=postgres
@@ -44,4 +29,4 @@ services:
         - postgres
      entrypoint: bash -c 'sleep infinity'
      volumes:
-       - .:/dea-notebooks
+       - ${GITHUB_WORKSPACE}:/home/jovyan/dea-notebooks


### PR DESCRIPTION
### Proposed changes
- Simplify the test workflow and make it reusable in `dea-sandbox`
- Remove `index` container, install the indexing tool in `sandbox` instead
- Make bash script pass the failure

### Closes issues (optional)
N/A
### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


