### PR TITLE
Ignore markdown and RST files from integration tests

### DIFF
--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -4,8 +4,14 @@ name: Test notebooks
 on:
   push:
     branches: [ develop, stable, nbtests ]
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
   pull_request:
     branches: [ develop, stable ]
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
 
 permissions:
   id-token: write   # This is required for requesting the JSON web token
@@ -29,13 +35,10 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Set up Datacube and Test
+    - name: Set up Datacube and test
       run: |
         sudo chown -R 1000:100 ./dea-notebooks
         cd ./dea-notebooks 
         CURRENT_UID=1000:100 docker-compose up -d
         docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
         docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh
-
-#    - name: Setup upterm session
-#      uses: lhotari/action-upterm@v1

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -5,13 +5,17 @@ on:
   push:
     branches: [ develop, stable, nbtests ]
     paths-ignore:
-      - '**.md'
-      - '**.rst'
+      - '**/*.md' # ignore markdown files
+      - '**/*.rst' # ignore restructured text files
+      - '.github/**' # ignore anything in .github folder
+      - '!.github/workflows/test_notebooks.yml' # except test_notebooks.yml
   pull_request:
     branches: [ develop, stable ]
     paths-ignore:
-      - '**.md'
-      - '**.rst'
+      - '**/*.md'
+      - '**/*.rst'
+      - '.github/**'
+      - '!.github/workflows/test_notebooks.yml'
 
 permissions:
   id-token: write   # This is required for requesting the JSON web token


### PR DESCRIPTION
### Proposed changes
This PR updates the DEA Notebooks integration tests to ignore any pushes/PRs that modify RST or MD files, or any files in the `.github/` folder (excluding the integration test YML itself):

```
    paths-ignore:
      - '**/*.md' # ignore markdown files
      - '**/*.rst' # ignore restructured text files
      - '.github/**' # ignore anything in .github folder
      - '!.github/workflows/test_notebooks.yml' # except test_notebooks.yml
```