### PR TITLE
pin index tool version as the bug in the new release

### DIFF
--- a/Tests/setup_test_datacube.sh
+++ b/Tests/setup_test_datacube.sh
@@ -5,7 +5,7 @@ set -ex
 set -o pipefail
 
 # install indexing tool
-pip3 install --no-cache  "odc-apps-dc-tools>=0.2.13"
+pip3 install --no-cache  "odc-apps-dc-tools==0.2.12"
 
 # Setup datacube
 datacube system init --no-init-users


### PR DESCRIPTION
### Proposed changes
Pin the index tool to a lower version as it has an issue related to https://github.com/opendatacube/datacube-core/issues/1490. Also #1113 not caused by the index tool by the dependency of `pystac`. So the sandbox docker image will pin `jsonschema<4.18` for compatibility. 

### Closes issues (optional)
- Closes Issue #1113 
### Checklist (replace `[ ]` with `[x]` to check off)
- [x] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [x] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [x] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


