### PR TITLE
fix rename param in xr rasterize

### DIFF
--- a/Tools/dea_tools/spatial.py
+++ b/Tools/dea_tools/spatial.py
@@ -2,18 +2,18 @@
 '''
 Tools for spatially manipulating Digital Earth Australia data.
 
-License: The code in this notebook is licensed under the Apache License, 
-Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth 
-Australia data is licensed under the Creative Commons by Attribution 4.0 
+License: The code in this notebook is licensed under the Apache License,
+Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0). Digital Earth
+Australia data is licensed under the Creative Commons by Attribution 4.0
 license (https://creativecommons.org/licenses/by/4.0/).
 
-Contact: If you need assistance, please post a question on the Open Data 
-Cube Slack channel (http://slack.opendatacube.org/) or on the GIS Stack 
-Exchange (https://gis.stackexchange.com/questions/ask?tags=open-data-cube) 
-using the `open-data-cube` tag (you can view previously asked questions 
-here: https://gis.stackexchange.com/questions/tagged/open-data-cube). 
+Contact: If you need assistance, please post a question on the Open Data
+Cube Slack channel (http://slack.opendatacube.org/) or on the GIS Stack
+Exchange (https://gis.stackexchange.com/questions/ask?tags=open-data-cube)
+using the `open-data-cube` tag (you can view previously asked questions
+here: https://gis.stackexchange.com/questions/tagged/open-data-cube).
 
-If you would like to report an issue with this script, file one on 
+If you would like to report an issue with this script, file one on
 Github: https://github.com/GeoscienceAustralia/dea-notebooks/issues/new
 
 Last modified: November 2022
@@ -45,15 +45,15 @@ from shapely.geometry import LineString, MultiLineString, shape, mapping
 
 def _da_to_geo(da, crs):
     """
-    Helper function that uses `odc-geo` to ensure that an 
-    `xarray.DataArray` has a GeoBox and .odc.* accessor. 
-    This is used to ensure that spatial information can be 
+    Helper function that uses `odc-geo` to ensure that an
+    `xarray.DataArray` has a GeoBox and .odc.* accessor.
+    This is used to ensure that spatial information can be
     consistently accessed from any input array.
-    
+
     If `da` has missing Coordinate Reference System (CRS)
     information, this can be supplied using the `crs` param.
     """
-    
+
     # Import the odc-geo package to add `.odc.x` attributes
     # to our input xr.DataArray
     import odc.geo.xr
@@ -68,7 +68,7 @@ def _da_to_geo(da, crs):
             "CRS using the `crs` parameter "
             "(e.g. `crs='EPSG:3577'`)."
         )
-        
+
     return da
 
 
@@ -92,7 +92,7 @@ def xr_vectorize(
     attribute_col : str, optional
         Name of the attribute column in the resulting
         ``geopandas.GeoDataFrame``. Values from ``da`` converted
-        to polygons will be assigned to this column. If None, 
+        to polygons will be assigned to this column. If None,
         the column name will default to 'attribute'.
     crs : str or CRS object, optional
         If ``da``'s coordinate reference system (CRS) cannot be
@@ -116,7 +116,7 @@ def xr_vectorize(
     gdf : geopandas.GeoDataFrame
 
     """
-    
+
     # Add GeoBox and odc.* accessor to array using `odc-geo`
     da = _da_to_geo(da, crs)
 
@@ -137,8 +137,8 @@ def xr_vectorize(
 
     # Create a geopandas dataframe populated with the polygon shapes
     attribute_name = attribute_col if attribute_col is not None else 'attribute'
-    gdf = gpd.GeoDataFrame(data={attribute_name: values}, 
-                           geometry=polygons, 
+    gdf = gpd.GeoDataFrame(data={attribute_name: values},
+                           geometry=polygons,
                            crs=da.odc.crs)
 
     # If a file path is supplied, export to file
@@ -156,23 +156,23 @@ def xr_rasterize(gdf,
                  name=None,
                  output_path=None,
                  verbose=True,
-                 **rasterio_kwargs):    
+                 **rasterio_kwargs):
     """
-    Rasterizes a vector ``geopandas.GeoDataFrame`` into a 
+    Rasterizes a vector ``geopandas.GeoDataFrame`` into a
     raster ``xarray.DataArray``.
-  
+
     Parameters
     ----------
     gdf : geopandas.GeoDataFrame
         A ``geopandas.GeoDataFrame`` object containing the vector
         data you want to rasterise.
     da : xarray.DataArray or xarray.Dataset
-        The shape, coordinates, dimensions, and transform of this object 
-        are used to define the array that ``gdf`` is rasterized into. 
+        The shape, coordinates, dimensions, and transform of this object
+        are used to define the array that ``gdf`` is rasterized into.
         It effectively provides a spatial template.
     attribute_col : string, optional
         Name of the attribute column in ``gdf`` containing values for
-        each vector feature that will be rasterized. If None, the 
+        each vector feature that will be rasterized. If None, the
         output will be a boolean array of 1's and 0's.
     crs : str or CRS object, optional
         If ``da``'s coordinate reference system (CRS) cannot be
@@ -185,25 +185,25 @@ def xr_rasterize(gdf,
         data as a GeoTIFF file.
     verbose : bool, optional
         Print debugging messages. Default True.
-    **rasterio_kwargs : 
+    **rasterio_kwargs :
         A set of keyword arguments to ``rasterio.features.rasterize``.
         Can include: 'all_touched', 'merge_alg', 'dtype'.
-    
+
     Returns
     -------
     da_rasterized : xarray.DataArray
         The rasterized vector data.
     """
-    
+
     # Add GeoBox and odc.* accessor to array using `odc-geo`
     da = _da_to_geo(da, crs)
 
     # Reproject vector data to raster's CRS
     gdf_reproj = gdf.to_crs(crs=da.odc.crs)
 
-    # If an attribute column is specified, rasterise using vector 
+    # If an attribute column is specified, rasterise using vector
     # attribute values. Otherwise, rasterise into a boolean array
-    if attribute_col is not None:        
+    if attribute_col is not None:
         # Use the geometry and attributes from `gdf` to create an iterable
         shapes = zip(gdf_reproj.geometry, gdf_reproj[attribute_col])
     else:
@@ -220,15 +220,13 @@ def xr_rasterize(gdf,
 
     # Convert numpy array to a full xarray.DataArray
     # and set array name if supplied
-    da_rasterized = odc.geo.xr.wrap_xr(im=im, 
-                                       gbox=da.odc.geobox)
-    da_rasterized.rename(name)
-    
+    da_rasterized = odc.geo.xr.wrap_xr(im=im, gbox=da.odc.geobox).rename(name)
+
     # If a file path is supplied, export to file
     if output_path is not None:
         if verbose: print(f"Exporting raster data to {output_path}")
         write_cog(da_rasterized, output_path, overwrite=True)
-    
+
     return da_rasterized
 
 
@@ -241,36 +239,36 @@ def subpixel_contours(da,
                       dim='time',
                       errors='ignore',
                       verbose=True):
-    
+
     """
-    Uses `skimage.measure.find_contours` to extract multiple z-value 
+    Uses `skimage.measure.find_contours` to extract multiple z-value
     contour lines from a two-dimensional array (e.g. multiple elevations
-    from a single DEM), or one z-value for each array along a specified 
-    dimension of a multi-dimensional array (e.g. to map waterlines 
-    across time by extracting a 0 NDWI contour from each individual 
-    timestep in an xarray timeseries).    
-    
-    Contours are returned as a geopandas.GeoDataFrame with one row per 
-    z-value or one row per array along a specified dimension. The 
-    `attribute_df` parameter can be used to pass custom attributes 
+    from a single DEM), or one z-value for each array along a specified
+    dimension of a multi-dimensional array (e.g. to map waterlines
+    across time by extracting a 0 NDWI contour from each individual
+    timestep in an xarray timeseries).
+
+    Contours are returned as a geopandas.GeoDataFrame with one row per
+    z-value or one row per array along a specified dimension. The
+    `attribute_df` parameter can be used to pass custom attributes
     to the output contour features.
-    
+
     Last modified: November 2022
-    
+
     Parameters
-    ----------  
+    ----------
     da : xarray DataArray
-        A two-dimensional or multi-dimensional array from which 
-        contours are extracted. If a two-dimensional array is provided, 
-        the analysis will run in 'single array, multiple z-values' mode 
+        A two-dimensional or multi-dimensional array from which
+        contours are extracted. If a two-dimensional array is provided,
+        the analysis will run in 'single array, multiple z-values' mode
         which allows you to specify multiple `z_values` to be extracted.
-        If a multi-dimensional array is provided, the analysis will run 
-        in 'single z-value, multiple arrays' mode allowing you to 
-        extract contours for each array along the dimension specified 
-        by the `dim` parameter.  
+        If a multi-dimensional array is provided, the analysis will run
+        in 'single z-value, multiple arrays' mode allowing you to
+        extract contours for each array along the dimension specified
+        by the `dim` parameter.
     z_values : int, float or list of ints, floats
-        An individual z-value or list of multiple z-values to extract 
-        from the array. If operating in 'single z-value, multiple 
+        An individual z-value or list of multiple z-values to extract
+        from the array. If operating in 'single z-value, multiple
         arrays' mode specify only a single z-value.
     crs : string or CRS object, optional
         If ``da``'s coordinate reference system (CRS) cannot be
@@ -280,19 +278,19 @@ def subpixel_contours(da,
         The path and filename for the output shapefile.
     attribute_df : pandas.Dataframe, optional
         A pandas.Dataframe containing attributes to pass to the output
-        contour features. The dataframe must contain either the same 
-        number of rows as supplied `z_values` (in 'multiple z-value, 
-        single array' mode), or the same number of rows as the number 
-        of arrays along the `dim` dimension ('single z-value, multiple 
+        contour features. The dataframe must contain either the same
+        number of rows as supplied `z_values` (in 'multiple z-value,
+        single array' mode), or the same number of rows as the number
+        of arrays along the `dim` dimension ('single z-value, multiple
         arrays mode').
     min_vertices : int, optional
-        The minimum number of vertices required for a contour to be 
-        extracted. The default (and minimum) value is 2, which is the 
+        The minimum number of vertices required for a contour to be
+        extracted. The default (and minimum) value is 2, which is the
         smallest number required to produce a contour line (i.e. a start
-        and end point). Higher values remove smaller contours, 
+        and end point). Higher values remove smaller contours,
         potentially removing noise from the output dataset.
     dim : string, optional
-        The name of the dimension along which to extract contours when 
+        The name of the dimension along which to extract contours when
         operating in 'single z-value, multiple arrays' mode. The default
         is 'time', which extracts contours for each array along the time
         dimension.
@@ -303,15 +301,15 @@ def subpixel_contours(da,
         be raised.
     verbose : bool, optional
         Print debugging messages. Default is True.
-        
+
     Returns
     -------
     output_gdf : geopandas geodataframe
-        A geopandas geodataframe object with one feature per z-value 
-        ('single array, multiple z-values' mode), or one row per array 
-        along the dimension specified by the `dim` parameter ('single 
-        z-value, multiple arrays' mode). If `attribute_df` was 
-        provided, these values will be included in the shapefile's 
+        A geopandas geodataframe object with one feature per z-value
+        ('single array, multiple z-values' mode), or one row per array
+        along the dimension specified by the `dim` parameter ('single
+        z-value, multiple arrays' mode). If `attribute_df` was
+        provided, these values will be included in the shapefile's
         attribute table.
     """
 
@@ -319,21 +317,21 @@ def subpixel_contours(da,
         '''
         Helper function to apply marching squares contour extraction
         to an array and return a data as a shapely MultiLineString.
-        The `min_vertices` parameter allows you to drop small contours 
+        The `min_vertices` parameter allows you to drop small contours
         with less than X vertices.
         '''
-        
+
         # Extracts contours from array, and converts each discrete
-        # contour into a Shapely LineString feature. If the function 
+        # contour into a Shapely LineString feature. If the function
         # returns a KeyError, this may be due to an unresolved issue in
         # scikit-image: https://github.com/scikit-image/scikit-image/issues/4830
-        try:            
-            line_features = [LineString(i[:,[1, 0]]) 
-                             for i in find_contours(da_i.data, z_value) 
+        try:
+            line_features = [LineString(i[:,[1, 0]])
+                             for i in find_contours(da_i.data, z_value)
                              if i.shape[0] > min_vertices]
         except KeyError:
-            line_features = [LineString(i[:,[1, 0]]) 
-                             for i in find_contours(da_i.data, z_value + 1e-12) 
+            line_features = [LineString(i[:,[1, 0]])
+                             for i in find_contours(da_i.data, z_value + 1e-12)
                              if i.shape[0] > min_vertices]
 
         # Output resulting lines into a single combined MultiLineString
@@ -344,9 +342,9 @@ def subpixel_contours(da,
     da = _da_to_geo(da, crs)
 
     # If z_values is supplied is not a list, convert to list:
-    z_values = z_values if (isinstance(z_values, list) or 
+    z_values = z_values if (isinstance(z_values, list) or
                             isinstance(z_values, np.ndarray)) else [z_values]
-    
+
     # If dask collection, load into memory
     if dask.is_dask_collection(da):
         if verbose:
@@ -358,13 +356,13 @@ def subpixel_contours(da,
         if verbose:
             print(f'Operating in multiple z-value, single array mode')
         dim = 'z_value'
-        contour_arrays = {str(i)[0:10]: 
-                          _contours_to_multiline(da, i, min_vertices) 
-                          for i in z_values}    
+        contour_arrays = {str(i)[0:10]:
+                          _contours_to_multiline(da, i, min_vertices)
+                          for i in z_values}
 
     else:
 
-        # Test if only a single z-value is given when operating in 
+        # Test if only a single z-value is given when operating in
         # single z-value, multiple arrays mode
         if verbose:
             print(f'Operating in single z-value, multiple arrays mode')
@@ -372,8 +370,8 @@ def subpixel_contours(da,
             raise ValueError('Please provide a single z-value when operating '
                              'in single z-value, multiple arrays mode')
 
-        contour_arrays = {str(i)[0:10]: 
-                          _contours_to_multiline(da_i, z_values[0], min_vertices) 
+        contour_arrays = {str(i)[0:10]:
+                          _contours_to_multiline(da_i, z_values[0], min_vertices)
                           for i, da_i in da.groupby(dim)}
 
     # If attributes are provided, add the contour keys to that dataframe
@@ -396,16 +394,16 @@ def subpixel_contours(da,
         attribute_df = list(contour_arrays.keys())
 
     # Convert output contours to a geopandas.GeoDataFrame
-    contours_gdf = gpd.GeoDataFrame(data=attribute_df, 
+    contours_gdf = gpd.GeoDataFrame(data=attribute_df,
                                     geometry=list(contour_arrays.values()),
-                                    crs=da.odc.crs)   
+                                    crs=da.odc.crs)
 
     # Define affine and use to convert array coords to geographic coords.
-    # We need to add 0.5 x pixel size to the x and y to obtain the centre 
+    # We need to add 0.5 x pixel size to the x and y to obtain the centre
     # point of our pixels, rather than the top-left corner
     affine = da.odc.geobox.transform
-    shapely_affine = [affine.a, affine.b, affine.d, affine.e, 
-                      affine.xoff + affine.a / 2.0, 
+    shapely_affine = [affine.a, affine.b, affine.d, affine.e,
+                      affine.xoff + affine.a / 2.0,
                       affine.yoff + affine.e / 2.0]
     contours_gdf['geometry'] = contours_gdf.affine_transform(shapely_affine)
 
@@ -444,88 +442,88 @@ def subpixel_contours(da,
         if verbose:
             print(f'Writing contours to {output_path}')
         contours_gdf.to_file(filename=output_path)
-        
+
     return contours_gdf
 
 
-def interpolate_2d(ds, 
-                   x_coords, 
-                   y_coords, 
-                   z_coords, 
+def interpolate_2d(ds,
+                   x_coords,
+                   y_coords,
+                   z_coords,
                    method='linear',
                    factor=1,
                    verbose=False,
                    **kwargs):
-    
+
     """
-    This function takes points with X, Y and Z coordinates, and 
-    interpolates Z-values across the extent of an existing xarray 
+    This function takes points with X, Y and Z coordinates, and
+    interpolates Z-values across the extent of an existing xarray
     dataset. This can be useful for producing smooth surfaces from point
-    data that can be compared directly against satellite data derived 
+    data that can be compared directly against satellite data derived
     from an OpenDataCube query.
-    
+
     Supported interpolation methods include 'linear', 'nearest' and
-    'cubic (using `scipy.interpolate.griddata`), and 'rbf' (using 
+    'cubic (using `scipy.interpolate.griddata`), and 'rbf' (using
     `scipy.interpolate.Rbf`).
-    
+
     Last modified: February 2020
-    
+
     Parameters
-    ----------  
+    ----------
     ds : xarray DataArray or Dataset
-        A two-dimensional or multi-dimensional array from which x and y 
-        dimensions will be copied and used for the area in which to 
-        interpolate point data. 
+        A two-dimensional or multi-dimensional array from which x and y
+        dimensions will be copied and used for the area in which to
+        interpolate point data.
     x_coords, y_coords : numpy array
-        Arrays containing X and Y coordinates for all points (e.g. 
+        Arrays containing X and Y coordinates for all points (e.g.
         longitudes and latitudes).
     z_coords : numpy array
-        An array containing Z coordinates for all points (e.g. 
-        elevations). These are the values you wish to interpolate 
+        An array containing Z coordinates for all points (e.g.
+        elevations). These are the values you wish to interpolate
         between.
     method : string, optional
         The method used to interpolate between point values. This string
-        is either passed to `scipy.interpolate.griddata` (for 'linear', 
-        'nearest' and 'cubic' methods), or used to specify Radial Basis 
+        is either passed to `scipy.interpolate.griddata` (for 'linear',
+        'nearest' and 'cubic' methods), or used to specify Radial Basis
         Function interpolation using `scipy.interpolate.Rbf` ('rbf').
         Defaults to 'linear'.
     factor : int, optional
-        An optional integer that can be used to subsample the spatial 
+        An optional integer that can be used to subsample the spatial
         interpolation extent to obtain faster interpolation times, then
-        up-sample this array back to the original dimensions of the 
-        data as a final step. For example, setting `factor=10` will 
-        interpolate data into a grid that has one tenth of the 
-        resolution of `ds`. This approach will be significantly faster 
-        than interpolating at full resolution, but will potentially 
+        up-sample this array back to the original dimensions of the
+        data as a final step. For example, setting `factor=10` will
+        interpolate data into a grid that has one tenth of the
+        resolution of `ds`. This approach will be significantly faster
+        than interpolating at full resolution, but will potentially
         produce less accurate or reliable results.
     verbose : bool, optional
         Print debugging messages. Default False.
-    **kwargs : 
-        Optional keyword arguments to pass to either 
-        `scipy.interpolate.griddata` (if `method` is 'linear', 'nearest' 
+    **kwargs :
+        Optional keyword arguments to pass to either
+        `scipy.interpolate.griddata` (if `method` is 'linear', 'nearest'
         or 'cubic'), or `scipy.interpolate.Rbf` (is `method` is 'rbf').
-      
+
     Returns
     -------
     interp_2d_array : xarray DataArray
-        An xarray DataArray containing with x and y coordinates copied 
-        from `ds_array`, and Z-values interpolated from the points data. 
+        An xarray DataArray containing with x and y coordinates copied
+        from `ds_array`, and Z-values interpolated from the points data.
     """
-    
+
     # Extract xy and elev points
     points_xy = np.vstack([x_coords, y_coords]).T
-    
-    # Extract x and y coordinates to interpolate into. 
-    # If `factor` is greater than 1, the coordinates will be subsampled 
-    # for faster run-times. If the last x or y value in the subsampled 
-    # grid aren't the same as the last x or y values in the original 
-    # full resolution grid, add the final full resolution grid value to 
+
+    # Extract x and y coordinates to interpolate into.
+    # If `factor` is greater than 1, the coordinates will be subsampled
+    # for faster run-times. If the last x or y value in the subsampled
+    # grid aren't the same as the last x or y values in the original
+    # full resolution grid, add the final full resolution grid value to
     # ensure data is interpolated up to the very edge of the array
     if ds.x[::factor][-1].item() == ds.x[-1].item():
         x_grid_coords = ds.x[::factor].values
     else:
         x_grid_coords = ds.x[::factor].values.tolist() + [ds.x[-1].item()]
-        
+
     if ds.y[::factor][-1].item() == ds.y[-1].item():
         y_grid_coords = ds.y[::factor].values
     else:
@@ -533,62 +531,62 @@ def interpolate_2d(ds,
 
     # Create grid to interpolate into
     grid_y, grid_x = np.meshgrid(x_grid_coords, y_grid_coords)
-    
+
     # Apply scipy.interpolate.griddata interpolation methods
     if method in ('linear', 'nearest', 'cubic'):
-        
-        # Interpolate x, y and z values 
-        interp_2d = scipy.interpolate.griddata(points=points_xy, 
-                                               values=z_coords, 
-                                               xi=(grid_y, grid_x), 
+
+        # Interpolate x, y and z values
+        interp_2d = scipy.interpolate.griddata(points=points_xy,
+                                               values=z_coords,
+                                               xi=(grid_y, grid_x),
                                                method=method,
                                                **kwargs)
-    
+
     # Apply Radial Basis Function interpolation
     elif method == 'rbf':
 
-        # Interpolate x, y and z values 
-        rbf = scipy.interpolate.Rbf(x_coords, y_coords, z_coords, **kwargs)  
+        # Interpolate x, y and z values
+        rbf = scipy.interpolate.Rbf(x_coords, y_coords, z_coords, **kwargs)
         interp_2d = rbf(grid_y, grid_x)
 
     # Create xarray dataarray from the data and resample to ds coords
-    interp_2d_da = xr.DataArray(interp_2d, 
-                                coords=[y_grid_coords, x_grid_coords], 
+    interp_2d_da = xr.DataArray(interp_2d,
+                                coords=[y_grid_coords, x_grid_coords],
                                 dims=['y', 'x'])
-    
+
     # If factor is greater than 1, resample the interpolated array to
     # match the input `ds` array
-    if factor > 1: 
-        interp_2d_da = interp_2d_da.interp_like(ds)   
+    if factor > 1:
+        interp_2d_da = interp_2d_da.interp_like(ds)
 
     return interp_2d_da
 
 
 def contours_to_arrays(gdf, col):
-    
+
     """
     This function converts a polyline shapefile into an array with three
     columns giving the X, Y and Z coordinates of each vertex. This data
-    can then be used as an input to interpolation procedures (e.g. using 
+    can then be used as an input to interpolation procedures (e.g. using
     a function like `interpolate_2d`.
-    
+
     Last modified: October 2021
-    
+
     Parameters
-    ----------  
+    ----------
     gdf : Geopandas GeoDataFrame
-        A GeoPandas GeoDataFrame of lines to convert into point 
+        A GeoPandas GeoDataFrame of lines to convert into point
         coordinates.
     col : str
-        A string giving the name of the GeoDataFrame field to use as 
+        A string giving the name of the GeoDataFrame field to use as
         Z-values.
-        
+
     Returns
     -------
-    A numpy array with three columns giving the X, Y and Z coordinates 
+    A numpy array with three columns giving the X, Y and Z coordinates
     of each vertex in the input GeoDataFrame.
-        
-    """        
+
+    """
 
     coords_zvals = []
 
@@ -597,55 +595,55 @@ def contours_to_arrays(gdf, col):
         val = gdf.iloc[i][col]
 
         try:
-            coords = np.concatenate([np.vstack(x.coords.xy).T 
+            coords = np.concatenate([np.vstack(x.coords.xy).T
                                      for x in gdf.iloc[i].geometry.geoms])
         except:
             coords = np.vstack(gdf.iloc[i].geometry.coords.xy).T
 
-        coords_zvals.append(np.column_stack((coords, 
-                                             np.full(np.shape(coords)[0], 
+        coords_zvals.append(np.column_stack((coords,
+                                             np.full(np.shape(coords)[0],
                                                      fill_value=val))))
 
     return np.concatenate(coords_zvals)
 
 
 def largest_region(bool_array, **kwargs):
-    
+
     '''
-    Takes a boolean array and identifies the largest contiguous region of 
-    connected True values. This is returned as a new array with cells in 
+    Takes a boolean array and identifies the largest contiguous region of
+    connected True values. This is returned as a new array with cells in
     the largest region marked as True, and all other cells marked as False.
-    
+
     Parameters
-    ----------  
+    ----------
     bool_array : boolean array
         A boolean array (numpy or xarray.DataArray) with True values for
-        the areas that will be inspected to find the largest group of 
+        the areas that will be inspected to find the largest group of
         connected cells
-    **kwargs : 
+    **kwargs :
         Optional keyword arguments to pass to `measure.label`
-        
+
     Returns
     -------
     largest_region : boolean array
-        A boolean array with cells in the largest region marked as True, 
-        and all other cells marked as False.       
-        
+        A boolean array with cells in the largest region marked as True,
+        and all other cells marked as False.
+
     '''
-    
+
     # First, break boolean array into unique, discrete regions/blobs
     blobs_labels = label(bool_array, background=0, **kwargs)
-    
+
     # Count the size of each blob, excluding the background class (0)
-    ids, counts = np.unique(blobs_labels[blobs_labels > 0], 
-                            return_counts=True) 
-    
+    ids, counts = np.unique(blobs_labels[blobs_labels > 0],
+                            return_counts=True)
+
     # Identify the region ID of the largest blob
     largest_region_id = ids[np.argmax(counts)]
-    
+
     # Produce a boolean array where 1 == the largest region
     largest_region = blobs_labels == largest_region_id
-    
+
     return largest_region
 
 
@@ -680,9 +678,9 @@ def zonal_stats_parallel(shp,
 
     """
     Summarizing raster datasets based on vector geometries in parallel.
-    Each cpu recieves an equal chunk of the dataset. 
+    Each cpu recieves an equal chunk of the dataset.
     Utilizes the perrygeo/rasterstats package.
-    
+
     Parameters
     ----------
     shp : str
@@ -697,33 +695,33 @@ def zonal_stats_parallel(shp,
     out_shp: str
         Path to export shapefile containing zonal statistics.
     ncpus: int
-        number of cores to parallelize the operations over. 
-    kwargs: 
+        number of cores to parallelize the operations over.
+    kwargs:
         Any other keyword arguments to rasterstats.zonal_stats()
         See https://github.com/perrygeo/python-rasterstats for
         all options
-            
+
     Returns
     -------
     Exports a shapefile to disk containing the zonal statistics requested
-    
+
     """
-    
+
     #yields n sized chunks from list l (used for splitting task to multiple processes)
     def chunks(l, n):
         for i in range(0, len(l), n):
             yield l[i:i + n]
 
     #calculates zonal stats and adds results to a dictionary
-    def worker(z,raster,d):	
+    def worker(z,raster,d):
         z_stats = zonal_stats(z,raster,stats=statistics,**kwargs)
         for i in range(0,len(z_stats)):
             d[z[i]['id']]=z_stats[i]
 
     #write output polygon
     def write_output(zones, out_shp,d):
-        
-        #copy schema and crs from input and add new fields for each statistic     
+
+        #copy schema and crs from input and add new fields for each statistic
         schema = zones.schema.copy()
         crs = zones.crs
         for stat in statistics:
@@ -734,16 +732,16 @@ def zonal_stats_parallel(shp,
                 for stat in statistics:
                     elem['properties'][stat]=d[elem['id']][stat]
                 output.write({'properties':elem['properties'],'geometry': mapping(shape(elem['geometry']))})
-    
+
     with fiona.open(shp) as zones:
         jobs = []
 
         # create manager dictionary (polygon ids=keys, stats=entries)
         # where multiple processes can write without conflicts
-        man = mp.Manager()	
-        d = man.dict()	
+        man = mp.Manager()
+        d = man.dict()
 
-        #split zone polygons into 'ncpus' chunks for parallel processing 
+        #split zone polygons into 'ncpus' chunks for parallel processing
         # and call worker() for each
         split = chunks(zones, len(zones)//ncpus)
         for z in split:
@@ -758,65 +756,65 @@ def zonal_stats_parallel(shp,
 
 
 def reverse_geocode(coords, site_classes=None, state_classes=None):
-    
+
     """
-    Takes a latitude and longitude coordinate, and performs a reverse 
-    geocode to return a plain-text description of the location in the 
+    Takes a latitude and longitude coordinate, and performs a reverse
+    geocode to return a plain-text description of the location in the
     form:
-        
+
         Site, State
-        
+
     E.g.: `reverse_geocode(coords=(-35.282163, 149.128835))`
-    
+
         'Canberra, Australian Capital Territory'
 
     Parameters
     ----------
     coords : tuple of floats
-        A tuple of (latitude, longitude) coordinates used to perform 
+        A tuple of (latitude, longitude) coordinates used to perform
         the reverse geocode.
     site_classes : list of strings, optional
-        A list of strings used to define the site part of the plain 
-        text location description. Because the contents of the geocoded 
+        A list of strings used to define the site part of the plain
+        text location description. Because the contents of the geocoded
         address can vary greatly depending on location, these strings
         are tested against the address one by one until a match is made.
-        Defaults to: `['city', 'town', 'village', 'suburb', 'hamlet', 
-                       'county', 'municipality']`.      
+        Defaults to: `['city', 'town', 'village', 'suburb', 'hamlet',
+                       'county', 'municipality']`.
     state_classes : list of strings, optional
-        A list of strings used to define the state part of the plain 
-        text location description. These strings are tested against the 
-        address one by one until a match is made. Defaults to: 
+        A list of strings used to define the state part of the plain
+        text location description. These strings are tested against the
+        address one by one until a match is made. Defaults to:
         `['state', 'territory']`.
 
     Returns
     -------
-    If a valid geocoded address is found, a plain text location 
+    If a valid geocoded address is found, a plain text location
     description will be returned:
-    
+
         'Site, State'
-    
+
     If no valid address is found, formatted coordinates will be returned
     instead:
-    
-        'XX.XX S, XX.XX E'   
+
+        'XX.XX S, XX.XX E'
 
     """
 
     # Run reverse geocode using coordinates
     geocoder = Nominatim(user_agent='Digital Earth Australia')
     out = geocoder.reverse(coords)
-    
+
     # Create plain text-coords as fall-back
     lat = f'{-coords[0]:.2f} S' if coords[0] < 0 else f'{coords[0]:.2f} N'
     lon = f'{-coords[1]:.2f} W' if coords[1] < 0 else f'{coords[1]:.2f} E'
 
     try:
-        
+
         # Get address from geocoded data
         address = out.raw['address']
 
         # Use site and state classes if supplied; else use defaults
-        default_site_classes = ['city', 'town', 'village', 'suburb', 'hamlet', 
+        default_site_classes = ['city', 'town', 'village', 'suburb', 'hamlet',
                                 'county', 'municipality']
         default_state_classes = ['state', 'territory']
         site_classes = site_classes if site_classes else default_site_classes
@@ -825,20 +823,20 @@ def reverse_geocode(coords, site_classes=None, state_classes=None):
         # Return the first site or state class that exists in address dict
         site = next((address[k] for k in site_classes if k in address), None)
         state = next((address[k] for k in state_classes if k in address), None)
-        
+
         # If site and state exist in the data, return this.
         # Otherwise, return N/E/S/W coordinates.
         if site and state:
 
             # Return as site, state formatted string
             return f'{site}, {state}'
-        
+
         else:
-            
+
             # If no geocoding result, return N/E/S/W coordinates
             print('No valid geocoded location; returning coordinates instead')
             return f'{lat}, {lon}'
-              
+
     except (KeyError, AttributeError):
 
         # If no geocoding result, return N/E/S/W coordinates


### PR DESCRIPTION
### Proposed changes
The rename parameter of the xr_rasterize function was not working because the renamed variable was not saved.

This
```python
da_rasterized = odc.geo.xr.wrap_xr(im=im, 
                                       gbox=da.odc.geobox)
    da_rasterized.rename(name)
```

Is changed to: `da_rasterized = odc.geo.xr.wrap_xr(im=im, gbox=da.odc.geobox).rename(name)`

In a new PR to avoid conflicts due to black formatting. 