### PR TITLE
Point DEA Intertidal KH link to product page, not notebook

### DIFF
--- a/DEA_products/DEA_Intertidal.ipynb
+++ b/DEA_products/DEA_Intertidal.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "**Note:** Visit the [DEA Intertidal product description](https://knowledge.dea.ga.gov.au/notebooks/DEA_products/DEA_Intertidal/) for technical information about DEA Intertidal including a comprehensive review of the methods employed in the generation of datasets in this product suite.\n",
+    "**Note:** Visit the [DEA Intertidal product description](https://knowledge.dea.ga.gov.au/data/product/dea-intertidal/?tab=overview) for technical information about DEA Intertidal including a comprehensive review of the methods employed in the generation of datasets in this product suite.\n",
     "\n",
     "</div>\n",
     "\n",


### PR DESCRIPTION
### Proposed changes
The current Knowledge Hub link accidently points to the DEA Notebooks product notebook page, not the product page itself. This fixes it.
