### PR TITLE
New BAM NRT notebook and required change to DEA tools plotting.py

### DIFF
--- a/Tools/dea_tools/plotting.py
+++ b/Tools/dea_tools/plotting.py
@@ -28,6 +28,7 @@ import pandas as pd
 import geopandas as gpd
 import matplotlib.patheffects as PathEffects
 import matplotlib.pyplot as plt
+import xarray as xr
 from matplotlib import colors as mcolours
 from matplotlib.animation import FuncAnimation
 from pathlib import Path


### PR DESCRIPTION
### Proposed changes
New BAM NRT notebook.
Required change to DEA Tools plotting.py to import xarray



### Checklist (replace `[ ]` with `[x]` to check off)
- [x] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [x] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [x] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


