### PR TITLE
Moved GeoMAD notebook in the sidebar of KH

### DIFF
--- a/DEA_products/README.rst
+++ b/DEA_products/README.rst
@@ -8,9 +8,9 @@ Notebooks introducing DEA's satellite datasets and derived products, including h
 
    DEA_Landsat_Surface_Reflectance.ipynb
    DEA_Sentinel2_Surface_Reflectance.ipynb
+   DEA_GeoMAD.ipynb
    DEA_Land_Cover.ipynb
    DEA_Fractional_Cover.ipynb
-   DEA_GeoMAD.ipynb
    DEA_Mangroves.ipynb
    DEA_Wetlands_Insight_Tool.ipynb
    DEA_Water_Observations.ipynb


### PR DESCRIPTION
### Proposed changes

This is to reflect the order of items in the KH data products sidebar. Minor change.

### Closes issues (optional)

### Checklist 
(Replace `[ ]` with `[x]` to check off)

- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [ ] Remove any unused Python packages from `Load packages`
- [ ] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with
- [ ] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)
