### PR TITLE
Fixed two links to python Tools files

### DIFF
--- a/Real_world_examples/Scalable_machine_learning/1_Extract_training_data.ipynb
+++ b/Real_world_examples/Scalable_machine_learning/1_Extract_training_data.ipynb
@@ -261,7 +261,7 @@
     "\n",
     "In addition to the `zonal_stats` parameter, we also need to set up a datacube query dictionary for the Open Data Cube query such as `measurements` (the bands to load from the satellite), the `resolution` (the cell size), and the `output_crs` (the output projection). These options will be added to a query dictionary that will be passed into `collect_training_data` using the parameter `collect_training_data(dc_query=query, ...)`. The query dictionary will be the only argument in the **feature layer function** which we will define and describe in a moment.\n",
     "\n",
-    "> Note: `collect_training_data` also has a number of additional parameters for handling ODC I/O read failures, where polygons that return an excessive number of null values can be resubmitted to the multiprocessing queue. Check out the [docs](../Tools/gen/dea_tools.classification.ipynb) to learn more.\n"
+    "> Note: `collect_training_data` also has a number of additional parameters for handling ODC I/O read failures, where polygons that return an excessive number of null values can be resubmitted to the multiprocessing queue. Check out the [docs](../../Tools/dea_tools/classification.py) to learn more.\n"
    ]
   },
   {


### PR DESCRIPTION
### Proposed changes

I fixed two broken links that I found in the sandbox. I think I may have broken these myself previously. They are to '.py' DEA Tools files. I tested my fix within the Sandbox.

### Closes issues (optional)

### Checklist 
(Replace `[ ]` with `[x]` to check off)

- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://docs.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with
- [ ] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)
