### PR TITLE
Add updated xr_interpolate func and tests

### DIFF
--- a/Tests/dea_tools/test_spatial.py
+++ b/Tests/dea_tools/test_spatial.py
@@ -8,7 +8,13 @@ import geopandas as gpd
 import datacube
 from datacube.utils.masking import mask_invalid_data
 
-from dea_tools.spatial import subpixel_contours, xr_vectorize, xr_rasterize
+from dea_tools.spatial import (
+    subpixel_contours,
+    xr_vectorize,
+    xr_rasterize,
+    xr_interpolate,
+)
+from dea_tools.validation import eval_metrics
 
 
 @pytest.fixture(
@@ -92,6 +98,19 @@ def categorical_da(request):
         da = da.odc.reproject(crs, resampling="nearest")
 
     return da
+
+
+# Test set of points covering the extent of `dem_da`
+@pytest.fixture()
+def points_gdf():
+    return gpd.GeoDataFrame(
+        data={"z": [400, 800, 900, 1100, 1200, 1500]},
+        geometry=gpd.points_from_xy(
+            x=[149.06, 149.06, 149.10, 149.16, 149.20, 149.20],
+            y=[-35.36, -35.22, -35.29, -35.29, -35.36, -35.22],
+            crs="EPSG:4326",
+        ),
+    )
 
 
 @pytest.mark.parametrize(
@@ -323,3 +342,96 @@ def test_subpixel_contours_dim(satellite_da):
 
 #     # Verify that no error is raised if we provide the correct CRS
 #     subpixel_contours(dem_da.drop_vars("spatial_ref"), z_values=700, crs="EPSG:4326")
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["linear", "cubic", "nearest", "rbf", "idw"],
+)
+def test_interpolate_2d(dem_da, points_gdf, method):
+    # Run interpolation and verify that pixel grids are the same and
+    # output contains data
+    interpolated_ds = xr_interpolate(
+        dem_da,
+        gdf=points_gdf,
+        method=method,
+        k=5,
+    )
+    assert interpolated_ds.odc.geobox == dem_da.odc.geobox
+    assert "z" in interpolated_ds.data_vars
+    assert interpolated_ds["z"].notnull().sum() > 0
+
+    # Sample interpolated values at each point, and verify that
+    # interpolated z values match our input z values
+    xs = xr.DataArray(points_gdf.to_crs(dem_da.odc.crs).geometry.x, dims="z")
+    ys = xr.DataArray(points_gdf.to_crs(dem_da.odc.crs).geometry.y, dims="z")
+    sampled = interpolated_ds["z"].interp(x=xs, y=ys, method="nearest")
+    val_stats = eval_metrics(points_gdf.z, sampled)
+    assert val_stats.Correlation > 0.9
+    assert val_stats.MAE < 10
+
+    # Verify that a factor above 1 still returns expected results
+    interpolated_ds_factor10 = xr_interpolate(
+        dem_da,
+        gdf=points_gdf,
+        method=method,
+        k=5,
+        factor=10,
+    )
+    assert interpolated_ds_factor10.odc.geobox == dem_da.odc.geobox
+    assert "z" in interpolated_ds_factor10.data_vars
+    assert interpolated_ds_factor10["z"].notnull().sum() > 0
+
+    # Verify that multiple columns can be processed, and that output
+    # includes only numeric vars
+    points_gdf["num_var"] = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+    points_gdf["obj_var"] = ["a", "b", "c", "d", "e", "f"]
+    interpolated_ds_cols = xr_interpolate(
+        dem_da,
+        gdf=points_gdf,
+        method=method,
+        k=5,
+    )
+    assert "z" in interpolated_ds_cols.data_vars
+    assert "num_var" in interpolated_ds_cols.data_vars
+    assert "obj_var" not in interpolated_ds_cols.data_vars
+
+    # Verify that specific columns can be selected
+    interpolated_ds_cols2 = xr_interpolate(
+        dem_da,
+        gdf=points_gdf,
+        columns=["num_var"],
+        method=method,
+        k=5,
+    )
+    assert "z" not in interpolated_ds_cols2.data_vars
+    assert "num_var" in interpolated_ds_cols2.data_vars
+
+    # Verify that error is raised if no numeric columns exist
+    with pytest.raises(ValueError):
+        xr_interpolate(
+            dem_da,
+            gdf=points_gdf,
+            columns=["obj_var"],
+            method=method,
+            k=5,
+        )
+
+    # Verify that error is raised if `gdf` doesn't overlap with `ds`
+    with pytest.raises(ValueError):
+        xr_interpolate(
+            dem_da,
+            gdf=points_gdf.set_crs("EPSG:3577", allow_override=True),
+            method=method,
+            k=5,
+        )
+
+    # If IDW method, verify that k will fail if greater than points
+    if method == "idw":
+        with pytest.raises(ValueError):
+            xr_interpolate(
+                dem_da,
+                gdf=points_gdf,
+                method=method,
+                k=10,
+            )

--- a/Tests/dea_tools/test_spatial.py
+++ b/Tests/dea_tools/test_spatial.py
@@ -348,7 +348,7 @@ def test_subpixel_contours_dim(satellite_da):
     "method",
     ["linear", "cubic", "nearest", "rbf", "idw"],
 )
-def test_interpolate_2d(dem_da, points_gdf, method):
+def test_xr_interpolate(dem_da, points_gdf, method):
     # Run interpolation and verify that pixel grids are the same and
     # output contains data
     interpolated_ds = xr_interpolate(

--- a/Tools/dea_tools/spatial.py
+++ b/Tools/dea_tools/spatial.py
@@ -696,7 +696,6 @@ def xr_interpolate(
 
     # Output dict
     correlation_outputs = {}
-    # correlation_outputs = []
 
     # For each numeric column, run interpolation
     for col, z_values in numeric_gdf.items():

--- a/Tools/gen/dea_tools.spatial.rst
+++ b/Tools/gen/dea_tools.spatial.rst
@@ -16,13 +16,13 @@
       add_geobox
       contours_to_arrays
       hillshade
-      interpolate_2d
       largest_region
       points_on_line
       reverse_geocode
       subpixel_contours
       sun_angles
       transform_geojson_wgs_to_epsg
+      xr_interpolate
       xr_rasterize
       xr_vectorize
       zonal_stats_parallel


### PR DESCRIPTION
### Proposed changes
This PR updates the existing `interpolate_2d` function into a brand new `xr_interpolation` function. Compared to `interpolate_2d`, this function:

- Supports a `geopandas.GeoDataFrame` points dataset as an input
- Automatically interpolates all numeric columns in this dataset 
- Also supports Inverse Distance Weighted interpolation, with option to restrict the interpolation to `k` nearest neighbours.

Example Inverse Distance Weighted interpolated  `xarray` output for a point `gdf` containing 7 columns:

![image](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/7dd17702-9aed-4de7-89c8-63a04c33473c)


Have added comprehensive tests, and deprecated `interpolate_2d` to be removed at a later date.

### Checklist 
(Replace `[ ]` with `[x]` to check off)

- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with
- [x] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)
