### PR TITLE
Pull pixel_tide resampling into function for easier re-use

### DIFF
--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -715,8 +715,6 @@ def model_tides(
 def _pixel_tides_resample(
     tides_lowres,
     ds,
-    y_dim,
-    x_dim,
     resample_method="bilinear",
     dask_chunks="auto",
     dask_compute=True,
@@ -755,6 +753,9 @@ def _pixel_tides_resample(
         array of tide heights will be generated matching the
         exact spatial resolution and extent of `ds`.
     """
+    # Determine spatial dimensions
+    y_dim, x_dim = ds.odc.spatial_dims
+    
     # Convert array to Dask, using no chunking along y and x dims,
     # and a single chunk for each timestep/quantile and tide model
     tides_lowres_dask = tides_lowres.chunk(

--- a/Tools/dea_tools/coastal.py
+++ b/Tools/dea_tools/coastal.py
@@ -1061,7 +1061,7 @@ def pixel_tides(
     if resample:
         print("Reprojecting tides into original array")
         tides_highres, tides_lowres = _pixel_tides_resample(
-            tides_lowres, ds, y_dim, x_dim, resample_method, dask_chunks, dask_compute
+            tides_lowres, ds, resample_method, dask_chunks, dask_compute
         )
         return tides_highres, tides_lowres
 


### PR DESCRIPTION
### Proposed changes
This is a simple refactor that modifies `dea_tools.coastal.pixel_tides` to pull out our current resampling code (used to resample low resolution modelled tides into the higher resolution of our satellite data) into a separate function. 

This will allow us to more easily re-use this functionality in external workflows (e.g. for resampling our ensemble tide models in DEA Intertidal).


