### PR TITLE
Add CODEOWNERS file to add list of default reviewers to repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,4 @@
 # for any pull requests in this repository.
 
 # Default reviewers for the entire repository
-*       @robbibt @BexDunn @erialC-P @uchchwhash @Matt-dea @Kooie-cate @geoscience-aman @JM-GA @treefern @margaretharrison @vnewey @Ariana-B
-
-<!-- # Example default reviewers for the "Tools" directory
-/Tools/* @user1 @user2
-
-# Example default reviewers for specific files
-DEA_notebooks_template.ipynb @user3 -->
+*       @robbibt @BexDunn @erialC-P @uchchwhash @Matt-dea @Kooie-cate @geoscience-aman @JM-GA @treefern @margaretharrison @vnewey @Ariana-B @amanda2099 @supermarkion

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This is the CODEOWNERS file that defines a set of default reviewers
+# for any pull requests in this repository.
+
+# Default reviewers for the entire repository
+*       @robbibt @BexDunn @erialC-P @uchchwhash @Matt-dea @Kooie-cate @geoscience-aman @JM-GA @treefern @margaretharrison @vnewey @Ariana-B
+
+<!-- # Example default reviewers for the "Tools" directory
+/Tools/* @user1 @user2
+
+# Example default reviewers for specific files
+DEA_notebooks_template.ipynb @user3 -->

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # for any pull requests in this repository.
 
 # Default reviewers for the entire repository
-*       @robbibt @BexDunn @erialC-P @uchchwhash @Matt-dea @Kooie-cate @geoscience-aman @JM-GA @treefern @margaretharrison @vnewey @Ariana-B @amanda2099 @supermarkion
+*       @robbibt @BexDunn @erialC-P @uchchwhash @Matt-dea @Kooie-cate @geoscience-aman @JM-GA @treefern @margaretharrison @vnewey @Ariana-B @amanda2099 @supermarkion @erin-telfer


### PR DESCRIPTION
### Proposed changes
This PR implements a set of default reviewers for pull requests to DEA Notebooks, similar to how SnS currently includes a list of default reviewers on their Bitbucket repositories. 

This list is currently based on members of the new DEA Notebooks Community of Practice, and includes:

@robbibt @BexDunn @erialC-P @uchchwhash @Matt-dea @Kooie-cate @geoscience-aman @JM-GA @treefern @margaretharrison @vnewey @Ariana-B @amanda2099 @supermarkion

The idea here is that everyone on this list will be tagged on new pull requests on DEA Notebooks (default reviewers aren't notified for draft pull requests, so if you have a work in progress simply leave it in draft until you're ready to click "Ready for review").

If you're tagged in a pull request and have time to have a quick look at it and provide feedback, that's fantastic - but there's no expectation to do so if you're busy! Hopefully this will just allow us to spread the workload of reviewing changes a little more widely, and make it easier for everyone in the Community of Practice to see the cool stuff we're all working on! 😃 

