### PR TITLE
added s2c to the dea explorer links and updated tags

### DIFF
--- a/DEA_notebooks_template.ipynb
+++ b/DEA_notebooks_template.ipynb
@@ -36,13 +36,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Descriptive title that follows notebook filename <img align=\"right\" src=\"../Supplementary_data/dea_logo.jpg\">\n",
+    "# Descriptive title that follows notebook filename <img align=\"right\" src=\"./Supplementary_data/dea_logo.jpg\">\n",
     "\n",
     "* **[Sign up to the DEA Sandbox](https://app.sandbox.dea.ga.gov.au/)** to run this notebook interactively from a browser\n",
     "* **Compatibility:** Notebook currently compatible with both the `NCI` and `DEA Sandbox` environments\n",
     "* **Products used:** \n",
     "[ga_s2am_ard_3](https://explorer.dea.ga.gov.au/products/ga_s2am_ard_3), \n",
     "[ga_s2bm_ard_3](https://explorer.dea.ga.gov.au/products/ga_s2bm_ard_3),\n",
+    "[ga_s2cm_ard_3](https://explorer.dea.ga.gov.au/products/ga_s2cm_ard_3),\n",
     "[ga_ls5t_ard_3](https://explorer.dea.ga.gov.au/products/ga_ls5t_ard_3),\n",
     "[ga_ls7e_ard_3](https://explorer.dea.ga.gov.au/products/ga_ls7e_ard_3),\n",
     "[ga_ls8c_ard_3](https://explorer.dea.ga.gov.au/products/ga_ls8c_ard_3)\n",
@@ -241,7 +242,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.8.6\n"
+      "1.8.19\n"
      ]
     }
    ],
@@ -263,7 +264,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "**Tags**: :index:`NCI compatible`, :index:`sandbox compatible`, :index:`sentinel 2`, :index:`landsat 8`, :index:`rgb`, :index:`NDVI`, :index:`time series`"
+    "**Tags**: :index:`template`, :index:`sandbox compatible`, "
    ]
   }
  ],
@@ -283,7 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.15"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
### Proposed changes
Added s2c to the example explorer links in the template.
Changed the tags to 'template' and 'sandbox-compatible'

### Checklist 
(Replace `[ ]` with `[x]` to check off)

- [x] Notebook created using the [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop)
- [x] Remove any unused Python packages from `Load packages`
- [x] Remove any unused/empty code cells
- [ ] Remove any guidance cells (e.g. `General advice`)
- [ ] Ensure that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Include relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [x] Clear all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] Test notebook on both the `NCI` and `DEA Sandbox` (flag if not working as part of PR and ask for help to solve if needed)
- [ ] If applicable, update the `Notebook currently compatible with the NCI|DEA Sandbox environment only` line below the notebook title to reflect the environments the notebook is compatible with
- [ ] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)
