### PR TITLE
Limit tide data downloaded in tests

### DIFF
--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -36,7 +36,9 @@ jobs:
         aws-region: ap-southeast-2
 
     - name: Copy tide modelling files with the AWS CLI
-      run: aws s3 sync s3://dea-non-public-data/tide_models/tide_models tide_models
+      run: |
+        aws s3 sync s3://dea-non-public-data/tide_models/tide_models/fes2014 tide_models/fes2014
+        aws s3 sync s3://dea-non-public-data/tide_models/tide_models/hamtide tide_models/hamtide
 
     - name: Login to Amazon ECR Private
       id: login-ecr


### PR DESCRIPTION
### Proposed changes
As part of the DEA Intertidal project, we recently we updated the tide model data available on the S3 `dea-non-public-data` bucket to include data from an additional ~5 tide models. 

To avoid this new data being synced during the DEA Notebooks integration tests (potentially leading to longer run times), this PR updates the "Copy tide modelling files with the AWS CLI" step of our tests to only download a smaller subset of the tide model data.

