### PR TITLE
Add manual reload trigger to layer selection

### DIFF
--- a/Tools/dea_tools/app/animations.py
+++ b/Tools/dea_tools/app/animations.py
@@ -803,6 +803,9 @@ class animation_app(HBox):
         
         elif change.new == "Sentinel-2 and Landsat":
             self.text_resolution.value = 30
+            
+        # Clear data load params to trigger data re-load
+        update_map_layers(self)
 
     # Set imagery style
     def update_styles(self, change):


### PR DESCRIPTION
### Proposed changes
The previous fix still didn't work because the widget was smart enough to realise the resolution value changed. 

This adds a manual reload to make sure data is reloaded every time a user changes the input products.
