### PR TITLE
Fix np.int issue in `classification.py` module

### DIFF
--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -1,6 +1,6 @@
 # classification.py
 """
-Machnine learning classification tools for analysing remote sensing data
+Machine learning classification tools for analysing remote sensing data
 using the Open Data Cube.
 
 License: The code in this notebook is licensed under the Apache License,
@@ -645,7 +645,7 @@ def collect_training_data(
     """
 
     # check the dtype of the class field
-    if gdf[field].dtype != np.int:
+    if gdf[field].dtype != int:
         raise ValueError(
             'The "field" column of the input vector must contain integer dtypes'
         )


### PR DESCRIPTION
### Proposed changes
A simple PR to fix #1070, caused by specifying the now deprecated `np.int` data type alias. This caused the `collect_training_data` func and the [Scalable_machine_learning/1_Extract_training_data.ipynb](https://docs.dea.ga.gov.au/notebooks/Real_world_examples/Scalable_machine_learning/1_Extract_training_data.html#Defining-feature-layers) notebook to break.

The easy solution is to replace this with `int`.

Also fixed a small typo!

### Closes issues (optional)
- Closes Issue #1070
