### PR TITLE
Relegated responsibility of the top-level table of contents to the dea-docs repo instead

### DIFF
--- a/Beginners_guide/README.rst
+++ b/Beginners_guide/README.rst
@@ -5,7 +5,6 @@ The Beginners Guide contains introductory notebooks aimed at introducing Jupyter
 
 .. toctree::
    :maxdepth: 1
-   :caption: Beginner's Guide
 
    01_Jupyter_notebooks.ipynb
    02_DEA.ipynb
@@ -25,7 +24,6 @@ Once you have you have completed the beginner tutorials, join advanced users in 
 
 .. toctree::
    :maxdepth: 2   
-   :caption: Guided Tutorial
    
    Guided_tutorial.ipynb
 

--- a/DEA_products/README.rst
+++ b/DEA_products/README.rst
@@ -5,7 +5,6 @@ Notebooks introducing DEA's satellite datasets and derived products, including h
 
 .. toctree::
    :maxdepth: 1
-   :caption: DEA products
 
    DEA_Landsat_Surface_Reflectance.ipynb
    DEA_Sentinel2_Surface_Reflectance.ipynb

--- a/How_to_guides/README.rst
+++ b/How_to_guides/README.rst
@@ -5,7 +5,6 @@ A recipe book of simple code examples demonstrating how to perform common geospa
 
 .. toctree::
    :maxdepth: 1
-   :caption: How to guides
 
    Analyse_multiple_polygons.ipynb
    Animated_timeseries.ipynb

--- a/Interactive_apps/README.rst
+++ b/Interactive_apps/README.rst
@@ -5,7 +5,6 @@ Interactive widgets and apps that require little or no coding to run
 
 .. toctree::
    :maxdepth: 1
-   :caption: Interactive apps
    
    Change_filmstrips.ipynb
    Coastal_transects.ipynb

--- a/README.rst
+++ b/README.rst
@@ -125,12 +125,3 @@ Once the pull request has been approved, you can merge it into the ``develop`` b
 
 See also `wiki <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Guide-to-using-DEA-Notebooks-with-git#reviewing-and-approving-a-pull-request>`_.
 
-.. toctree::
-   :hidden:
-
-   Beginners_guide/README
-   DEA_products/README
-   How_to_guides/README
-   Interactive_apps/README
-   Real_world_examples/README
-   Tools/index

--- a/Real_world_examples/README.rst
+++ b/Real_world_examples/README.rst
@@ -5,7 +5,6 @@ More complex case study-based workflows demonstrating how DEA can be used to add
 
 .. toctree::
    :maxdepth: 1
-   :caption: Real World Examples
    
    Burnt_area_mapping.ipynb
    Burnt_area_mapping_near_realtime.ipynb

--- a/Real_world_examples/Scalable_machine_learning/README.rst
+++ b/Real_world_examples/Scalable_machine_learning/README.rst
@@ -142,7 +142,6 @@ To begin working through the notebooks in this ``Scalable Supervised Machine Lea
 
 .. toctree::
    :maxdepth: 1
-   :caption: Scalable Supervised Machine Learning on the Open Data Cube
 
    1_Extract_training_data.ipynb
    2_Inspect_training_data.ipynb


### PR DESCRIPTION
(cherry picked from commit 01f5718305435262bc34051cd3873564585c7c2b)

### Proposed changes
Relegated responsibility of the top-level table of contents to the dea-docs repo instead because this allows the use of sub-headings in the sidebar of the DEA Knowledge Hub website. It also makes sense that the website should manage the structure of its own sidebar. The dea-notebooks repo still manages its own notebooks table of contents trees (toctrees) below the top level.

Also, I removed the redundant `:caption:` properties on the toctrees because they contained the same content as the page title, and were therefore redundant.

### Closes issues (optional)

### Checklist (replace `[ ]` with `[x]` to check off)
- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with


