### PR TITLE
Folium map

### DIFF
--- a/Tools/dea_tools/maps.py
+++ b/Tools/dea_tools/maps.py
@@ -1,0 +1,262 @@
+import folium
+import folium.plugins        
+
+from odc.ui import image_aspect, mk_data_uri, to_png_data, mk_image_overlay, zoom_from_bbox
+from odc.algo import to_rgba
+from datacube.testutils.geom import epsg4326
+        
+# TODO favor datacube OWS style config over the ad hoc (clamp, bands) settings
+
+def folium_map_default(bbox, zoom_start=None, location=None, **kwargs):
+    """
+    Sensible defaults for a map based on the bounding box of the image to be shown.
+    """
+    if zoom_start is None:
+        zoom_start = zoom_from_bbox(bbox)
+    if location is None:
+        location = (bbox.bottom + bbox.top) * 0.5, (bbox.right + bbox.left) * 0.5
+
+    kwargs['zoom_start'] = zoom_start
+    kwargs['location'] = location
+    
+    return folium.Map(**kwargs)
+
+
+def ipyleaflet_map_default(bbox, zoom=None, center=None, **kwargs):
+    """
+    Sensible defaults for a map based on the bounding box of the image to be shown.
+    """
+    # this is an optional dependency
+    import ipyleaflet
+
+    if zoom is None:
+        zoom = zoom_from_bbox(bbox)
+    if center is None:
+        center = (bbox.bottom + bbox.top) * 0.5, (bbox.right + bbox.left) * 0.5
+
+    kwargs['zoom'] = zoom
+    kwargs['center'] = center
+    
+    return ipyleaflet.Map(**kwargs)
+
+
+def folium_image_overlay(data, bounds, clamp=None, bands=('red', 'green', 'blue'), name=None):
+    # this is a partial port of odc.ui.mk_image_overlay
+    # too bad that function returns an ipyleaflet.ImageOverlay but we need the folium one
+    rgba = to_rgba(data, clamp=clamp, bands=bands)
+    png_str = mk_data_uri(to_png_data(rgba.values), "image/png")
+    return folium.raster_layers.ImageOverlay(png_str, bounds=bounds, name=name)
+    
+
+def folium_map(data,
+               clamp=None,
+               bands=('red', 'green', 'blue'),
+               enable_fullscreen=True,
+               enable_layers_control=False,
+               zoom_start=None,
+               location=None,
+               **folium_map_kwargs):
+    """
+    Puts an xarray Dataset with a single observation in time
+    on to a `folium` map (see: https://python-visualization.github.io/folium/).
+
+    Parameters
+    ----------
+    data : xarray Dataset
+        A dataset with a single observation in time (or without a time dimension)
+    TODO: ...
+
+    Returns
+    -------
+    the newly created `folium` map
+    """
+
+    # get rid of the time dimension
+    if "time" in data.dims:
+        assert data.time.shape[0] == 1, "multiple observations not supported yet"
+        data = data.isel(time=0)
+
+    for band in bands:
+        assert band in data, f"band {band} is not found in dataset"
+
+    bbox = data.extent.to_crs(epsg4326).boundingbox
+    bounds = ((bbox.top, bbox.left), (bbox.bottom, bbox.right))
+
+    fm = folium_map_default(bbox, zoom_start=zoom_start, location=location, **folium_map_kwargs)
+
+    folium_image_overlay(data, bounds, clamp=clamp, bands=bands).add_to(fm)
+    
+    if enable_fullscreen:
+        folium.plugins.Fullscreen(position="topright", title="Fullscreen", title_cancel="Exit fullscreen").add_to(fm)
+        
+    if enable_layers_control:
+        folium.LayerControl().add_to(fm)
+
+    return fm
+
+
+def folium_sidebyside_map(left_data,
+                          right_data,
+                          left_clamp=None,
+                          left_bands=('red', 'green', 'blue'),
+                          right_clamp=None,
+                          right_bands=('red', 'green', 'blue'),
+                          enable_fullscreen=True,
+                          enable_layers_control=False,
+                          zoom_start=None,
+                          location=None,
+                          **folium_map_kwargs):
+    """
+    Puts two xarray datasets side-by-side for comparison
+    on to a `folium` map (see: https://python-visualization.github.io/folium/).
+
+    Parameters
+    ----------
+    data : xarray Dataset
+        A dataset with a single observation in time (or without a time dimension)
+    TODO: ...
+
+    Returns
+    -------
+    the newly created `folium` map
+    """
+
+    # get rid of the time dimension
+    if "time" in left_data.dims:
+        assert left_data.time.shape[0] == 1, "multiple observations not supported yet"
+        left_data = left_data.isel(time=0)
+
+    if "time" in right_data.dims:
+        assert right_data.time.shape[0] == 1, "multiple observations not supported yet"
+        right_data = right_data.isel(time=0)
+
+    for band in left_bands:
+        assert band in left_data, f"band {band} is not found in left dataset"
+        
+    for band in right_bands:
+        assert band in right_data, f"band {band} is not found in right dataset"
+
+    bbox = left_data.extent.to_crs(epsg4326).boundingbox
+    bounds = ((bbox.top, bbox.left), (bbox.bottom, bbox.right))
+
+    fm = folium_map_default(bbox, zoom_start=zoom_start, location=location, **folium_map_kwargs)
+
+    left_layer = folium_image_overlay(left_data, bounds, clamp=left_clamp, bands=left_bands, name="left")
+    right_layer = folium_image_overlay(right_data, bounds, clamp=right_clamp, bands=right_bands, name="right")
+    
+    left_layer.add_to(fm)
+    right_layer.add_to(fm)    
+
+    sbs = folium.plugins.SideBySideLayers(left_layer, right_layer)
+    sbs.add_to(fm)
+    
+    if enable_fullscreen:
+        folium.plugins.Fullscreen(position="topright", title="Fullscreen", title_cancel="Exit fullscreen").add_to(fm)
+        
+    if enable_layers_control:
+        folium.LayerControl().add_to(fm)
+
+    return fm
+
+
+def ipyleaflet_map(data,
+                   clamp=None,
+                   bands=('red', 'green', 'blue'),
+                   enable_fullscreen=True,
+                   enable_layers_control=False,
+                   zoom=None,
+                   center=None,
+                   **ipyleaflet_map_kwargs):
+    """
+    Puts two xarray datasets side-by-side for comparison
+    on to a `ipyleaflet` map.
+
+    Parameters
+    ----------
+    data : xarray Dataset
+        A dataset with a single observation in time (or without a time dimension)
+    TODO: ...
+
+    Returns
+    -------
+    the newly created `ipyleaflet` map
+    """
+    # this is an optional dependency
+    import ipyleaflet
+
+    for band in bands:
+        assert band in data, f"band {band} is not found in left dataset"
+
+    bbox = data.extent.to_crs(epsg4326).boundingbox
+    bounds = ((bbox.top, bbox.left), (bbox.bottom, bbox.right))
+
+    im = ipyleaflet_map_default(bbox, zoom=zoom, center=center, **ipyleaflet_map_kwargs)
+
+    layer = mk_image_overlay(data, clamp=clamp, bands=bands)
+    
+    im.add_layer(layer)
+
+    if enable_fullscreen:
+        im.add_control(ipyleaflet.FullScreenControl())
+    
+    if enable_layers_control:
+        im.add_control(ipyleaflet.LayersControl())
+
+    return im
+
+
+def ipyleaflet_split_map(left_data,
+                         right_data,
+                         left_clamp=None,
+                         left_bands=('red', 'green', 'blue'),
+                         right_clamp=None,
+                         right_bands=('red', 'green', 'blue'),
+                         enable_fullscreen=True,
+                         enable_layers_control=True,
+                         zoom=None,
+                         center=None,
+                         **ipyleaflet_map_kwargs):
+    """
+    Puts two xarray datasets side-by-side for comparison
+    on to a `ipyleaflet` map.
+
+    Parameters
+    ----------
+    data : xarray Dataset
+        A dataset with a single observation in time (or without a time dimension)
+    TODO: ...
+
+    Returns
+    -------
+    the newly created `ipyleaflet` map
+    """
+    # this is an optional dependency
+    import ipyleaflet
+
+    for band in left_bands:
+        assert band in left_data, f"band {band} is not found in left dataset"
+        
+    for band in right_bands:
+        assert band in right_data, f"band {band} is not found in right dataset"
+
+    bbox = left_data.extent.to_crs(epsg4326).boundingbox
+    bounds = ((bbox.top, bbox.left), (bbox.bottom, bbox.right))
+
+    im = ipyleaflet_map_default(bbox, zoom=zoom, center=center, **ipyleaflet_map_kwargs)
+
+    left_layer = mk_image_overlay(left_data, clamp=left_clamp, bands=left_bands, layer_name="left")
+    right_layer = mk_image_overlay(right_data, clamp=right_clamp, bands=right_bands, layer_name="right")
+    
+    im.add_layer(left_layer)
+    im.add_layer(right_layer)    
+    
+    smc = ipyleaflet.SplitMapControl(left_layer=left_layer, right_layer=right_layer)
+    im.add_control(smc)
+
+    if enable_fullscreen:
+        im.add_control(ipyleaflet.FullScreenControl())
+    
+    if enable_layers_control:
+        im.add_control(ipyleaflet.LayersControl())
+
+    return im

--- a/Tools/dea_tools/maps.py
+++ b/Tools/dea_tools/maps.py
@@ -23,15 +23,18 @@ RGB_CFG = {
 }
 
 
+def center_of_bbox(bbox):
+    return (bbox.bottom + bbox.top) * 0.5, (bbox.right + bbox.left) * 0.5
+
 
 def folium_map_default(bbox, zoom_start=None, location=None, **kwargs):
     """
-    Sensible defaults for a map based on the bounding box of the image to be shown.
+    Sensible defaults for a folium map based on the bounding box of the image to be shown.
     """
     if zoom_start is None:
         zoom_start = zoom_from_bbox(bbox)
     if location is None:
-        location = (bbox.bottom + bbox.top) * 0.5, (bbox.right + bbox.left) * 0.5
+        location = center_of_bbox(bbox)
 
     kwargs['zoom_start'] = zoom_start
     kwargs['location'] = location
@@ -41,12 +44,12 @@ def folium_map_default(bbox, zoom_start=None, location=None, **kwargs):
 
 def folium_dualmap_default(bbox, zoom_start=None, location=None, **kwargs):
     """
-    Sensible defaults for a dual map based on the bounding box of the image to be shown.
+    Sensible defaults for a folium dual map based on the bounding box of the image to be shown.
     """
     if zoom_start is None:
         zoom_start = zoom_from_bbox(bbox)
     if location is None:
-        location = (bbox.bottom + bbox.top) * 0.5, (bbox.right + bbox.left) * 0.5
+        location = center_of_bbox(bbox)
 
     kwargs['zoom_start'] = zoom_start
     kwargs['location'] = location
@@ -56,14 +59,14 @@ def folium_dualmap_default(bbox, zoom_start=None, location=None, **kwargs):
 
 def ipyleaflet_map_default(bbox, zoom=None, center=None, **kwargs):
     """
-    Sensible defaults for a map based on the bounding box of the image to be shown.
+    Sensible defaults for a ipyleaflet map based on the bounding box of the image to be shown.
     """
     import ipyleaflet
 
     if zoom is None:
         zoom = zoom_from_bbox(bbox)
     if center is None:
-        center = (bbox.bottom + bbox.top) * 0.5, (bbox.right + bbox.left) * 0.5
+        center = center_of_bbox(bbox)
 
     kwargs['zoom'] = zoom
     kwargs['center'] = center
@@ -169,7 +172,16 @@ def folium_map(data,
     ----------
     data : xarray Dataset
         A dataset with a single observation in time (or without a time dimension)
-    TODO: ...
+    ows_style_config : dict 
+        Datacube OWS style configuration (see https://datacube-ows.readthedocs.io/en/latest/styling_howto.html)
+    enable_fullscreen : bool
+        Enable a Full Screen control on the map
+    enable_layers_control : bool
+        Enable a Layers control (that lists the layers to show/hide them)
+    zoom_start : int
+        The zoom level (default: a zoom layer that shows the whole dataset)
+    location : (float, float)
+        The location the starting view is centered on (default: center of the dataset bounds)
 
     Returns
     -------
@@ -201,7 +213,16 @@ def folium_dual_map(left_data,
     ----------
     data : xarray Dataset
         A dataset with a single observation in time (or without a time dimension)
-    TODO: ...
+    ows_style_config : dict 
+        Datacube OWS style configuration (see https://datacube-ows.readthedocs.io/en/latest/styling_howto.html)
+    enable_fullscreen : bool
+        Enable a Full Screen control on the map
+    enable_layers_control : bool
+        Enable a Layers control (that lists the layers to show/hide them)
+    zoom_start : int
+        The zoom level (default: a zoom layer that shows the whole dataset)
+    location : (float, float)
+        The location the starting view is centered on (default: center of the dataset bounds)
 
     Returns
     -------
@@ -216,48 +237,6 @@ def folium_dual_map(left_data,
     left_layer.add_to(fm.m1)
     right_layer.add_to(fm.m2)    
 
-    folium_add_controls(fm, enable_fullscreen=enable_fullscreen, enable_layers_control=enable_layers_control)
-
-    return fm
-
-
-def folium_sidebyside_map(left_data,
-                          right_data,
-                          left_ows_style=None,
-                          right_ows_style=None,
-                          enable_fullscreen=True,
-                          enable_layers_control=False,
-                          zoom_start=None,
-                          location=None,
-                          **folium_map_kwargs):
-    """
-    DOES NOT WORK AS INTENDED.
-    
-    Puts two xarray datasets side-by-side for comparison
-    on to a `folium` map (see: https://python-visualization.github.io/folium/).
-
-    Parameters
-    ----------
-    data : xarray Dataset
-        A dataset with a single observation in time (or without a time dimension)
-    TODO: ...
-
-    Returns
-    -------
-    the newly created `folium` map
-    """
-    
-    fm = folium_map_default(bounding_box(left_data), zoom_start=zoom_start, location=location, **folium_map_kwargs)
-    
-    left_layer = folium_image_overlay(left_data, ows_style_config=left_ows_style, name="left")
-    right_layer = folium_image_overlay(right_data, ows_style_config=right_ows_style, name="right")
-    
-    left_layer.add_to(fm)
-    right_layer.add_to(fm)
-    
-    sbs = folium.plugins.SideBySideLayers(left_layer, right_layer)
-    sbs.add_to(fm)
-    
     folium_add_controls(fm, enable_fullscreen=enable_fullscreen, enable_layers_control=enable_layers_control)
 
     return fm
@@ -278,7 +257,16 @@ def ipyleaflet_map(data,
     ----------
     data : xarray Dataset
         A dataset with a single observation in time (or without a time dimension)
-    TODO: ...
+    ows_style_config : dict 
+        Datacube OWS style configuration (see https://datacube-ows.readthedocs.io/en/latest/styling_howto.html)
+    enable_fullscreen : bool
+        Enable a Full Screen control on the map
+    enable_layers_control : bool
+        Enable a Layers control (that lists the layers to show/hide them)
+    zoom_start : int
+        The zoom level (default: a zoom layer that shows the whole dataset)
+    location : (float, float)
+        The location the starting view is centered on (default: center of the dataset bounds)
 
     Returns
     -------
@@ -290,49 +278,6 @@ def ipyleaflet_map(data,
 
     layer = ipyleaflet_image_overlay(data, ows_style_config=ows_style_config)
     im.add_layer(layer)
-
-    ipyleaflet_add_controls(im, enable_fullscreen=enable_fullscreen, enable_layers_control=enable_layers_control)
-
-    return im
-
-
-def ipyleaflet_split_map(left_data,
-                         right_data,
-                         left_ows_style=None,
-                         right_ows_style=None,
-                         enable_fullscreen=True,
-                         enable_layers_control=True,
-                         zoom=None,
-                         center=None,
-                         **ipyleaflet_map_kwargs):
-    """
-    DOES NOT WORK AS INTENDED.
-    
-    Puts two xarray datasets side-by-side for comparison
-    on to a `ipyleaflet` map.
-
-    Parameters
-    ----------
-    data : xarray Dataset
-        A dataset with a single observation in time (or without a time dimension)
-    TODO: ...
-
-    Returns
-    -------
-    the newly created `ipyleaflet` map
-    """
-    import ipyleaflet
-
-    im = ipyleaflet_map_default(bounding_box(left_data), zoom=zoom, center=center, **ipyleaflet_map_kwargs)
-
-    left_layer = ipyleaflet_image_overlay(left_data, ows_style_config=left_ows_style, layer_name="left")
-    right_layer = ipyleaflet_image_overlay(right_data, ows_style_config=right_ows_style, layer_name="right")
-    
-    im.add_layer(left_layer)
-    im.add_layer(right_layer)    
-    
-    smc = ipyleaflet.SplitMapControl(left_layer=left_layer, right_layer=right_layer)
-    im.add_control(smc)
 
     ipyleaflet_add_controls(im, enable_fullscreen=enable_fullscreen, enable_layers_control=enable_layers_control)
 

--- a/Tools/setup.py
+++ b/Tools/setup.py
@@ -36,6 +36,7 @@ REQUIRED = [
     'dask',
     'dask-ml',
     'datacube',
+    'datacube-ows',
     'Fiona',
     'folium',
     'geopandas',


### PR DESCRIPTION
### Proposed changes
- Provide helper functions `folium_map` and `ipyleaflet_map` that enables easy placing of an xarray Dataset on a webmap
- Provide `folium_dual_map` that lets us compare datasets side-by-side
- These functions support styling using the datacube OWS configuration

### Closes issues (optional)
- Closes Issue #1139 

### Checklist (replace `[ ]` with `[x]` to check off)
- [X] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [X] Remove any unused Python packages from `Load packages`
- [X] Remove any unused/empty code cells
- [X] Remove any guidance cells (e.g. `General advice`)
- [X] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [X] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex.html), and re-use tags if possible)
- [X] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with

Have not testing on NCI.

