### PR TITLE
clarify dea-tools pip installation instructions

### DIFF
--- a/Tools/README.rst
+++ b/Tools/README.rst
@@ -51,7 +51,8 @@ With conda
 Install dea-tools
 ~~~~~~~~~~~~~~~~~
 
-Install the package from the source on any system with ``pip``:
+You can install ``dea-tools`` with ``pip`` in a Python environment where
+`GDAL https://pypi.org/project/GDAL/`_ and `pyproj https://pypi.org/project/pyproj/`_ are already installed.
 
 .. code-block:: bash
 


### PR DESCRIPTION
### Proposed changes
Installing `dea-tools` with `pip` is tricky, and we should clarify that it doesn't just work.