### PR TITLE
Allow `subpixel_contours` time format to be customised

### DIFF
--- a/Tools/dea_tools/spatial.py
+++ b/Tools/dea_tools/spatial.py
@@ -418,7 +418,7 @@ def subpixel_contours(
         """
         if isinstance(i, np.datetime64):
             ts = pd.to_datetime(str(i))
-            i = ts.strftime(date_format)
+            i = ts.strftime(time_format)
         return i
 
     # Verify input data is a xr.DataArray

--- a/Tools/dea_tools/spatial.py
+++ b/Tools/dea_tools/spatial.py
@@ -27,6 +27,7 @@ import warnings
 import collections
 import odc.geo.xr
 import numpy as np
+import pandas as pd
 import xarray as xr
 import geopandas as gpd
 import rasterio.features


### PR DESCRIPTION
### Proposed changes
A small PR, mainly to test whether our new tests allow us to successfully add features to `dea-tools` functions without breaking existing code. The new tests successfully caught several issues with the PR, and pass now that they were fixed!

The specific change allows users to customise how dates are formatted in a geopandas object returned by the `subpixel_contours` function, e.g.:

![image](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/d5b73d63-7b27-4140-a074-bdbfc661006e)

For example, a user may want dates to be formatted like `"%Y-%m-%d"` (the default), or like `"%Y"`, `"%Y-%m"` etc. This change replaced the previous approach of crudely converting dates to a string then clipping them to the first 10 characters (`str(i)[0:10]`). 

(This update will be required for any future updates to DEA Coastlines that require sub-annual shorelines)