### PR TITLE
Mitch predict_xr

### DIFF
--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -336,7 +336,7 @@ def predict_xr(
             print("   probabilities...")
             out_proba = model.predict_proba(input_data_flattened)
 
-            # convert to %
+            # return either one band with the max probability, or the whole probability array
             if max_proba == True:
                 print("  returning single probability band.")
                 out_proba = da.max(out_proba, axis=1) * 100.0
@@ -348,12 +348,10 @@ def predict_xr(
             else:
                 print("  returning class probability array.")
                 out_proba = out_proba * 100.0
-                
                 class_names = model.classes_  # Get the unique class names from the fitted classifier
 
-                probabilities_dataset = xr.Dataset()
-
                 # Loop through each class (band)
+                probabilities_dataset = xr.Dataset()
                 for i, class_name in enumerate(class_names):
                     reshaped_band = out_proba[:, i].reshape(len(y), len(x))
                     reshaped_da = xr.DataArray(

--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -288,7 +288,7 @@ def predict_xr(
             input_xr.chunks["y"][0]
         )
 
-    def _predict_func(model, input_xr, persist, proba, proba_max, clean, return_input):
+    def _predict_func(model, input_xr, persist, proba, max_proba, clean, return_input):
         x, y, crs = input_xr.x, input_xr.y, input_xr.geobox.crs
 
         input_data = []
@@ -337,7 +337,7 @@ def predict_xr(
             out_proba = model.predict_proba(input_data_flattened)
 
             # convert to %
-            if proba_max == True:
+            if max_proba == True:
                 print("  returning single probability band.")
                 out_proba = da.max(out_proba, axis=1) * 100.0
             else:
@@ -402,12 +402,12 @@ def predict_xr(
         model = ParallelPostFit(model)
         with joblib.parallel_backend("dask"):
             output_xr = _predict_func(
-                model, input_xr, persist, proba, proba_max, clean, return_input
+                model, input_xr, persist, proba, max_proba, clean, return_input
             )
 
     else:
         output_xr = _predict_func(
-            model, input_xr, persist, proba, proba_max, clean, return_input
+            model, input_xr, persist, proba, max_proba, clean, return_input
         ).compute()
 
     return output_xr

--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -402,12 +402,12 @@ def predict_xr(
         model = ParallelPostFit(model)
         with joblib.parallel_backend("dask"):
             output_xr = _predict_func(
-                model, input_xr, persist, proba, clean, return_input
+                model, input_xr, persist, proba, proba_max, clean, return_input
             )
 
     else:
         output_xr = _predict_func(
-            model, input_xr, persist, proba, clean, return_input
+            model, input_xr, persist, proba, proba_max, clean, return_input
         ).compute()
 
     return output_xr


### PR DESCRIPTION
### Proposed changes
Updating the `predict_xr()` function to allow returning the full array of prediciton probabilities our of `predict_proba()`, which is actually the default behaviour normally

### Closes issues (optional)
- Closes Issue #000

### Checklist 
(Replace `[ ]` with `[x]` to check off)

- [ x] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x ] Remove any unused Python packages from `Load packages`
- [ x] Remove any unused/empty code cells
- [x ] Remove any guidance cells (e.g. `General advice`)
- [x ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [x ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with
- [x ] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)
