### PR TITLE
Add pre-commit hook to avoid duplicates

### DIFF
--- a/.githooks/check_duplicate_ipynb.sh
+++ b/.githooks/check_duplicate_ipynb.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 
-echo "Checking for duplicate .ipynb filenames in the incoming push..."
+echo "Checking for duplicate .ipynb filenames..."
 
-# Get the list of changed files in the push
-while read oldrev newrev refname; do
-    # Get all added/modified .ipynb files
-    files=$(git diff --name-only --diff-filter=A "$oldrev" "$newrev" | grep '\.ipynb$' || true)
+# Get all existing and staged .ipynb files
+all_files=$(git ls-files | grep '\.ipynb$' || true)
+staged_files=$(git diff --cached --name-only --diff-filter=A | grep '\.ipynb$' || true)
 
-    if [[ -z "$files" ]]; then
-        continue  # No new .ipynb files, skip checking
-    fi
+# Combine them to ensure we check for duplicates globally
+combined_files=$(echo -e "$all_files\n$staged_files" | sort -u)
 
-    # Extract just the filenames (ignore paths)
-    filenames=$(basename -a $files)
+if [[ -z "$combined_files" ]]; then
+    exit 0  # No .ipynb files found, allow commit
+fi
 
-    # Check for duplicates
-    duplicates=$(echo "$filenames" | sort | uniq -d)
+# Extract only filenames (ignore paths)
+filenames=$(basename -a $combined_files)
 
-    if [[ -n "$duplicates" ]]; then
-        echo "Duplicate .ipynb filenames detected in the push:"
-        echo "$duplicates"
-        echo "Push rejected! Ensure unique .ipynb filenames."
-        exit 1  # Reject the push
-    fi
-done
+# Check for duplicates
+duplicates=$(echo "$filenames" | sort | uniq -d)
 
-exit 0  # Allow push if no duplicates
+if [[ -n "$duplicates" ]]; then
+    echo "Duplicate .ipynb filenames detected in repository and staged changes:"
+    echo "$duplicates"
+    echo "Commit rejected! Ensure unique .ipynb filenames."
+    exit 1  # Prevent commit
+fi
 
+exit 0  # Allow commit

--- a/.githooks/check_duplicate_ipynb.sh
+++ b/.githooks/check_duplicate_ipynb.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Checking for duplicate .ipynb filenames in the incoming push..."
+
+# Get the list of changed files in the push
+while read oldrev newrev refname; do
+    # Get all added/modified .ipynb files
+    files=$(git diff --name-only --diff-filter=A "$oldrev" "$newrev" | grep '\.ipynb$' || true)
+
+    if [[ -z "$files" ]]; then
+        continue  # No new .ipynb files, skip checking
+    fi
+
+    # Extract just the filenames (ignore paths)
+    filenames=$(basename -a $files)
+
+    # Check for duplicates
+    duplicates=$(echo "$filenames" | sort | uniq -d)
+
+    if [[ -n "$duplicates" ]]; then
+        echo "Duplicate .ipynb filenames detected in the push:"
+        echo "$duplicates"
+        echo "Push rejected! Ensure unique .ipynb filenames."
+        exit 1  # Reject the push
+    fi
+done
+
+exit 0  # Allow push if no duplicates
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  skip: [check-duplicate-ipynb] 
+
 repos:
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: check-duplicate-ipynb
+        name: Check for duplicate .ipynb filenames
+        entry: bash .githooks/check_duplicate_ipynb.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
Add `pre-commit` hook to check duplicate notebooks before commit, both locally and remotely. Aiming to save human from sanity-checking as much as possible.

### Closes issues (optional)
N/A
If there are duplicates, the output should be
```
ubuntu@ip-10-0-13-183:~/work/dea-notebooks$ git commit -a -m "add test"
Check for duplicate .ipynb filenames.....................................Failed
- hook id: check-duplicate-ipynb
- exit code: 1

Checking for duplicate .ipynb filenames...
Duplicate .ipynb filenames detected in repository and staged changes:
test1.ipynb
Commit rejected! Ensure unique .ipynb filenames.
```

### Checklist
<!--- (Replace `[ ]` with `[x]` to check off) --->

If this is a notebook, then have you: 
- [ ] Checked the structure of the notebook follows our [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/wiki/NotebookTemplate)
- [ ] Removed any unused Python packages from `Load packages`
- [ ] Removed any unused/empty code cells
- [ ] Removed any guidance cells (e.g. `General advice`)
- [ ] Ensured that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [ ] Included relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [ ] Tested notebook on the [DEA Sandbox](https://knowledge.dea.ga.gov.au/guides/setup/Sandbox/sandbox/)
- [ ] Cleared all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [ ] If applicable, update the `Notebook currently compatible with` line below the notebook title to reflect the environments the notebook is compatible with
- [ ] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)

<!--- 
⭐ Did you get stuck? These might help: 
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Getting-started-with-Git
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Create-a-DEA-Notebook
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook
--->
