### PR TITLE
Added new wiki links to README and edited README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@
 DEA Notebooks
 #############
 
+This is the Digital Earth Australia notebooks and tools repository.
+
 .. image:: https://img.shields.io/badge/DOI-10.26186/145234-0e7fbf.svg
   :target: https://doi.org/10.26186/145234
   :alt: DOI
@@ -20,13 +22,11 @@ DEA Notebooks
   :target: https://github.com/GeoscienceAustralia/dea-notebooks/actions/workflows/test_notebooks.yml
   :alt: Notebook testing
 
-This is the Digital Earth Australia notebooks and tools repository.
-
 **Contribute:** We'd love your contribution! DEA Notebooks is an open-source project and welcomes contributions from everyone.
 
 **License:** The code in this repository is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_. Digital Earth Australia data is licensed under the `Creative Commons by Attribution 4.0 license <https://creativecommons.org/licenses/by/4.0/>`_.
 
-**Documentation:** See the `DEA Notebooks Wiki </GeoscienceAustralia/dea-notebooks/wiki>`.
+**Documentation:** See the `DEA Notebooks Wiki </GeoscienceAustralia/dea-notebooks/wiki>`_.
 
 **Contact:** If you need assistance with any of the Jupyter Notebooks or Python code in this repository, please post a question on the `Open Data Cube Slack channel <http://slack.opendatacube.org/>`_ or on the `GIS Stack Exchange <https://gis.stackexchange.com/questions/ask?tags=open-data-cube>`_ using the ``open-data-cube`` tag (you can view `previously asked questions here <https://gis.stackexchange.com/questions/tagged/open-data-cube>`_). If you would like to report an issue with a notebook, you can `file one on Github <https://github.com/GeoscienceAustralia/dea-notebooks>`_.
 
@@ -41,17 +41,10 @@ We encourage you to check out the other usages of our notebooks, code and tools 
 Contributing to DEA Notebooks
 =============================
 
-To get started with using ``dea-notebooks``, `visit the DEA Notebooks Wiki page <https://github.com/GeoscienceAustralia/dea-notebooks/wiki>`_. This page includes guides for getting started on both the `DEA Sandbox <https://github.com/GeoscienceAustralia/dea-notebooks/wiki#getting-started-on-the-dea-sandbox>`_ and `NCI environments <https://github.com/GeoscienceAustralia/dea-notebooks/wiki#getting-started-on-the-nci>`_.
+To get started, see either of these articles on our Wiki.
 
-Once you're set up, there are two main options for interacting with ``dea-notebooks`` and contributing back to the repository:
-
-* **DEA notebooks using git**: Git is a version-control software designed to help track changes to files and collaborate with multiple users on a project. Using ``git`` is the recommended workflow for working with ``dea-notebooks`` as it makes it easy to stay up to date with the latest versions of functions and code and makes it impossible to lose your work. 
-
-  * Refer to the repository's `Guide to using DEA Notebooks with git <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Guide-to-using-DEA-Notebooks-with-git>`_ wiki article.
-
-* **DEA notebooks using Github**: Alternatively, the Github website can be used to upload and modify the ``dea-notebooks`` repository directly. This can be a good way to get started with ``dea-notebooks``. 
-
-  * Refer to the repository's `Guide to DEA Notebooks using the Github website <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Guide-to-using-DEA-Notebooks-with-the-Github-website>`_ wiki article.
+* `Create a DEA Notebook </GeoscienceAustralia/dea-notebooks/wiki/Create-a-DEA-Notebook>`_
+* `Edit a DEA Notebook </GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook>`_
 
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -37,15 +37,8 @@ We encourage you to check out the other usages of our notebooks, code and tools 
 
 ----------
 
-Contributing to DEA Notebooks
-=============================
-
-To get started, see either of these articles on our Wiki.
-
-* `Create a DEA Notebook </GeoscienceAustralia/dea-notebooks/wiki/Create-a-DEA-Notebook>`_
-* `Edit a DEA Notebook </GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook>`_
-
-----------
+Introduction
+============
 
 The Digital Earth Australia notebooks and tools repository (``dea-notebooks``) hosts Jupyter Notebooks, Python scripts and workflows for analysing `Digital Earth Australia (DEA) <https://www.ga.gov.au/dea>`_ satellite data and derived products. This documentation is designed to provide a guide to getting started with DEA, and to showcase the wide range of geospatial analyses that can be achieved using DEA data and open-source software including `Open Data Cube <https://www.opendatacube.org/>`_ and `xarray <http://xarray.pydata.org/en/stable/>`_.
 
@@ -68,6 +61,16 @@ Supporting functions and data for the notebooks are kept in the following direct
 - `Supplementary_data <https://github.com/GeoscienceAustralia/dea-notebooks/tree/stable/Supplementary_data>`_: *Supplementary files required for the analyses above (e.g. images, rasters, shapefiles, training data)*
 
 All notebooks in the ``dea-notebooks`` repository contain tags describing their functionality. If you are searching for a specific functionality, use the `Tags Index </genindex/>`_ to search for a suitable example. If there is a functionality that has not been documented that you think should be, please create an 'Issue' in the `dea-notebooks repository. <https://github.com/GeoscienceAustralia/dea-notebooks/issues>`_
+
+----------
+
+Contributing to DEA Notebooks
+=============================
+
+To get started, see either of these articles.
+
+* `Create a DEA Notebook </GeoscienceAustralia/dea-notebooks/wiki/Create-a-DEA-Notebook>`_
+* `Edit a DEA Notebook </GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook>`_
 
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -27,13 +27,14 @@ This is the Digital Earth Australia notebooks and tools repository.
 **License:** The code in this repository is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_. Digital Earth Australia data is licensed under the `Creative Commons by Attribution 4.0 license <https://creativecommons.org/licenses/by/4.0/>`_.
 
 **Documentation:** See the `DEA Notebooks Wiki </GeoscienceAustralia/dea-notebooks/wiki>`_.
+
 **Contact:** For assistance with any of these notebooks and tools, please ask a question on our `Open Data Cube Slack channel <http://slack.opendatacube.org/>`_ or on the `GIS Stack Exchange <https://gis.stackexchange.com/questions/tagged/open-data-cube>`_ using the ``open-data-cube`` tag. You can also `report an issue on this repository </GeoscienceAustralia/dea-notebooks/issues>`_.
 
-**Citing DEA Notebooks:** If you use any of the notebooks, code or tools in this repository in your work, please reference them using the following citation:
+**Citation:** If you use this repository in your work, please reference it with the following citation.
 
     Krause, C., Dunn, B., Bishop-Taylor, R., Adams, C., Burton, C., Alger, M., Chua, S., Phillips, C., Newey, V., Kouzoubov, K., Leith, A., Ayers, D., Hicks, A., DEA Notebooks contributors 2021. Digital Earth Australia notebooks and tools repository. Geoscience Australia, Canberra. https://doi.org/10.26186/145234
-    
-We encourage you to check out the other usages of our notebooks, code and tools at our `USAGE <https://github.com/GeoscienceAustralia/dea-notebooks/blob/stable/USAGE.rst>`_ page, and to add your paper, training course, creative work or other exciting project there as well!    
+
+We would also appreciate it if you add a citation of your work to our `USAGE <https://github.com/GeoscienceAustralia/dea-notebooks/blob/stable/USAGE.rst>`_ page.
 
 ----------
 
@@ -61,6 +62,8 @@ Supporting functions and data for the notebooks are kept in the following direct
 - `Supplementary_data <https://github.com/GeoscienceAustralia/dea-notebooks/tree/stable/Supplementary_data>`_: *Supplementary files required for the analyses above (e.g. images, rasters, shapefiles, training data)*
 
 All notebooks in the ``dea-notebooks`` repository contain tags describing their functionality. If you are searching for a specific functionality, use the `Tags Index </genindex/>`_ to search for a suitable example. If there is a functionality that has not been documented that you think should be, please create an 'Issue' in the `dea-notebooks repository. <https://github.com/GeoscienceAustralia/dea-notebooks/issues>`_
+
+We encourage you to check out the other usages of our notebooks, code and tools at our `USAGE <https://github.com/GeoscienceAustralia/dea-notebooks/blob/stable/USAGE.rst>`_ page.
 
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 DEA Notebooks
 #############
 
-This is the Digital Earth Australia notebooks and tools repository.
+This is the notebooks and tools repository of Digital Earth Australia (DEA).
 
 .. image:: https://img.shields.io/badge/DOI-10.26186/145234-0e7fbf.svg
   :target: https://doi.org/10.26186/145234
@@ -24,7 +24,7 @@ This is the Digital Earth Australia notebooks and tools repository.
 
 **Contribute:** We'd love your contribution! DEA Notebooks is an open-source project and welcomes contributions from everyone.
 
-**License:** The code in this repository is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_. Digital Earth Australia data is licensed under the `Creative Commons by Attribution 4.0 license <https://creativecommons.org/licenses/by/4.0/>`_.
+**License:** The code in this repository is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_. DEA data is licensed under the `Creative Commons by Attribution 4.0 license <https://creativecommons.org/licenses/by/4.0/>`_.
 
 **Documentation:** See the `DEA Notebooks Wiki </GeoscienceAustralia/dea-notebooks/wiki>`_.
 
@@ -41,7 +41,7 @@ We would also appreciate it if you add a citation of your work to our `USAGE <ht
 Introduction
 ============
 
-The Digital Earth Australia notebooks and tools repository (``dea-notebooks``) hosts Jupyter Notebooks, Python scripts and workflows for analysing `Digital Earth Australia (DEA) <https://www.ga.gov.au/dea>`_ satellite data and derived products. This documentation is designed to provide a guide to getting started with DEA, and to showcase the wide range of geospatial analyses that can be achieved using DEA data and open-source software including `Open Data Cube <https://www.opendatacube.org/>`_ and `xarray <http://xarray.pydata.org/en/stable/>`_.
+This repository hosts Jupyter Notebooks, Python scripts and workflows for analysing `Digital Earth Australia (DEA) <https://www.ga.gov.au/dea>`_ satellite data and derived products. This documentation is designed to provide a guide to getting started with DEA, and to showcase the wide range of geospatial analyses that can be achieved using DEA data and open-source software including `Open Data Cube <https://www.opendatacube.org/>`_ and `xarray <http://xarray.pydata.org/en/stable/>`_.
 
 The repository is based around the following directory structure (from simple to increasingly complex applications):
 

--- a/README.rst
+++ b/README.rst
@@ -120,5 +120,3 @@ If the notebook meets all the checklist requirements, click the green 'Review' b
 
 Once the pull request has been approved, you can merge it into the ``develop`` branch. Select the 'Squash and merge' option from the drop-down menu to the right of the green 'merge' button. Once you have merged the new branch in, you need to delete the branch. There is a button on the page that asks you if you would like to delete the now merged branch. Select 'Yes' to delete it.
 
-See also `wiki <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Guide-to-using-DEA-Notebooks-with-git#reviewing-and-approving-a-pull-request>`_.
-

--- a/README.rst
+++ b/README.rst
@@ -26,9 +26,9 @@ This is the notebooks and tools repository of Digital Earth Australia (DEA).
 
 **License:** The code in this repository is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_. DEA data is licensed under the `Creative Commons by Attribution 4.0 license <https://creativecommons.org/licenses/by/4.0/>`_.
 
-**Documentation:** See the `DEA Notebooks Wiki </GeoscienceAustralia/dea-notebooks/wiki>`_.
+**Documentation:** See the `DEA Notebooks Wiki <https://github.com/GeoscienceAustralia/dea-notebooks/wiki>`_.
 
-**Contact:** For assistance with any of these notebooks and tools, please ask a question on our `Open Data Cube Slack channel <http://slack.opendatacube.org/>`_ or on the `GIS Stack Exchange <https://gis.stackexchange.com/questions/tagged/open-data-cube>`_ using the ``open-data-cube`` tag. You can also `report an issue on this repository </GeoscienceAustralia/dea-notebooks/issues>`_.
+**Contact:** For assistance with any of these notebooks and tools, please ask a question on our `Open Data Cube Slack channel <http://slack.opendatacube.org/>`_ or on the `GIS Stack Exchange <https://gis.stackexchange.com/questions/tagged/open-data-cube>`_ using the ``open-data-cube`` tag. You can also `report an issue on this repository <https://github.com/GeoscienceAustralia/dea-notebooks/issues>`_.
 
 **Citation:** If you use this repository in your work, please reference it with the following citation.
 
@@ -72,8 +72,8 @@ Contributing to DEA Notebooks
 
 To get started, see either of these articles.
 
-* `Create a DEA Notebook </GeoscienceAustralia/dea-notebooks/wiki/Create-a-DEA-Notebook>`_
-* `Edit a DEA Notebook </GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook>`_
+* `Create a DEA Notebook <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Create-a-DEA-Notebook>`_
+* `Edit a DEA Notebook <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook>`_
 
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@
   :width: 900
   :alt: Digital Earth Australia logo
 
-Digital Earth Australia notebooks and tools repository
-######################################################
+DEA Notebooks
+#############
 
 .. image:: https://img.shields.io/badge/DOI-10.26186/145234-0e7fbf.svg
   :target: https://doi.org/10.26186/145234
@@ -20,11 +20,13 @@ Digital Earth Australia notebooks and tools repository
   :target: https://github.com/GeoscienceAustralia/dea-notebooks/actions/workflows/test_notebooks.yml
   :alt: Notebook testing
 
+This is the Digital Earth Australia notebooks and tools repository.
+
 **Contribute:** We'd love your contribution! DEA Notebooks is an open-source project and welcomes contributions from everyone.
 
 **License:** The code in this repository is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_. Digital Earth Australia data is licensed under the `Creative Commons by Attribution 4.0 license <https://creativecommons.org/licenses/by/4.0/>`_.
 
-**Documentation:** The **Digital Earth Australia Knowledge Hub** is located at: `<https://docs.dea.ga.gov.au/>`_ . The DEA Notebooks section in the DEA Knowledge Hub is generated from the Jupyter notebooks on the ``stable`` branch of this repository. 
+**Documentation:** See the `DEA Notebooks Wiki </GeoscienceAustralia/dea-notebooks/wiki>`.
 
 **Contact:** If you need assistance with any of the Jupyter Notebooks or Python code in this repository, please post a question on the `Open Data Cube Slack channel <http://slack.opendatacube.org/>`_ or on the `GIS Stack Exchange <https://gis.stackexchange.com/questions/ask?tags=open-data-cube>`_ using the ``open-data-cube`` tag (you can view `previously asked questions here <https://gis.stackexchange.com/questions/tagged/open-data-cube>`_). If you would like to report an issue with a notebook, you can `file one on Github <https://github.com/GeoscienceAustralia/dea-notebooks>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,7 @@ This is the Digital Earth Australia notebooks and tools repository.
 **License:** The code in this repository is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_. Digital Earth Australia data is licensed under the `Creative Commons by Attribution 4.0 license <https://creativecommons.org/licenses/by/4.0/>`_.
 
 **Documentation:** See the `DEA Notebooks Wiki </GeoscienceAustralia/dea-notebooks/wiki>`_.
-
-**Contact:** If you need assistance with any of the Jupyter Notebooks or Python code in this repository, please post a question on the `Open Data Cube Slack channel <http://slack.opendatacube.org/>`_ or on the `GIS Stack Exchange <https://gis.stackexchange.com/questions/ask?tags=open-data-cube>`_ using the ``open-data-cube`` tag (you can view `previously asked questions here <https://gis.stackexchange.com/questions/tagged/open-data-cube>`_). If you would like to report an issue with a notebook, you can `file one on Github <https://github.com/GeoscienceAustralia/dea-notebooks>`_.
+**Contact:** For assistance with any of these notebooks and tools, please ask a question on our `Open Data Cube Slack channel <http://slack.opendatacube.org/>`_ or on the `GIS Stack Exchange <https://gis.stackexchange.com/questions/tagged/open-data-cube>`_ using the ``open-data-cube`` tag. You can also `report an issue on this repository </GeoscienceAustralia/dea-notebooks/issues>`_.
 
 **Citing DEA Notebooks:** If you use any of the notebooks, code or tools in this repository in your work, please reference them using the following citation:
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Digital Earth Australia notebooks and tools repository
   :target: https://github.com/GeoscienceAustralia/dea-notebooks/actions/workflows/test_notebooks.yml
   :alt: Notebook testing
 
-**Contribute:** We'd love your contribution! DEA Notebooks is an open-source project and welcomes contributions from everyone. Please use this handy `template notebook <https://github.com/GeoscienceAustralia/dea-notebooks/blob/develop/DEA_notebooks_template.ipynb>`_ to construct your contribution!
+**Contribute:** We'd love your contribution! DEA Notebooks is an open-source project and welcomes contributions from everyone.
 
 **License:** The code in this repository is licensed under the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_. Digital Earth Australia data is licensed under the `Creative Commons by Attribution 4.0 license <https://creativecommons.org/licenses/by/4.0/>`_.
 
@@ -33,6 +33,23 @@ Digital Earth Australia notebooks and tools repository
     Krause, C., Dunn, B., Bishop-Taylor, R., Adams, C., Burton, C., Alger, M., Chua, S., Phillips, C., Newey, V., Kouzoubov, K., Leith, A., Ayers, D., Hicks, A., DEA Notebooks contributors 2021. Digital Earth Australia notebooks and tools repository. Geoscience Australia, Canberra. https://doi.org/10.26186/145234
     
 We encourage you to check out the other usages of our notebooks, code and tools at our `USAGE <https://github.com/GeoscienceAustralia/dea-notebooks/blob/stable/USAGE.rst>`_ page, and to add your paper, training course, creative work or other exciting project there as well!    
+
+----------
+
+Contributing to DEA Notebooks
+=============================
+
+To get started with using ``dea-notebooks``, `visit the DEA Notebooks Wiki page <https://github.com/GeoscienceAustralia/dea-notebooks/wiki>`_. This page includes guides for getting started on both the `DEA Sandbox <https://github.com/GeoscienceAustralia/dea-notebooks/wiki#getting-started-on-the-dea-sandbox>`_ and `NCI environments <https://github.com/GeoscienceAustralia/dea-notebooks/wiki#getting-started-on-the-nci>`_.
+
+Once you're set up, there are two main options for interacting with ``dea-notebooks`` and contributing back to the repository:
+
+* **DEA notebooks using git**: Git is a version-control software designed to help track changes to files and collaborate with multiple users on a project. Using ``git`` is the recommended workflow for working with ``dea-notebooks`` as it makes it easy to stay up to date with the latest versions of functions and code and makes it impossible to lose your work. 
+
+  * Refer to the repository's `Guide to using DEA Notebooks with git <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Guide-to-using-DEA-Notebooks-with-git>`_ wiki article.
+
+* **DEA notebooks using Github**: Alternatively, the Github website can be used to upload and modify the ``dea-notebooks`` repository directly. This can be a good way to get started with ``dea-notebooks``. 
+
+  * Refer to the repository's `Guide to DEA Notebooks using the Github website <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Guide-to-using-DEA-Notebooks-with-the-Github-website>`_ wiki article.
 
 ----------
 
@@ -60,25 +77,8 @@ All notebooks in the ``dea-notebooks`` repository contain tags describing their 
 
 ----------
 
-Getting started with DEA Notebooks
-==================================
-
-To get started with using ``dea-notebooks``, `visit the DEA Notebooks Wiki page <https://github.com/GeoscienceAustralia/dea-notebooks/wiki>`_. This page includes guides for getting started on both the `DEA Sandbox <https://github.com/GeoscienceAustralia/dea-notebooks/wiki#getting-started-on-the-dea-sandbox>`_ and `NCI environments <https://github.com/GeoscienceAustralia/dea-notebooks/wiki#getting-started-on-the-nci>`_.
-
-Once you're set up, there are two main options for interacting with ``dea-notebooks`` and contributing back to the repository:
-
-* **DEA notebooks using git**: Git is a version-control software designed to help track changes to files and collaborate with multiple users on a project. Using ``git`` is the recommended workflow for working with ``dea-notebooks`` as it makes it easy to stay up to date with the latest versions of functions and code and makes it impossible to lose your work. 
-
-  * Refer to the repository's `Guide to using DEA Notebooks with git <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Guide-to-using-DEA-Notebooks-with-git>`_ wiki article.
-
-* **DEA notebooks using Github**: Alternatively, the Github website can be used to upload and modify the ``dea-notebooks`` repository directly. This can be a good way to get started with ``dea-notebooks``. 
-
-  * Refer to the repository's `Guide to DEA Notebooks using the Github website <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Guide-to-using-DEA-Notebooks-with-the-Github-website>`_ wiki article.
-
-----------
-
-Contributing to DEA Notebooks
-=============================
+Git workflow
+============
 
 Develop, stable and working branches
 ------------------------------------


### PR DESCRIPTION
### Proposed changes

See the [edited README here](https://github.com/GeoscienceAustralia/dea-notebooks/tree/feature/readme-wiki-links).

* Replaced the section that included links to the wiki with a new section called 'Contributing to DEA Notebooks' that simply includes the links to the two wiki articles I created recently.
* Edited several other parts of the README to make it shorter and easier to read.
* Renamed existing section called 'Contributing to DEA Notebooks' to 'Git workflow' to avoid confusion.

I spell-checked my work.
