### PR TITLE
Updated references to the old repo name 'dea-docs' to the new name

### DIFF
--- a/.github/workflows/trigger_docs.yaml
+++ b/.github/workflows/trigger_docs.yaml
@@ -1,9 +1,9 @@
 
 name: Trigger DEA Docs Build
-# Documentation in this repo is not built in this GitHub Action. Instead, it is built by a separate Action in the dea-docs repo.
-# See here: https://github.com/GeoscienceAustralia/dea-docs/blob/master/.github/workflows/main.yml
+# Documentation in this repo is not built in this GitHub Action. Instead, it is built by a separate Action in the dea-knowledge-hub repo.
+# See here: https://github.com/GeoscienceAustralia/dea-knowledge-hub/blob/main/.github/workflows/deploy-production.yaml
 
-# The below action triggers a build in dea-docs when changes are pushed to the 'stable' branch in the current repo
+# The below action triggers a build in dea-knowledge-hub when changes are pushed to the 'stable' branch in the current repo
 
 on:
   push:
@@ -18,6 +18,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_PAT }}
-          repository: GeoscienceAustralia/dea-docs
+          repository: GeoscienceAustralia/dea-knowledge-hub
           event-type: republish-docs
 

--- a/DEA_notebooks_template.ipynb
+++ b/DEA_notebooks_template.ipynb
@@ -11,7 +11,7 @@
     "* When adding **Products used**, embed the hyperlink to that specific product on the DEA Explorer using the `[product_name](product url)` syntax.\n",
     "* When writing in Markdown cells, start each sentence on a **new line**. This makes it easy to see changes through git commits.\n",
     "* Use Australian English in markdown cells and code comments.\n",
-    "* Check the [known issues](https://github.com/GeoscienceAustralia/dea-knowledge-hub/wiki/Known-issues) for formatting regarding the conversion of notebooks to DEA docs using Sphinx. Things to be aware of:\n",
+    "* See the [Knowledge Hub formatting troubleshooting guide](https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Troubleshooting-Knowledge-Hub-formatting) to ensure your formatting will display properly on the [DEA Knowledge Hub](https://knowledge.dea.ga.gov.au/). Things to be aware of:\n",
     "    * Sphinx is highly sensitive to bulleted lists:\n",
     "        * Ensure that there is an empty line between any preceding text and the list\n",
     "        * Only use the `*` bullet (`-` is not recognised)\n",

--- a/DEA_notebooks_template.ipynb
+++ b/DEA_notebooks_template.ipynb
@@ -11,7 +11,7 @@
     "* When adding **Products used**, embed the hyperlink to that specific product on the DEA Explorer using the `[product_name](product url)` syntax.\n",
     "* When writing in Markdown cells, start each sentence on a **new line**. This makes it easy to see changes through git commits.\n",
     "* Use Australian English in markdown cells and code comments.\n",
-    "* Check the [known issues](https://github.com/GeoscienceAustralia/dea-docs/wiki/Known-issues) for formatting regarding the conversion of notebooks to DEA docs using Sphinx. Things to be aware of:\n",
+    "* Check the [known issues](https://github.com/GeoscienceAustralia/dea-knowledge-hub/wiki/Known-issues) for formatting regarding the conversion of notebooks to DEA docs using Sphinx. Things to be aware of:\n",
     "    * Sphinx is highly sensitive to bulleted lists:\n",
     "        * Ensure that there is an empty line between any preceding text and the list\n",
     "        * Only use the `*` bullet (`-` is not recognised)\n",


### PR DESCRIPTION
### Proposed changes

Some references to the old repo name 'dea-docs' existed in the repo, so I updated them to use the new name 'dea-knowledge-hub'. This also involved updating a few links.

### Closes issues (optional)

### Checklist 
(Replace `[ ]` with `[x]` to check off)

- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with
- [ ] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)
