### PR TITLE
Update tests to ignore Markdown, RST and template and landing page notebooks

### DIFF
--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -5,21 +5,19 @@ on:
   push:
     branches: [ develop, stable, nbtests ]
     paths-ignore:
-      - 'README.md' # ignore readme
       - 'DEA_Sandbox.ipynb' # ignore landing page
       - 'DEA_notebooks_template.ipynb' # ignore template
-      - '**/*.md' # ignore markdown files in nested folders
-      - '**/*.rst' # ignore restructured text files
+      - '*.md' # ignore all markdown files
+      - '*.rst' # ignore all restructured text files
       - '.github/**' # ignore anything in .github folder
       - '!.github/workflows/test_notebooks.yml' # except test_notebooks.yml
   pull_request:
     branches: [ develop, stable ]
     paths-ignore:
-      - 'README.md'
       - 'DEA_Sandbox.ipynb'
       - 'DEA_notebooks_template.ipynb'
-      - '**/*.md'
-      - '**/*.rst'
+      - '*.md'
+      - '*.rst'
       - '.github/**'
       - '!.github/workflows/test_notebooks.yml'
 

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -5,13 +5,19 @@ on:
   push:
     branches: [ develop, stable, nbtests ]
     paths-ignore:
-      - '**/*.md' # ignore markdown files
+      - 'README.md' # ignore readme
+      - 'DEA_Sandbox.ipynb' # ignore landing page
+      - 'DEA_notebooks_template.ipynb' # ignore template
+      - '**/*.md' # ignore markdown files in nested folders
       - '**/*.rst' # ignore restructured text files
       - '.github/**' # ignore anything in .github folder
       - '!.github/workflows/test_notebooks.yml' # except test_notebooks.yml
   pull_request:
     branches: [ develop, stable ]
     paths-ignore:
+      - 'README.md'
+      - 'DEA_Sandbox.ipynb'
+      - 'DEA_notebooks_template.ipynb'
       - '**/*.md'
       - '**/*.rst'
       - '.github/**'


### PR DESCRIPTION
### Proposed changes
This PR updates the "ignore-paths" line of our Github Actions testing workflow to ignore future updates to the repo's Readme, template notebook or landing page notebook.

This will prevent us having to wait ~30 minutes for tests to run after making minor updates to Markdown or RST files.

