### PR TITLE
Minor update to dea_tools with changes to band indices and plotting scripts

### DIFF
--- a/Tools/dea_tools/bandindices.py
+++ b/Tools/dea_tools/bandindices.py
@@ -15,7 +15,7 @@ here: https://gis.stackexchange.com/questions/tagged/open-data-cube).
 If you would like to report an issue with this script, you can file one
 on Github (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 
-Last modified: March 2021
+Last modified: June 2023
 '''
 
 # Import required packages
@@ -39,7 +39,7 @@ def calculate_indices(ds,
     in memory. This can be a memory-expensive operation, so to avoid
     this, set `inplace=True`.
 
-    Last modified: April 2023
+    Last modified: June 2023
     
     Parameters
     ----------
@@ -76,6 +76,7 @@ def calculate_indices(ds,
         * ``'NDSI'`` (Normalised Difference Snow Index, Hall 1995)
         * ``'NDTI'`` (Normalise Difference Tillage Index,
                 Van Deventeret et al. 1997)
+        * ``'NDTI2'`` (Normalised Difference Turbidity Index, Lacaux et al., 2007)
         * ``'NDVI'`` (Normalised Difference Vegetation Index, Rouse 1973)
         * ``'NDWI'`` (Normalised Difference Water Index, McFeeters 1996)
         * ``'SAVI'`` (Soil Adjusted Vegetation Index, Huete 1988)
@@ -85,7 +86,6 @@ def calculate_indices(ds,
         * ``'TCB_GSO'`` (Tasseled Cap Brightness, Nedkov 2017)
         * ``'TCG_GSO'`` (Tasseled Cap Greeness, Nedkov 2017)
         * ``'TCW_GSO'`` (Tasseled Cap Wetness, Nedkov 2017)
-        * ``'TI'`` (Normalised Difference Turbidity Index, Lacaux et al 2007)
         * ``'WI'`` (Water Index, Fisher 2016)
         * ``'kNDVI'`` (Non-linear Normalised Difference Vegation Index,
                  Camps-Valls et al. 2021)
@@ -201,6 +201,11 @@ def calculate_indices(ds,
                   # Van Deventer et al. 1997
                   'NDTI': lambda ds: (ds.swir1 - ds.swir2) /
                                      (ds.swir1 + ds.swir2),
+        
+                  # Normalised Difference Turbidity Index,
+                  # Lacaux et al., 2007
+                  'NDTI2': lambda ds: (ds.red - ds.green) /
+                                     (ds.red + ds.green),
 
                   # Normalised Difference Water Index, McFeeters 1996
                   'NDWI': lambda ds: (ds.green - ds.nir) /
@@ -287,11 +292,7 @@ def calculate_indices(ds,
 
                   # Iron Oxide Ratio, Segal 1982
                   'IOR': lambda ds: (ds.red / ds.blue),
-      
-                  # Normalised Difference Turbidity Index , Lacaux et al 2007
-                  #NB. 'NDTI' key already used. 'TI' used in lieu.
-                  'TI': lambda ds:  (ds.red - ds.green) /
-                                    (ds.red + ds.green)
+
     }
     
     # If index supplied is not a list, convert to list. This allows us to

--- a/Tools/dea_tools/plotting.py
+++ b/Tools/dea_tools/plotting.py
@@ -108,7 +108,7 @@ def rgb(ds,
         gives width of each facet in inches. Defaults to None, which 
         will calculate the aspect based on the x and y dimensions of 
         the input data.
-    titles : string or list of strings (optional)
+    titles : string or list of strings, optional
         Replace the xarray 'time' dimension on plot titles with a string
         or list of string titles, when a list of index values are
         provided, of your choice. Defaults to None.

--- a/Tools/dea_tools/plotting.py
+++ b/Tools/dea_tools/plotting.py
@@ -51,7 +51,7 @@ def rgb(ds,
         col_wrap=4,
         size=6,
         aspect=None,
-        titles = None,
+        titles=None,
         savefig_path=None,
         savefig_kwargs={},
         **kwargs):

--- a/Tools/dea_tools/plotting.py
+++ b/Tools/dea_tools/plotting.py
@@ -51,6 +51,7 @@ def rgb(ds,
         col_wrap=4,
         size=6,
         aspect=None,
+        titles = None,
         savefig_path=None,
         savefig_kwargs={},
         **kwargs):
@@ -107,6 +108,10 @@ def rgb(ds,
         gives width of each facet in inches. Defaults to None, which 
         will calculate the aspect based on the x and y dimensions of 
         the input data.
+    titles : string or list of strings (optional)
+        Replace the xarray 'time' dimension on plot titles with a string
+        or list of string titles, when a list of index values are
+        provided, of your choice. Defaults to None.
     savefig_path : string, optional
         Path to export image file for the RGB plot. Defaults to None, 
         which does not export an image file.
@@ -182,6 +187,9 @@ def rgb(ds,
                              col_wrap=col_wrap,
                              **aspect_size_kwarg,
                              **kwargs)
+        if titles is not None:
+            for ax, title in zip(img.axs.flat, titles):
+                ax.set_title(title)
 
     # If values provided for `index`, extract corresponding observations and
     # plot as either single image or facet plot
@@ -221,6 +229,9 @@ def rgb(ds,
                                  col_wrap=col_wrap,
                                  **aspect_size_kwarg,
                                  **kwargs)
+            if titles is not None:
+                for ax, title in zip(img.axs.flat, titles):
+                    ax.set_title(title)
 
         # If only one index is supplied, squeeze out index_dim and plot as a
         # single panel
@@ -229,6 +240,9 @@ def rgb(ds,
             img = da.squeeze(dim=index_dim).plot.imshow(robust=robust,
                                                         **aspect_size_kwarg,
                                                         **kwargs)
+            if titles is not None:
+                for ax, title in zip(img.axs.flat, titles):
+                    ax.set_title(title)
 
     # If an export path is provided, save image to file. Individual and
     # faceted plots have a different API (figure vs fig) so we get around this


### PR DESCRIPTION
### Proposed changes

This PR includes a minor revision to the naming of the normalised difference turbidity index (NDTI) in the calculate_indices function of bandindices.py. There is also added functionality enabling plot naming in the rgb function of plotting.py.

Updates in the Turbidity_Animated_Timeseries.ipynb PR are reliant upon these changes and so cannot be merged until this PR is approved.

There are no notebook related changes in this PR.


