### PR TITLE
Fix `pixel_tides` issues when `ds` has no time dimension

### DIFF
--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -619,21 +619,19 @@ def pixel_tides(
     )
 
     # Insert modelled tide values back into flattened array, then unstack
-    # back to 3D (x, y, time)
+    # back to 3D (y, x, time)
     tides_lowres = (
         
         # Convert dataframe to xarray format
         tide_df.set_index(["x", "y"], append=True)
         .to_xarray()
         
-        # Re-index and transpose to match dimensions in `ds`. The `...`
-        # places any extra dimensions (like "time" if it did not exist
-        # in the original `ds`) at the end
+        # Re-index and transpose back into 3D
         .tide_m.reindex_like(rescaled_ds)
-        .transpose(*list(ds.dims.keys()), ...)
+        .transpose("y", "x", "time")
         .astype(np.float32)
     )
-
+    
     # Optionally calculate and return quantiles rather than raw data
     if calculate_quantiles is not None:
 
@@ -643,6 +641,9 @@ def pixel_tides(
 
     else:
         reproject_dim = "time"
+
+
+    # return tides_lowres, rescaled_ds
 
     # Ensure CRS is present
     tides_lowres = tides_lowres.odc.assign_crs(ds.odc.geobox.crs)

--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -16,7 +16,7 @@ https://gis.stackexchange.com/questions/tagged/open-data-cube).
 If you would like to report an issue with this script, you can file one 
 on Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 
-Last modified: January 2023
+Last modified: March 2023
 
 """
 
@@ -153,10 +153,11 @@ def transect_distances(transects_gdf, lines_gdf, mode="distance"):
 
 
 def get_coastlines(
-    bbox: tuple, crs="EPSG:4326", layer="shorelines", drop_wms=True
+    bbox: tuple, crs="EPSG:4326", layer="shorelines_annual", drop_wms=True
 ) -> gpd.GeoDataFrame:
     """
-    Get DEA Coastlines data for a provided bounding box using WFS.
+    Load DEA Coastlines annual shorelines or rates of change points data
+    for a provided bounding box using WFS.
 
     For a full description of the DEA Coastlines dataset, refer to the
     official Geoscience Australia product description:
@@ -173,8 +174,8 @@ def get_coastlines(
         is provided as a geopandas object.
     layer : str, optional
         Which DEA Coastlines layer to load. Options include the annual
-        shoreline vectors ("shorelines") and the rates of change
-        statistics points ("statistics"). Defaults to "shorelines".
+        shoreline vectors ("shorelines_annual") and the rates of change
+        points ("rates_of_change"). Defaults to "shorelines_annual".
     drop_wms : bool, optional
         Whether to drop WMS-specific attribute columns from the data.
         These columns are used for visualising the dataset on DEA Maps,
@@ -197,9 +198,7 @@ def get_coastlines(
 
     # Query WFS
     wfs = WebFeatureService(url=WFS_ADDRESS, version="1.1.0")
-    layer_name = (
-        "dea:coastlines" if layer == "shorelines" else "dea:coastlines_statistics"
-    )
+    layer_name = f"dea:{layer}"
     response = wfs.getfeature(
         typename=layer_name,
         bbox=tuple(bbox) + (crs,),

--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -568,7 +568,7 @@ def pixel_tides(
 
     import odc.geo.xr
     from odc.geo.geobox import GeoBox
-    
+
     # First test if no time dimension and nothing passed to `times`
     if ('time' not in ds.dims) & (times is None):
         raise ValueError(
@@ -577,7 +577,7 @@ def pixel_tides(
             "using the `times` parameter. For example: "
             "`times=pd.date_range(start='2000', end='2001', freq='5h')`"
         )
-        
+
     # If custom times are provided, convert them to a consistent 
     # pandas.DatatimeIndex format
     if times is not None:
@@ -587,7 +587,7 @@ def pixel_tides(
             time_coords = pd.DatetimeIndex([times])
         else: 
             time_coords = times
-            
+
     # Otherwise, use times from `ds` directly
     else:
         time_coords = ds.coords["time"]
@@ -621,17 +621,17 @@ def pixel_tides(
     # Insert modelled tide values back into flattened array, then unstack
     # back to 3D (y, x, time)
     tides_lowres = (
-        
+
         # Convert dataframe to xarray format
         tide_df.set_index(["x", "y"], append=True)
         .to_xarray()
-        
+
         # Re-index and transpose back into 3D
         .tide_m.reindex_like(rescaled_ds)
         .transpose("y", "x", "time")
         .astype(np.float32)
     )
-    
+
     # Optionally calculate and return quantiles rather than raw data
     if calculate_quantiles is not None:
 
@@ -641,9 +641,6 @@ def pixel_tides(
 
     else:
         reproject_dim = "time"
-
-
-    # return tides_lowres, rescaled_ds
 
     # Ensure CRS is present
     tides_lowres = tides_lowres.odc.assign_crs(ds.odc.geobox.crs)


### PR DESCRIPTION
### Proposed changes
This PR updates the `pixel_tides` function to better handle situations where an input array has no time dimension. 

The function failed in this scenario:

- You pass in a dataset `ds` with no time dimension, and a set of custom times via the `times` param
- The function models tides into a pandas dataframe, then tries to reshape and transpose the data back into 3D xarray format by matching it to the original dimensions from `ds`
- Because the modelled tides dataframe has multiple timesteps but the original `ds` has no time dim, the [transpose steps fails](https://github.com/GeoscienceAustralia/dea-notebooks/compare/pixel_tides_update?expand=1#diff-9a8d3841a66e6cc352119d7194f661f0ac4be96b059c0ea527640d30d65e55d9L605) when trying to reshape x/y/time data into x/y dimensions

![image](https://user-images.githubusercontent.com/17680388/230244082-a611ce7b-bc99-4609-a3b9-0b4f90126ff7.png)


Two fixes to address this:

- Better error catching to make the function fail completely if a dataset with no time dimension is passed and no custom times are provided
- Hard code the list of dimensions instead of getting them from the input `ds`. This ensures they are in the order expected by the re-projection step.

![image](https://user-images.githubusercontent.com/17680388/230248486-e34153c6-7b62-4b41-b7e6-c67df4e6ba42.png)


Have also cleaned up some un-needed OTPS code in one of the new FES2014 funcs.
