### PR TITLE
Minor updates for NCI environment compatibility

### DIFF
--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -48,6 +48,6 @@ jobs:
       run: |
         sudo chown -R 1000:100 ./dea-notebooks
         cd ./dea-notebooks 
-        CURRENT_UID=1000:100 docker-compose up -d
+        CURRENT_UID=1000:100 docker compose up -d
         docker compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
         docker compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -49,5 +49,5 @@ jobs:
         sudo chown -R 1000:100 ./dea-notebooks
         cd ./dea-notebooks 
         CURRENT_UID=1000:100 docker-compose up -d
-        docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
-        docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh
+        docker compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
+        docker compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh

--- a/Tests/dea_tools/test_coastal.py
+++ b/Tests/dea_tools/test_coastal.py
@@ -76,6 +76,7 @@ def satellite_ds(request):
         output_crs=crs,
         resolution=res,
         group_by="solar_day",
+        skip_broken_datasets=True,
         dask_chunks={},
     )
 

--- a/Tests/dea_tools/test_spatial.py
+++ b/Tests/dea_tools/test_spatial.py
@@ -80,6 +80,7 @@ def satellite_da(request):
         output_crs=crs,
         resolution=res,
         group_by="solar_day",
+        skip_broken_datasets=True,
     )
 
     # Mask nodata

--- a/Tests/dea_tools/test_temporal.py
+++ b/Tests/dea_tools/test_temporal.py
@@ -23,6 +23,7 @@ def satellite_ds():
         resolution=(-200, 200),
         output_crs="EPSG:3577",
         group_by="solar_day",
+        skip_broken_datasets=True,
     )
 
     # Mask nodata

--- a/Tests/dea_tools/test_temporal.py
+++ b/Tests/dea_tools/test_temporal.py
@@ -21,6 +21,7 @@ def satellite_ds():
         y=(-18.0008 - 0.01, -18.0008 + 0.01),
         time=("2020-01", "2020-02"),
         resolution=(-200, 200),
+        output_crs="EPSG:3577",
         group_by="solar_day",
     )
 

--- a/Tests/dea_tools/test_temporal.py
+++ b/Tests/dea_tools/test_temporal.py
@@ -21,7 +21,7 @@ def satellite_ds():
         y=(-18.0008 - 0.01, -18.0008 + 0.01),
         time=("2020-01", "2020-02"),
         resolution=(-200, 200),
-        output_crs="EPSG:3577",
+        output_crs="EPSG:3577",  # Added here temporarily until NCI environment is updated to include load hints
         group_by="solar_day",
         skip_broken_datasets=True,
     )


### PR DESCRIPTION
### Proposed changes
This PR makes two minor changes to hopefully allow tests to run sucessfully on the NCI:

- Explicitly declare "output_crs" in temporal tests, as load hints don't appear to be set up correctly on NCI
- Add "skip_broken_datasets" to work around missing datasets/indexing issues