### PR TITLE
Replace np.bool with bool

### DIFF
--- a/Tools/dea_tools/datahandling.py
+++ b/Tools/dea_tools/datahandling.py
@@ -692,8 +692,8 @@ def wofs_fuser(dest, src):
     Note: this is a copy of the function located here:
     https://github.com/GeoscienceAustralia/digitalearthau/blob/develop/digitalearthau/utils.py
     """
-    empty = (dest & 1).astype(np.bool)
-    both = ~empty & ~((src & 1).astype(np.bool))
+    empty = (dest & 1).astype(bool)
+    both = ~empty & ~((src & 1).astype(bool))
     dest[empty] = src[empty]
     dest[both] |= src[both]
 
@@ -739,7 +739,7 @@ def dilate(array, dilation=10, invert=True):
         array = ~array
 
     return ~binary_dilation(
-        array.astype(np.bool), structure=kernel.reshape((1,) + kernel.shape)
+        array.astype(bool), structure=kernel.reshape((1,) + kernel.shape)
     )
 
 


### PR DESCRIPTION
### Proposed changes
`np.bool` has been deprecated and raises an error when using `wofs_fuser` to load WOFS data, so it needs to be replaced with `bool`.

### Closes issues (optional)
- Closes Issue #1079 

### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


