### PR TITLE
Change `xr_interpolate` extent Error to Warning

### DIFF
--- a/Tests/dea_tools/test_spatial.py
+++ b/Tests/dea_tools/test_spatial.py
@@ -417,8 +417,8 @@ def test_xr_interpolate(dem_da, points_gdf, method):
             k=5,
         )
 
-    # Verify that error is raised if `gdf` doesn't overlap with `ds`
-    with pytest.raises(ValueError):
+    # Verify that warning is raised if `gdf` doesn't overlap with `ds`
+    with pytest.warns():
         xr_interpolate(
             dem_da,
             gdf=points_gdf.set_crs("EPSG:3577", allow_override=True),

--- a/Tools/dea_tools/spatial.py
+++ b/Tools/dea_tools/spatial.py
@@ -646,10 +646,10 @@ def xr_interpolate(
     ds = add_geobox(ds, crs)
     y_dim, x_dim = ds.odc.spatial_dims
 
-    # Reproject to match input `ds`, and raise error if there are no overlaps
+    # Reproject to match input `ds`, and raise warning if there are no overlaps
     gdf = gdf.to_crs(ds.odc.crs)
     if not gdf.dissolve().intersects(ds.odc.geobox.extent.geom).item():
-        raise ValueError("The supplied `gdf` does not overlap spatially with `ds`.")
+        warnings.warn("The supplied `gdf` does not overlap spatially with `ds`.", stacklevel=2)
 
     # Select subset of numeric columns (non-numeric are not supported)
     numeric_gdf = gdf.select_dtypes("number")

--- a/Tools/dea_tools/spatial.py
+++ b/Tools/dea_tools/spatial.py
@@ -601,7 +601,7 @@ def xr_interpolate(
         A dataset of spatial points including at least one numeric column.
         By default all numeric columns in this dataset will be spatially
         interpolated into the extent of `ds`; specific columns can be
-        selected using `columns`. An error will be raised if the points
+        selected using `columns`. An warning will be raised if the points
         in `gdf` do not overlap with the extent of `ds`.
     columns : list, optional
         An optional list of specific columns in gdf` to run the


### PR DESCRIPTION
### Proposed changes
Previously the xr_interpolate function returned an error if all points were outside the dataset extent.  This was an invalid requirement: it's often useful to interpolate from points outside the boundary of a dataset. 

This PR changes the error to a warning. 

### Closes issues (optional)
- Closes Issue #000

### Checklist 
(Replace `[ ]` with `[x]` to check off)

- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with
- [x] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)
