### PR TITLE
Bug fix #1136 fix typos and grammatical errors

### DIFF
--- a/DEA_products/DEA_Mangroves.ipynb
+++ b/DEA_products/DEA_Mangroves.ipynb
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## What this product offers\n",
+    "### What this product offers\n",
     "\n",
     "The [DEA Mangroves](https://cmi.ga.gov.au/data-products/dea/634/dea-mangrove-canopy-cover-landsat) data product maps the annual canopy cover density of Australian mangroves within a fixed extent around the entire continental coastline. \n",
     "The extent represents a union of [Global Mangrove Watch layers](https://data.unep-wcmc.org/datasets/45) for multiple years, produced by the Japanese Aerospace Exploration Agency.\n",
@@ -57,7 +57,7 @@
     "tags": []
    },
    "source": [
-    "## Publications\n",
+    "### Publications\n",
     "\n",
     "[Lymburner, L., Bunting, P., Lucas, R., Scarth, P., Alam, I., Phillips, C., Ticehurst, C., & Held, A., (2020). Mapping the multi-decadal mangrove dynamics of the Australian coastline. Remote Sensing of Environment, 238, 111185.](https://doi.org/10.1016/j.rse.2019.05.004)"
    ]
@@ -385,7 +385,7 @@
        "            &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width,\n",
        "                initial-scale=1.0, maximum-scale=1.0, user-scalable=no&quot; /&gt;\n",
        "            &lt;style&gt;\n",
-       "                #map_b56b8d3d7cdb0608635c1dbde232a795 {\n",
+       "                #map_25556faf95341e64b36cc4a441d7f792 {\n",
        "                    position: relative;\n",
        "                    width: 100.0%;\n",
        "                    height: 100.0%;\n",
@@ -399,14 +399,14 @@
        "&lt;body&gt;\n",
        "    \n",
        "    \n",
-       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_b56b8d3d7cdb0608635c1dbde232a795&quot; &gt;&lt;/div&gt;\n",
+       "            &lt;div class=&quot;folium-map&quot; id=&quot;map_25556faf95341e64b36cc4a441d7f792&quot; &gt;&lt;/div&gt;\n",
        "        \n",
        "&lt;/body&gt;\n",
        "&lt;script&gt;\n",
        "    \n",
        "    \n",
-       "            var map_b56b8d3d7cdb0608635c1dbde232a795 = L.map(\n",
-       "                &quot;map_b56b8d3d7cdb0608635c1dbde232a795&quot;,\n",
+       "            var map_25556faf95341e64b36cc4a441d7f792 = L.map(\n",
+       "                &quot;map_25556faf95341e64b36cc4a441d7f792&quot;,\n",
        "                {\n",
        "                    center: [-15.74995, 136.60435],\n",
        "                    crs: L.CRS.EPSG3857,\n",
@@ -420,33 +420,33 @@
        "\n",
        "        \n",
        "    \n",
-       "            var tile_layer_cdcc8a5b1adc17fed3193c2dd51feb78 = L.tileLayer(\n",
+       "            var tile_layer_2c91e00cc8bf2b6a3552289f9a625b08 = L.tileLayer(\n",
        "                &quot;http://mt1.google.com/vt/lyrs=y\\u0026z={z}\\u0026x={x}\\u0026y={y}&quot;,\n",
        "                {&quot;attribution&quot;: &quot;Google&quot;, &quot;detectRetina&quot;: false, &quot;maxNativeZoom&quot;: 18, &quot;maxZoom&quot;: 18, &quot;minZoom&quot;: 0, &quot;noWrap&quot;: false, &quot;opacity&quot;: 1, &quot;subdomains&quot;: &quot;abc&quot;, &quot;tms&quot;: false}\n",
-       "            ).addTo(map_b56b8d3d7cdb0608635c1dbde232a795);\n",
+       "            ).addTo(map_25556faf95341e64b36cc4a441d7f792);\n",
        "        \n",
        "    \n",
-       "            var poly_line_cf628e27124e75e8d3b912738dd828be = L.polyline(\n",
+       "            var poly_line_854c9d03ddb08c73884dfab47a9d218d = L.polyline(\n",
        "                [[-15.6806, 136.5202], [-15.6806, 136.6885], [-15.8193, 136.6885], [-15.8193, 136.5202], [-15.6806, 136.5202]],\n",
        "                {&quot;bubblingMouseEvents&quot;: true, &quot;color&quot;: &quot;red&quot;, &quot;dashArray&quot;: null, &quot;dashOffset&quot;: null, &quot;fill&quot;: false, &quot;fillColor&quot;: &quot;red&quot;, &quot;fillOpacity&quot;: 0.2, &quot;fillRule&quot;: &quot;evenodd&quot;, &quot;lineCap&quot;: &quot;round&quot;, &quot;lineJoin&quot;: &quot;round&quot;, &quot;noClip&quot;: false, &quot;opacity&quot;: 0.8, &quot;smoothFactor&quot;: 1.0, &quot;stroke&quot;: true, &quot;weight&quot;: 3}\n",
-       "            ).addTo(map_b56b8d3d7cdb0608635c1dbde232a795);\n",
+       "            ).addTo(map_25556faf95341e64b36cc4a441d7f792);\n",
        "        \n",
        "    \n",
-       "                var lat_lng_popup_2a6b65c0b6395601c90f5cc06f6a2254 = L.popup();\n",
+       "                var lat_lng_popup_60d16801380a873657d977da4638bf6f = L.popup();\n",
        "                function latLngPop(e) {\n",
-       "                    lat_lng_popup_2a6b65c0b6395601c90f5cc06f6a2254\n",
+       "                    lat_lng_popup_60d16801380a873657d977da4638bf6f\n",
        "                        .setLatLng(e.latlng)\n",
        "                        .setContent(&quot;Latitude: &quot; + e.latlng.lat.toFixed(4) +\n",
        "                                    &quot;&lt;br&gt;Longitude: &quot; + e.latlng.lng.toFixed(4))\n",
-       "                        .openOn(map_b56b8d3d7cdb0608635c1dbde232a795);\n",
+       "                        .openOn(map_25556faf95341e64b36cc4a441d7f792);\n",
        "                    }\n",
-       "                map_b56b8d3d7cdb0608635c1dbde232a795.on(&#x27;click&#x27;, latLngPop);\n",
+       "                map_25556faf95341e64b36cc4a441d7f792.on(&#x27;click&#x27;, latLngPop);\n",
        "            \n",
        "&lt;/script&gt;\n",
        "&lt;/html&gt;\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
       ],
       "text/plain": [
-       "<folium.folium.Map at 0x7f76b594a880>"
+       "<folium.folium.Map at 0x7f25cf711a90>"
       ]
      },
      "execution_count": 5,
@@ -853,7 +853,7 @@
        "    canopy_cover_class  (time, y, x) uint8 255 255 255 255 ... 255 255 255 255\n",
        "Attributes:\n",
        "    crs:           EPSG:3577\n",
-       "    grid_mapping:  spatial_ref</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-9b73c300-2878-4789-99c8-b0ba1b09e773' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-9b73c300-2878-4789-99c8-b0ba1b09e773' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 35</li><li><span class='xr-has-index'>y</span>: 531</li><li><span class='xr-has-index'>x</span>: 624</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-f961b56f-649a-4cab-8030-b3876487c477' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f961b56f-649a-4cab-8030-b3876487c477' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1988-07-01T23:59:59.999999 ... 2...</div><input id='attrs-ab4e1b5a-9b2b-46d4-9b35-74eb05f03983' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ab4e1b5a-9b2b-46d4-9b35-74eb05f03983' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a6c9045a-6efa-434a-bd20-c86777c36aae' class='xr-var-data-in' type='checkbox'><label for='data-a6c9045a-6efa-434a-bd20-c86777c36aae' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>seconds since 1970-01-01 00:00:00</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;1988-07-01T23:59:59.999999000&#x27;, &#x27;1989-07-02T11:59:59.999999000&#x27;,\n",
+       "    grid_mapping:  spatial_ref</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-62d600c9-dfe3-45a4-a72a-456d64e36b8d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-62d600c9-dfe3-45a4-a72a-456d64e36b8d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 35</li><li><span class='xr-has-index'>y</span>: 531</li><li><span class='xr-has-index'>x</span>: 624</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-c68b349a-82fa-48b1-a85e-8e121286c51f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c68b349a-82fa-48b1-a85e-8e121286c51f' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>1988-07-01T23:59:59.999999 ... 2...</div><input id='attrs-132d1378-64ec-43bc-aadb-1e29533d6cd9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-132d1378-64ec-43bc-aadb-1e29533d6cd9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d2479b1a-db35-4294-9055-c8a14478bf56' class='xr-var-data-in' type='checkbox'><label for='data-d2479b1a-db35-4294-9055-c8a14478bf56' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>seconds since 1970-01-01 00:00:00</dd></dl></div><div class='xr-var-data'><pre>array([&#x27;1988-07-01T23:59:59.999999000&#x27;, &#x27;1989-07-02T11:59:59.999999000&#x27;,\n",
        "       &#x27;1990-07-02T11:59:59.999999000&#x27;, &#x27;1991-07-02T11:59:59.999999000&#x27;,\n",
        "       &#x27;1992-07-01T23:59:59.999999000&#x27;, &#x27;1993-07-02T11:59:59.999999000&#x27;,\n",
        "       &#x27;1994-07-02T11:59:59.999999000&#x27;, &#x27;1995-07-02T11:59:59.999999000&#x27;,\n",
@@ -870,7 +870,7 @@
        "       &#x27;2016-07-01T23:59:59.999999000&#x27;, &#x27;2017-07-02T11:59:59.999999000&#x27;,\n",
        "       &#x27;2018-07-02T11:59:59.999999000&#x27;, &#x27;2019-07-02T11:59:59.999999000&#x27;,\n",
        "       &#x27;2020-07-01T23:59:59.999999000&#x27;, &#x27;2021-07-02T11:59:59.999999000&#x27;,\n",
-       "       &#x27;2022-07-02T11:59:59.999999000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.675e+06 ... -1.691e+06</div><input id='attrs-027160d5-1dd0-4204-ba8c-add6527d1308' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-027160d5-1dd0-4204-ba8c-add6527d1308' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d72270db-4e82-4aa8-87a4-13c9249761f1' class='xr-var-data-in' type='checkbox'><label for='data-d72270db-4e82-4aa8-87a4-13c9249761f1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>metre</dd><dt><span>resolution :</span></dt><dd>-30.0</dd><dt><span>crs :</span></dt><dd>EPSG:3577</dd></dl></div><div class='xr-var-data'><pre>array([-1674945., -1674975., -1675005., ..., -1690785., -1690815., -1690845.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4.871e+05 4.872e+05 ... 5.058e+05</div><input id='attrs-6ad1997c-c49f-40c2-b531-868d16f30f04' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6ad1997c-c49f-40c2-b531-868d16f30f04' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c672f858-6da8-44a2-b7e9-abab61ff77c4' class='xr-var-data-in' type='checkbox'><label for='data-c672f858-6da8-44a2-b7e9-abab61ff77c4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>metre</dd><dt><span>resolution :</span></dt><dd>30.0</dd><dt><span>crs :</span></dt><dd>EPSG:3577</dd></dl></div><div class='xr-var-data'><pre>array([487125., 487155., 487185., ..., 505755., 505785., 505815.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>3577</div><input id='attrs-3df607f5-0b1a-4ef4-a970-f269ccc2e822' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3df607f5-0b1a-4ef4-a970-f269ccc2e822' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3502305b-7f68-46ee-82a7-cbc848e43186' class='xr-var-data-in' type='checkbox'><label for='data-3502305b-7f68-46ee-82a7-cbc848e43186' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>spatial_ref :</span></dt><dd>PROJCS[&quot;GDA94 / Australian Albers&quot;,GEOGCS[&quot;GDA94&quot;,DATUM[&quot;Geocentric_Datum_of_Australia_1994&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6283&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4283&quot;]],PROJECTION[&quot;Albers_Conic_Equal_Area&quot;],PARAMETER[&quot;latitude_of_center&quot;,0],PARAMETER[&quot;longitude_of_center&quot;,132],PARAMETER[&quot;standard_parallel_1&quot;,-18],PARAMETER[&quot;standard_parallel_2&quot;,-36],PARAMETER[&quot;false_easting&quot;,0],PARAMETER[&quot;false_northing&quot;,0],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Easting&quot;,EAST],AXIS[&quot;Northing&quot;,NORTH],AUTHORITY[&quot;EPSG&quot;,&quot;3577&quot;]]</dd><dt><span>grid_mapping_name :</span></dt><dd>albers_conical_equal_area</dd></dl></div><div class='xr-var-data'><pre>array(3577, dtype=int32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5bf7f8c5-0eb1-4915-aa87-a14e422dfb95' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5bf7f8c5-0eb1-4915-aa87-a14e422dfb95' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>canopy_cover_class</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>255 255 255 255 ... 255 255 255 255</div><input id='attrs-8977705f-14d8-439d-85cb-5b23ea0d91ea' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8977705f-14d8-439d-85cb-5b23ea0d91ea' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-802e3047-fbc6-454d-a5e3-b349d2649f59' class='xr-var-data-in' type='checkbox'><label for='data-802e3047-fbc6-454d-a5e3-b349d2649f59' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>1</dd><dt><span>nodata :</span></dt><dd>255</dd><dt><span>flags_definition :</span></dt><dd>{&#x27;woodland&#x27;: {&#x27;bits&#x27;: [0, 1, 2, 3, 4, 5, 6, 7], &#x27;values&#x27;: {&#x27;1&#x27;: True}, &#x27;description&#x27;: &#x27;Woodland&#x27;}, &#x27;notobserved&#x27;: {&#x27;bits&#x27;: [0, 1, 2, 3, 4, 5, 6, 7], &#x27;values&#x27;: {&#x27;0&#x27;: True}, &#x27;description&#x27;: &#x27;Mangroves not observed&#x27;}, &#x27;open_forest&#x27;: {&#x27;bits&#x27;: [0, 1, 2, 3, 4, 5, 6, 7], &#x27;values&#x27;: {&#x27;2&#x27;: True}, &#x27;description&#x27;: &#x27;Open Forest&#x27;}, &#x27;closed_forest&#x27;: {&#x27;bits&#x27;: [0, 1, 2, 3, 4, 5, 6, 7], &#x27;values&#x27;: {&#x27;3&#x27;: True}, &#x27;description&#x27;: &#x27;Closed Forest&#x27;}}</dd><dt><span>crs :</span></dt><dd>EPSG:3577</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><pre>array([[[255, 255, 255, ..., 255, 255, 255],\n",
+       "       &#x27;2022-07-02T11:59:59.999999000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.675e+06 ... -1.691e+06</div><input id='attrs-271d83de-9e32-43f2-b5bc-8d3979e31b97' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-271d83de-9e32-43f2-b5bc-8d3979e31b97' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d48ef425-762e-405f-86d4-272929ca47c6' class='xr-var-data-in' type='checkbox'><label for='data-d48ef425-762e-405f-86d4-272929ca47c6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>metre</dd><dt><span>resolution :</span></dt><dd>-30.0</dd><dt><span>crs :</span></dt><dd>EPSG:3577</dd></dl></div><div class='xr-var-data'><pre>array([-1674945., -1674975., -1675005., ..., -1690785., -1690815., -1690845.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4.871e+05 4.872e+05 ... 5.058e+05</div><input id='attrs-c1c27da2-9480-4c0e-bcb1-afe78b4ba792' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c1c27da2-9480-4c0e-bcb1-afe78b4ba792' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7aa4b64c-0827-4e63-b415-6ac336047031' class='xr-var-data-in' type='checkbox'><label for='data-7aa4b64c-0827-4e63-b415-6ac336047031' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>metre</dd><dt><span>resolution :</span></dt><dd>30.0</dd><dt><span>crs :</span></dt><dd>EPSG:3577</dd></dl></div><div class='xr-var-data'><pre>array([487125., 487155., 487185., ..., 505755., 505785., 505815.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>3577</div><input id='attrs-ba3548fb-bf1e-48b8-8df4-b24b7ae44566' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ba3548fb-bf1e-48b8-8df4-b24b7ae44566' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2115ee35-6571-4738-bc84-5ee635abf8eb' class='xr-var-data-in' type='checkbox'><label for='data-2115ee35-6571-4738-bc84-5ee635abf8eb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>spatial_ref :</span></dt><dd>PROJCS[&quot;GDA94 / Australian Albers&quot;,GEOGCS[&quot;GDA94&quot;,DATUM[&quot;Geocentric_Datum_of_Australia_1994&quot;,SPHEROID[&quot;GRS 1980&quot;,6378137,298.257222101,AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6283&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;4283&quot;]],PROJECTION[&quot;Albers_Conic_Equal_Area&quot;],PARAMETER[&quot;latitude_of_center&quot;,0],PARAMETER[&quot;longitude_of_center&quot;,132],PARAMETER[&quot;standard_parallel_1&quot;,-18],PARAMETER[&quot;standard_parallel_2&quot;,-36],PARAMETER[&quot;false_easting&quot;,0],PARAMETER[&quot;false_northing&quot;,0],UNIT[&quot;metre&quot;,1,AUTHORITY[&quot;EPSG&quot;,&quot;9001&quot;]],AXIS[&quot;Easting&quot;,EAST],AXIS[&quot;Northing&quot;,NORTH],AUTHORITY[&quot;EPSG&quot;,&quot;3577&quot;]]</dd><dt><span>grid_mapping_name :</span></dt><dd>albers_conical_equal_area</dd></dl></div><div class='xr-var-data'><pre>array(3577, dtype=int32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0c2e6ff6-d91d-46af-a01b-4a2ea1fcf4cd' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0c2e6ff6-d91d-46af-a01b-4a2ea1fcf4cd' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>canopy_cover_class</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>uint8</div><div class='xr-var-preview xr-preview'>255 255 255 255 ... 255 255 255 255</div><input id='attrs-0d97b1c9-db0f-416d-b609-6715edfe45b9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0d97b1c9-db0f-416d-b609-6715edfe45b9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-89914d87-3fa0-4d0e-bb02-0ea690ef28e4' class='xr-var-data-in' type='checkbox'><label for='data-89914d87-3fa0-4d0e-bb02-0ea690ef28e4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>1</dd><dt><span>nodata :</span></dt><dd>255</dd><dt><span>flags_definition :</span></dt><dd>{&#x27;woodland&#x27;: {&#x27;bits&#x27;: [0, 1, 2, 3, 4, 5, 6, 7], &#x27;values&#x27;: {&#x27;1&#x27;: True}, &#x27;description&#x27;: &#x27;Woodland&#x27;}, &#x27;notobserved&#x27;: {&#x27;bits&#x27;: [0, 1, 2, 3, 4, 5, 6, 7], &#x27;values&#x27;: {&#x27;0&#x27;: True}, &#x27;description&#x27;: &#x27;Mangroves not observed&#x27;}, &#x27;open_forest&#x27;: {&#x27;bits&#x27;: [0, 1, 2, 3, 4, 5, 6, 7], &#x27;values&#x27;: {&#x27;2&#x27;: True}, &#x27;description&#x27;: &#x27;Open Forest&#x27;}, &#x27;closed_forest&#x27;: {&#x27;bits&#x27;: [0, 1, 2, 3, 4, 5, 6, 7], &#x27;values&#x27;: {&#x27;3&#x27;: True}, &#x27;description&#x27;: &#x27;Closed Forest&#x27;}}</dd><dt><span>crs :</span></dt><dd>EPSG:3577</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><pre>array([[[255, 255, 255, ..., 255, 255, 255],\n",
        "        [255, 255, 255, ..., 255, 255, 255],\n",
        "        [255, 255, 255, ..., 255, 255, 255],\n",
        "        ...,\n",
@@ -910,7 +910,7 @@
        "        ...,\n",
        "        [255, 255, 255, ..., 255, 255, 255],\n",
        "        [255, 255, 255, ..., 255, 255, 255],\n",
-       "        [255, 255, 255, ..., 255, 255, 255]]], dtype=uint8)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-69bb5cc3-bae4-44f5-a120-3bc82df327ec' class='xr-section-summary-in' type='checkbox'  ><label for='section-69bb5cc3-bae4-44f5-a120-3bc82df327ec' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-d0c2deaf-a9ec-4e3e-b83e-983ca81bb898' class='xr-index-data-in' type='checkbox'/><label for='index-d0c2deaf-a9ec-4e3e-b83e-983ca81bb898' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1988-07-01 23:59:59.999999&#x27;, &#x27;1989-07-02 11:59:59.999999&#x27;,\n",
+       "        [255, 255, 255, ..., 255, 255, 255]]], dtype=uint8)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a555a7cd-035a-4f26-8d29-bf8bc36bd27d' class='xr-section-summary-in' type='checkbox'  ><label for='section-a555a7cd-035a-4f26-8d29-bf8bc36bd27d' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-da24f824-2600-4c49-a537-e356f80d7b35' class='xr-index-data-in' type='checkbox'/><label for='index-da24f824-2600-4c49-a537-e356f80d7b35' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;1988-07-01 23:59:59.999999&#x27;, &#x27;1989-07-02 11:59:59.999999&#x27;,\n",
        "               &#x27;1990-07-02 11:59:59.999999&#x27;, &#x27;1991-07-02 11:59:59.999999&#x27;,\n",
        "               &#x27;1992-07-01 23:59:59.999999&#x27;, &#x27;1993-07-02 11:59:59.999999&#x27;,\n",
        "               &#x27;1994-07-02 11:59:59.999999&#x27;, &#x27;1995-07-02 11:59:59.999999&#x27;,\n",
@@ -928,17 +928,17 @@
        "               &#x27;2018-07-02 11:59:59.999999&#x27;, &#x27;2019-07-02 11:59:59.999999&#x27;,\n",
        "               &#x27;2020-07-01 23:59:59.999999&#x27;, &#x27;2021-07-02 11:59:59.999999&#x27;,\n",
        "               &#x27;2022-07-02 11:59:59.999999&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-352c37a9-34f4-477a-aae4-bed650ab80c8' class='xr-index-data-in' type='checkbox'/><label for='index-352c37a9-34f4-477a-aae4-bed650ab80c8' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([-1674945.0, -1674975.0, -1675005.0, -1675035.0, -1675065.0,\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-f452ce1c-da10-470e-a5fa-68e4a480d17c' class='xr-index-data-in' type='checkbox'/><label for='index-f452ce1c-da10-470e-a5fa-68e4a480d17c' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([-1674945.0, -1674975.0, -1675005.0, -1675035.0, -1675065.0,\n",
        "              -1675095.0, -1675125.0, -1675155.0, -1675185.0, -1675215.0,\n",
        "              ...\n",
        "              -1690575.0, -1690605.0, -1690635.0, -1690665.0, -1690695.0,\n",
        "              -1690725.0, -1690755.0, -1690785.0, -1690815.0, -1690845.0],\n",
-       "             dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=531))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-cb5493c2-2856-4914-891e-209d919894c7' class='xr-index-data-in' type='checkbox'/><label for='index-cb5493c2-2856-4914-891e-209d919894c7' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([487125.0, 487155.0, 487185.0, 487215.0, 487245.0, 487275.0,\n",
+       "             dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=531))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-4b481fdd-6418-43f2-9d79-f166f894fbdd' class='xr-index-data-in' type='checkbox'/><label for='index-4b481fdd-6418-43f2-9d79-f166f894fbdd' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([487125.0, 487155.0, 487185.0, 487215.0, 487245.0, 487275.0,\n",
        "              487305.0, 487335.0, 487365.0, 487395.0,\n",
        "              ...\n",
        "              505545.0, 505575.0, 505605.0, 505635.0, 505665.0, 505695.0,\n",
        "              505725.0, 505755.0, 505785.0, 505815.0],\n",
-       "             dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=624))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-53f6771b-f382-4ce2-bbd4-8f1fee2ad2d0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-53f6771b-f382-4ce2-bbd4-8f1fee2ad2d0' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>crs :</span></dt><dd>EPSG:3577</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div></li></ul></div></div>"
+       "             dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=624))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1b2d63ba-6321-4063-b05b-33f2864bb793' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1b2d63ba-6321-4063-b05b-33f2864bb793' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>crs :</span></dt><dd>EPSG:3577</dd><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -970,7 +970,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### View the DEA Mangroves class values and definitons\n",
+    "### View the DEA Mangroves class values and definitions\n",
     "\n",
     "You'll see that four classes are identified in this dataset.\n",
     "The `notobserved` class was separated from `nodata` pixels in this workflow to identify locations where mangroves have been observed but there is poor observation density.\n",
@@ -1085,7 +1085,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plotting Data\n",
+    "## Plotting data\n",
     "\n",
     "### Plot a single timestep"
    ]
@@ -1098,7 +1098,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x7f76aff356d0>"
+       "<matplotlib.collections.QuadMesh at 0x7f25cde04100>"
       ]
      },
      "execution_count": 8,
@@ -1148,7 +1148,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db722580a18148f98b0cddb211dd446c",
+       "model_id": "e7922db71e48423eb412707a645b77b5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1177,7 +1177,7 @@
     }
    ],
    "source": [
-    "# Produce time series animation of RGB\n",
+    "# Produce a time series animation of mangrove canopy cover\n",
     "xr_animation(\n",
     "    ds=mangroves,\n",
     "    bands=[\"masked\"],\n",


### PR DESCRIPTION
### Proposed changes
Minor typo and grammatical updates to DEA Mangroves product notebook

### Closes issues (optional)
- Closes Issue #1136 

### Checklist (replace `[ ]` with `[x]` to check off)
- [x] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [x] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [x] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


