### PR TITLE
Add Sentinel-2 and Landsat option to animation notebook

### DIFF
--- a/Interactive_apps/Generating_satellite_animations.ipynb
+++ b/Interactive_apps/Generating_satellite_animations.ipynb
@@ -79,6 +79,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -92,6 +93,7 @@
     "\n",
     "* **Landsat**: Data from the Landsat 5, 7, 8 and 9 satellites\n",
     "* **Sentinel-2**: Data from the Sentinel-2A and 2B satellites\n",
+    "* **Sentinel-2 and Landsat**: Data from both Sentinel-2 and Landsat 5, 7, 8 and 9 satellites\n",
     "\n",
     "Satellite imagery can be viewed and exported in two colour styles:\n",
     "\n",

--- a/Tools/dea_tools/app/animations.py
+++ b/Tools/dea_tools/app/animations.py
@@ -795,10 +795,10 @@ class animation_app(HBox):
     def update_dealayer(self, change):
         self.dealayer = change.new
 
-        if change.new == "ga_ls_ard_3":
+        if change.new == "Landsat":
             self.text_resolution.value = 30
 
-        else:
+        elif change.new == "Sentinel-2":
             self.text_resolution.value = 10
 
     # Set imagery style

--- a/Tools/dea_tools/app/animations.py
+++ b/Tools/dea_tools/app/animations.py
@@ -82,6 +82,23 @@ sat_params = {
             ),
         },
     },
+    "Sentinel-2 and Landsat": {
+        "products": [
+            "ga_s2am_ard_3",
+            "ga_s2bm_ard_3",
+            "ga_ls5t_ard_3",
+            "ga_ls7e_ard_3",
+            "ga_ls8c_ard_3",
+            "ga_ls9c_ard_3",
+        ],
+        "styles": {
+            "True colour": ("simple_rgb", ["nbart_red", "nbart_green", "nbart_blue"]),
+            "False colour": (
+                "infrared_green",
+                ["nbart_common_swir_1", "nbart_common_nir", "nbart_green"],
+            ),
+        },
+    },
 }
 
 
@@ -325,6 +342,7 @@ class animation_app(HBox):
         self.dealayer_list = [
             ("Landsat", "Landsat"),
             ("Sentinel-2", "Sentinel-2"),
+            ("Sentinel-2 and Landsat", "Sentinel-2 and Landsat")
         ]
         self.dealayer = self.dealayer_list[0][1]
 
@@ -527,13 +545,13 @@ class animation_app(HBox):
 
         checkbox_rolling_median = deawidgets.create_checkbox(
             self.rolling_median,
-            "Apply rolling median to produce<br>smooth, cloud-free animations",
+            "Apply rolling median to produce smooth, cloud-free animations",
             layout={"width": "85%"},
         )
         text_rolling_median_window = widgets.IntText(
             value=20,
             step=1,
-            description="</br>Rolling window (timesteps)",
+            description="Rolling window (timesteps)",
             layout={
                 "width": "85%",
                 "margin": "0px",

--- a/Tools/dea_tools/app/animations.py
+++ b/Tools/dea_tools/app/animations.py
@@ -800,6 +800,9 @@ class animation_app(HBox):
 
         elif change.new == "Sentinel-2":
             self.text_resolution.value = 10
+        
+        elif change.new == "Sentinel-2 and Landsat":
+            self.text_resolution.value = 30
 
     # Set imagery style
     def update_styles(self, change):


### PR DESCRIPTION
### Proposed changes
A small PR to add a combined "Sentinel-2 and Landsat" layer to our interactive animations notebook. This will allow users to create animations that combine both Sentinel-2 and Landsat data:

![image](https://user-images.githubusercontent.com/17680388/233513937-730732a6-2f2e-4ee9-a99c-7f7193e4a55a.png)
