### PR TITLE
Exclude interactive notebooks from tests, only run "latest" on schedule (not PRs)

### DIFF
--- a/.github/workflows/test_notebooks_pullrequest.yml
+++ b/.github/workflows/test_notebooks_pullrequest.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           separator: ' '
           files: '**/*.ipynb'
-          files_ignore:
+          files_ignore: |
             - Real_world_examples/Scalable_machine_learning
             - Real_world_examples/Estimate_climate_driver_influence_on_rainfall.ipynb
             - Real_world_examples/Mapping_inundation_using_stream_gauges.ipynb

--- a/.github/workflows/test_notebooks_pullrequest.yml
+++ b/.github/workflows/test_notebooks_pullrequest.yml
@@ -24,12 +24,20 @@ jobs:
         with:
           path: dea-notebooks
 
+      # Detects changed Jupyter Notebooks, excluding interactive notebooks
       - name: Get changed notebook files
         id: changed-notebooks
         uses: tj-actions/changed-files@v45
         with:
-          files: '**/*.ipynb'
           separator: ' '
+          files: '**/*.ipynb'
+          files_ignore:
+            - Real_world_examples/Scalable_machine_learning
+            - Real_world_examples/Estimate_climate_driver_influence_on_rainfall.ipynb
+            - Real_world_examples/Mapping_inundation_using_stream_gauges.ipynb
+            - How_to_guides/Land_cover_pixel_drill.ipynb
+            - How_to_guides/External_data_ERA5_Climate.ipynb
+            - How_to_guides/Imagery_on_web_map.ipynb
 
       - name: Print changed notebook files
         if: steps.changed-notebooks.outputs.any_changed == 'true'

--- a/.github/workflows/test_notebooks_scheduled.yml
+++ b/.github/workflows/test_notebooks_scheduled.yml
@@ -1,17 +1,15 @@
 
-name: Test entire repo against DEA Sandbox image
+name: Scheduled test of entire repo against DEA Sandbox images
 
-# This workflow tests the entire repository against DEA Sandbox "stable" image 
-# when Python code changes (i.e. DEA Tools changes) are proposed to the develop branch
+# This workflow tests the entire repository against DEA Sandbox "stable" and
+# "latest" images on a regular schedule (twice weekly)
 
-on:  
-  # Run whenever a pull request to the develop branch modifies Python files
-  # in DEA Tools. This catches potential issues early before changes are merged
-  pull_request:
-    branches:
-      - develop
-    paths:
-      - '**/*.py'
+on:
+  # Run on schedule: Every Sunday and Wednesday at 10:00 UTC
+  # This is intended to catch problems that may occur even without code changes
+  # (e.g. changes to the DEA Sandbox images)
+  schedule:
+    - cron: "0 10 * * 0,3"
   
   # Allow manual triggering through the GitHub UI
   # Useful for on-demand testing or troubleshooting
@@ -25,11 +23,12 @@ jobs:
   test-notebooks:
     runs-on: ubuntu-latest
 
-    # Test DEA Notebooks sections against stable Sandbox image
+    # Test DEA Notebooks sections against both stable and latest Sandbox image
     strategy:
       
       matrix:
         image: 
+          - "latest"
           - "stable"
         tests:
           - "dea_tools"


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
To fix some recent issues with our updated tests, this PR:

- Ignores certain interactive notebooks when running the "changed files" test. This will prevent expected failures from causing the run to fail.
- Separates "latest" tests into a seperate workflow that only runs on schedule, not on PRs. This will prevent noisy failures distracting from other more useful failures.
