### PR TITLE
Add multiple tide model support to `pixel_tides`

### DIFF
--- a/Tests/dea_tools/test_coastal.py
+++ b/Tests/dea_tools/test_coastal.py
@@ -1,6 +1,5 @@
 import pytest
 import datacube
-import pyproj
 import numpy as np
 import pandas as pd
 import xarray as xr

--- a/Tests/dea_tools/test_coastal.py
+++ b/Tests/dea_tools/test_coastal.py
@@ -191,9 +191,11 @@ def test_pixel_tides_quantile(satellite_ds):
     assert modelled_tides_ds["quantile"].values.tolist() == quantiles
     assert modelled_tides_lowres["quantile"].values.tolist() == quantiles
 
-    # Verify tides are monotonically increasing from  along
-    # quantile dim (in this case, axis=0)
+    # Verify tides are monotonically increasing along quantile dim 
+    # (in this case, axis=0)
     assert np.all(np.diff(modelled_tides_ds, axis=0) > 0)
+    
+    # Test results match expected results for a set of points across array
 
     # Set up pyproj transformer to convert between coordinates
     reproject = pyproj.Transformer.from_crs(
@@ -210,7 +212,7 @@ def test_pixel_tides_quantile(satellite_ds):
     x_coords = xr.DataArray(x, dims=["point"])
     y_coords = xr.DataArray(y, dims=["point"])
 
-    # Extract modelled tides for each corner
+    # Extract modelled tides for each point
     try:
         extracted_tides = modelled_tides_ds.sel(
             x=x_coords, y=y_coords, method="nearest"

--- a/Tests/dea_tools/test_coastal.py
+++ b/Tests/dea_tools/test_coastal.py
@@ -178,6 +178,62 @@ def test_pixel_tides(satellite_ds, measured_tides_ds, resolution):
     assert np.allclose(extracted_tides.values, expected_tides, atol=0.03)
 
 
+def test_pixel_tides_quantile(satellite_ds):
+    # Model tides using `pixel_tides` and `calculate_quantiles`
+    quantiles = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+    modelled_tides_ds, modelled_tides_lowres = pixel_tides(
+        satellite_ds, calculate_quantiles=quantiles
+    )
+
+    # Verify that outputs contain quantile dim and values match inputs
+    assert "quantile" in modelled_tides_ds.dims
+    assert "quantile" in modelled_tides_lowres.dims
+    assert modelled_tides_ds["quantile"].values.tolist() == quantiles
+    assert modelled_tides_lowres["quantile"].values.tolist() == quantiles
+
+    # Verify tides are monotonically increasing from  along
+    # quantile dim (in this case, axis=0)
+    assert np.all(np.diff(modelled_tides_ds, axis=0) > 0)
+
+    # Set up pyproj transformer to convert between coordinates
+    reproject = pyproj.Transformer.from_crs(
+        crs_from="EPSG:4326",
+        crs_to=f"EPSG:{satellite_ds.odc.geobox.crs.to_epsg()}",
+        always_xy=True,
+    )
+
+    # Reproject test point coordinates and create arrays
+    x, y = reproject.transform(
+        [122.14438, 122.30304, 122.12964, 122.29235],
+        [-17.91625, -17.92713, -18.07656, -18.08751],
+    )
+    x_coords = xr.DataArray(x, dims=["point"])
+    y_coords = xr.DataArray(y, dims=["point"])
+
+    # Extract modelled tides for each corner
+    try:
+        extracted_tides = modelled_tides_ds.sel(
+            x=x_coords, y=y_coords, method="nearest"
+        )
+    except KeyError:
+        extracted_tides = modelled_tides_ds.sel(
+            longitude=x_coords, latitude=y_coords, method="nearest"
+        )
+
+    # Test if extracted tides match expected results (to within ~3 cm)
+    expected_tides = np.array(
+        [
+            [-1.83, -1.98, -1.98, -2.07],
+            [-1.38, -1.44, -1.44, -1.47],
+            [-0.73, -0.78, -0.79, -0.82],
+            [-0.38, -0.36, -0.36, -0.35],
+            [0.49, 0.44, 0.44, 0.41],
+            [1.58, 1.61, 1.62, 1.64],
+        ]
+    )
+    assert np.allclose(extracted_tides.values, expected_tides, atol=0.03)
+
+
 @pytest.mark.parametrize(
     "ebb_flow, swap_dims, tidepost_lat, tidepost_lon",
     [

--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -552,7 +552,7 @@ def pixel_tides(
 
     Returns:
     --------
-    If `resample` is True:
+    If `resample` is False:
 
         tides_lowres : xr.DataArray
             A low resolution data array giving either tide heights every
@@ -560,7 +560,7 @@ def pixel_tides(
             time in `times` (if `times` is not None), or tide height quantiles
             for every quantile provided by `calculate_quantiles`.
 
-    If `resample` is False:
+    If `resample` is True:
 
         tides_highres, tides_lowres : tuple of xr.DataArrays
             In addition to `tides_lowres` (see above), a high resolution

--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -701,15 +701,16 @@ def pixel_tides(
     tides_lowres = (
         # Merge all our results into a single pandas.DataFrame
         pd.concat(model_outputs, axis=1)
-        # Convert to an xarray.DataArray, with columns (i.e. different tide
-        # model outputs) used to create a new "tide_model" dimension
+        # Convert to an xarray.DataArray, with each column (i.e. 
+        # different tide model outputs) converted to a new array along
+        # "tide_model" dimension
         .to_xarray()
         .to_array("tide_model")
-        # Re-index and transpose back into the original 3D shape of our data
+        # Re-index and transpose back into the original dimensions
         .reindex_like(rescaled_ds)
         .transpose("tide_model", "time", y_dim, x_dim)
         .astype(np.float32)
-        # Rename the entire array as "tide_m"
+        # Rename the entire array to "tide_m"
         .rename("tide_m")
     )
 
@@ -740,7 +741,7 @@ def pixel_tides(
             resampling=resample_method,
         ).transpose(
             *tides_lowres.dims
-        )  # Reorder dims to match low-res
+        )  # Reorder dims to match `tides_lowres` array
 
         return tides_highres, tides_lowres
 

--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -538,9 +538,9 @@ def pixel_tides(
         resolution pixels. Defaults to "bilinear"; valid options include
         "nearest", "cubic", "min", "max", "average" etc.
     model : string or list of strings
-        The tide model or a list of models used to model tides. Options
-        include:
-        - "FES2014" (only pre-configured option on DEA Sandbox)
+        The tide model or a list of models used to model tides, as 
+        supported by the `pyTMD` Python package. Options include:
+        - "FES2014" (default; pre-configured on DEA Sandbox)
         - "TPXO8-atlas"
         - "TPXO9-atlas-v5"
     **model_tides_kwargs :

--- a/Tools/dea_tools/datahandling.py
+++ b/Tools/dea_tools/datahandling.py
@@ -932,7 +932,7 @@ def parallel_apply(ds, dim, func, *args, **kwargs):
     *args :
         Any number of arguments that will be passed to `func`.
     **kwargs :
-        Any number of keywork arguments that will be passed to `func`.
+        Any number of keyword arguments that will be passed to `func`.
 
     Returns
     -------

--- a/Tools/dea_tools/datahandling.py
+++ b/Tools/dea_tools/datahandling.py
@@ -905,7 +905,7 @@ def nearest(
     return nearest_array
 
 
-def parallel_apply(ds, dim, func, *args):
+def parallel_apply(ds, dim, func, *args, **kwargs):
     """
     Applies a custom function in parallel along the dimension of an
     xarray.Dataset or xarray.DataArray.
@@ -931,6 +931,8 @@ def parallel_apply(ds, dim, func, *args):
         function should be the array along `dim`.
     *args :
         Any number of arguments that will be passed to `func`.
+    **kwargs :
+        Any number of keywork arguments that will be passed to `func`.
 
     Returns
     -------
@@ -942,8 +944,12 @@ def parallel_apply(ds, dim, func, *args):
     from concurrent.futures import ProcessPoolExecutor
     from tqdm import tqdm
     from itertools import repeat
+    from functools import partial
 
     with ProcessPoolExecutor() as executor:
+        
+        # Update func to add kwargs
+        func = partial(func, **kwargs)
 
         # Apply func in parallel
         groups = [group for (i, group) in ds.groupby(dim)]


### PR DESCRIPTION
### Proposed changes
Currently, the `pixel_tides` function only allows us to run a single tide model at once (by default, "FES2014").

This PR updates the function to allow a user to specify a list of tide models:
```
tides_highres, tides_lowres = pixel_tides(
    ds=ds,
    times=times,
    model=["TPXO9-atlas-v5", "FES2014", "FES2012"],
)
```
Outputs are now returned as an `xr.DataArray` with a new "tide_model" dimension, making it easy to plot and compare different model outputs:

```
tides_highres.isel(time=[0, 1, 2, 3, 4]).plot(col="time", row="tide_model")
```
![image](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/9fae00b0-9e1e-4351-a675-fc53dd50a12f)
![image](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/82c90417-98e6-460d-b1d9-ef00960be40f)

For backwards compatibility, the "tide_model" dimension is squeezed out if only one model is requested (the default).

Other minor updates:

- Added an additional test to `test_coastal.py` to test the existing "calculate_quantiles" functionality that is used for Intertidal Exposure.
- Switched `pixel_tides` to use `xr_reproject` from `odc.geo` instead of `odc.algo`
- Improved `pixel_tides` docstring and fixed up some silly mistakes

