### PR TITLE
Update load_ard for Sentinel-2C, add better error handling

### DIFF
--- a/Tools/dea_tools/datahandling.py
+++ b/Tools/dea_tools/datahandling.py
@@ -112,7 +112,7 @@ def load_ard(
 ):
     """
     Load multiple Geoscience Australia Landsat or Sentinel 2
-    Analysis Ready Data products (e.g. Landsat 5, 7, 8, 9; Sentinel 2A, 2B, 2C),
+    Collection 3  Analysis Ready Data products (e.g. Landsat 5, 7, 8, 9; Sentinel 2A, 2B, 2C),
     optionally apply pixel quality/cloud masking and contiguity masks,
     and drop time steps that contain greater than a minimum proportion
     of good quality (e.g. non-cloudy or shadowed) pixels.
@@ -260,11 +260,11 @@ def load_ard(
 
     # Convert products to a list if it is passed as a string
     products = [products] if isinstance(products, str) else products
-    
+
     # Valid Landsat products
     valid_ls = ["ga_ls5t_ard_3", "ga_ls7e_ard_3", "ga_ls8c_ard_3", "ga_ls9c_ard_3"]
     valid_s2 = ["ga_s2am_ard_3", "ga_s2bm_ard_3", "ga_s2cm_ard_3"]
-    
+
     # Verify that products were provided
     if not products:
         raise ValueError(
@@ -272,7 +272,7 @@ def load_ard(
             f"product names to load data from. Valid options are: "
             f"{valid_ls + valid_s2}."
         )
-    
+
     # Determine whether products are all Landsat, all S2, or mixed
     elif all([product in valid_ls for product in products]):
         product_type = "ls"
@@ -280,7 +280,7 @@ def load_ard(
         product_type = "s2"
     elif all([product in valid_s2 + valid_ls for product in products]):
         product_type = "mixed"
-    
+
         warnings.warn(
             "You have selected a combination of Landsat and Sentinel-2 "
             "products. This can produce unexpected results as these "
@@ -290,7 +290,9 @@ def load_ard(
         )
     else:
         # If an invalid product is passed, raise error
-        invalid_products = [product for product in products if product not in valid_s2 + valid_ls]
+        invalid_products = [
+            product for product in products if product not in valid_s2 + valid_ls
+        ]
         raise ValueError(
             f"The `load_ard` function only supports Landsat and "
             f"Sentinel-2 Analysis Ready Data products; {invalid_products} is not supported. "

--- a/Tools/dea_tools/datahandling.py
+++ b/Tools/dea_tools/datahandling.py
@@ -17,7 +17,7 @@ here: https://gis.stackexchange.com/questions/tagged/open-data-cube).
 If you would like to report an issue with this script, you can file one
 on GitHub (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 
-Last modified: Feb 2024
+Last modified: February 2025
 """
 
 import datetime
@@ -112,7 +112,7 @@ def load_ard(
 ):
     """
     Load multiple Geoscience Australia Landsat or Sentinel 2
-    Collection 3 products (e.g. Landsat 5, 7, 8, 9; Sentinel 2A and 2B),
+    Analysis Ready Data products (e.g. Landsat 5, 7, 8, 9; Sentinel 2A, 2B, 2C),
     optionally apply pixel quality/cloud masking and contiguity masks,
     and drop time steps that contain greater than a minimum proportion
     of good quality (e.g. non-cloudy or shadowed) pixels.
@@ -126,13 +126,14 @@ def load_ard(
     And Sentinel-2 products:
         * ga_s2am_ard_3
         * ga_s2bm_ard_3
+        * ga_s2cm_ard_3
 
     Cloud masking can be performed using the Fmask (Function of Mask)
     cloud mask for Landsat and Sentinel-2, and the s2cloudless
     (Sentinel Hub cloud detector for Sentinel-2 imagery) cloud mask for
     Sentinel-2.
 
-    Last modified: June 2023
+    Last modified: February 2025
 
     Parameters
     ----------
@@ -142,7 +143,8 @@ def load_ard(
     products : list
         A list of product names to load. Valid options are
         ['ga_ls5t_ard_3', 'ga_ls7e_ard_3', 'ga_ls8c_ard_3', 'ga_ls9c_ard_3']
-        for Landsat, ['ga_s2am_ard_3', 'ga_s2bm_ard_3'] for Sentinel 2.
+        for Landsat, ['ga_s2am_ard_3', 'ga_s2bm_ard_3', 'ga_s2cm_ard_3']
+        for Sentinel 2.
     cloud_mask : string, optional
         The cloud mask used by the function. This is used for both
         masking out poor quality pixels (e.g. clouds) if
@@ -256,29 +258,43 @@ def load_ard(
     # Setup #
     #########
 
+    # Convert products to a list if it is passed as a string
+    products = [products] if isinstance(products, str) else products
+    
+    # Valid Landsat products
+    valid_ls = ["ga_ls5t_ard_3", "ga_ls7e_ard_3", "ga_ls8c_ard_3", "ga_ls9c_ard_3"]
+    valid_s2 = ["ga_s2am_ard_3", "ga_s2bm_ard_3", "ga_s2cm_ard_3"]
+    
     # Verify that products were provided
     if not products:
         raise ValueError(
-            "Please provide a list of product names to load data from. "
-            "Valid options are: ['ga_ls5t_ard_3', 'ga_ls7e_ard_3', "
-            "'ga_ls8c_ard_3', 'ga_ls9c_ard_3'] for Landsat, and "
-            "['ga_s2am_ard_3', 'ga_s2bm_ard_3'] for Sentinel 2."
+            f"Please provide a list of Landsat or Sentinel-2 Analysis Ready Data "
+            f"product names to load data from. Valid options are: "
+            f"{valid_ls + valid_s2}."
         )
-
+    
     # Determine whether products are all Landsat, all S2, or mixed
-    elif all(["ls" in product for product in products]):
+    elif all([product in valid_ls for product in products]):
         product_type = "ls"
-    elif all(["s2" in product for product in products]):
+    elif all([product in valid_s2 for product in products]):
         product_type = "s2"
-    else:
+    elif all([product in valid_s2 + valid_ls for product in products]):
         product_type = "mixed"
-
+    
         warnings.warn(
             "You have selected a combination of Landsat and Sentinel-2 "
             "products. This can produce unexpected results as these "
             "products use the same names for different spectral bands "
             "(e.g. Landsat and Sentinel-2's 'nbart_swir_2'); use with "
             "caution."
+        )
+    else:
+        # If an invalid product is passed, raise error
+        invalid_products = [product for product in products if product not in valid_s2 + valid_ls]
+        raise ValueError(
+            f"The `load_ard` function only supports Landsat and "
+            f"Sentinel-2 Analysis Ready Data products; {invalid_products} is not supported. "
+            f"Valid options are: {valid_ls + valid_s2}."
         )
 
     # Set contiguity band depending on `mask_contiguity`;


### PR DESCRIPTION
### Proposed changes
This PR updates the `load_ard` function in preperation for Sentinel-2C data being available. It mainly updates function documentation, but also:

- Added better error checking to verify that a user passes a valid list of Landsat and/or Sentinel-2 products. This will raise an error if a non-ARD product is passed, and also provide better handling of products with "s2" in the name which aren't ARD products (e.g. `ga_s2ls_intertidal_3`).

### Checklist 

- [ ] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [x] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [ ] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with
- [x] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)
