### PR TITLE
Fixing some bullet points displaying incorrectly on the KH

### DIFF
--- a/How_to_guides/Reprojecting_data.ipynb
+++ b/How_to_guides/Reprojecting_data.ipynb
@@ -169,6 +169,7 @@
     "Now we have loaded our raster dataset, we can inspect its `GeoBox` object that we will use to allow us to reproject data.\n",
     "The `GeoBox` can be accessed using the `.geobox` method.\n",
     "It includes a set of information that together completely define the spatial grid of our data:\n",
+    "\n",
     "* The width (e.g. `95`) and height (e.g. `90`) of our data in pixels\n",
     "* An `Affine` object which defines the spatial resolution (e.g. `-0.0020751667555555255` and `0.0020769114631576106`) and spatial position (e.g. `149.036528545` and `-35.198132594`) of our data\n",
     "* The coordinate reference system of our data (e.g. `+init=epsg:4326`)\n"
@@ -779,7 +780,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/Interactive_apps/Generating_satellite_animations.ipynb
+++ b/Interactive_apps/Generating_satellite_animations.ipynb
@@ -79,7 +79,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -130,6 +129,7 @@
     "\n",
     "The animation tool supports several advanced features. \n",
     "To access these, click on the `Advanced` tab in the menu to the left of the map to expand it:\n",
+    "\n",
     "* `Frame interval`: The frame rate used to animate the satellite data. \n",
     "Values are in milliseconds - larger values will produce a longer, slower animation.\n",
     "* `Resolution`: The spatial resolution to load data (in metres). By default, the tool will automatically set the best possible resolution depending on the satellites selected (i.e. 30 m for Landsat, 10 m for Sentinel-2). \n",
@@ -251,7 +251,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
### Proposed changes

I added a newline above the bullet list on two pages because this is a Markdown formatting error that caused the bullet lists to render incorrectly on the knowledge hub. It does not change the way it displays on the Sandbox.

### Checklist 
(Replace `[ ]` with `[x]` to check off)

I tested it in the DEA Sandbox.

