### PR TITLE
Loosen `pyTMD` version restriction, fix broken DEA Tools build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
+      
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'  # Pin to <3.12 for compatibility with pip==22.0.4
+          python-version: '3.11'  # Specify a stable Python version
       
       - name: Get history and tags for SCM versioning
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'  # Specify a stable Python version
+          python-version: '3.11'  # Pin to <3.12 for compatibility with pip==22.0.4
       
       - name: Get history and tags for SCM versioning
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       
       - name: Set up Python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'  # Pin to <3.12 for compatibility with pip==22.0.4
+      
       - name: Get history and tags for SCM versioning
         run: |
           git fetch --prune --unshallow

--- a/Tools/setup.py
+++ b/Tools/setup.py
@@ -56,7 +56,7 @@ REQUIRED = [
     'pystac-client',
     'planetary-computer',
     'python-dateutil',
-    'pyTMD<=2.1.6',    
+    'pyTMD!=2.1.7',    
     'pytz',
     'rasterio',
     'rasterstats',


### PR DESCRIPTION
### Proposed changes
Removes the upper limit on the `pyTMD` tide modelling package in favour of excluding a specific version. This will allow DEA Tools to be used more easily in our external DEA Coastlines code which requires a higher version of `pyTMD`.

This PR also includes an attempt to fix the failing DEA Tools package build here, by pinning Python to <3.12: https://github.com/GeoscienceAustralia/dea-notebooks/actions/runs/13402753502

This issue may have been caused by a recent update to `ubuntu-latest`, which uses Python 3.12 by default (which is incompatible with the older `pip==22.0.4` version we use to build the package).

