### PR TITLE
Add missing dependency

### DIFF
--- a/Tools/setup.py
+++ b/Tools/setup.py
@@ -61,6 +61,7 @@ REQUIRED = [
     'rasterio',
     'rasterstats',
     'requests',
+    'rioxarray',
     'scikit-image',
     'scikit-learn',
     'scipy',


### PR DESCRIPTION
### Proposed changes
Forgot to include `rioxarray` as a dependency of DEA Tools. This is causing some of the DEA Tools documentation to fail to render in Knowledge Hub:
https://github.com/GeoscienceAustralia/dea-docs/actions/runs/7968549294/job/21752987045#step:5:24

