### PR TITLE
Update `files_ignore` approach to properly ignore interactive notebooks in tests (attempt to fix #1321)

### DIFF
--- a/.github/workflows/test_notebooks_pullrequest.yml
+++ b/.github/workflows/test_notebooks_pullrequest.yml
@@ -31,13 +31,7 @@ jobs:
         with:
           separator: ' '
           files: '**/*.ipynb'
-          files_ignore: |
-            - **/Scalable_machine_learning/
-            - **/Estimate_climate_driver_influence_on_rainfall.ipynb
-            - **/Mapping_inundation_using_stream_gauges.ipynb
-            - **/Land_cover_pixel_drill.ipynb
-            - **/External_data_ERA5_Climate.ipynb
-            - **/Imagery_on_web_map.ipynb
+          files_ignore: 'How_to_guides/Imagery_on_web_map.ipynb'
 
       - name: Print changed notebook files
         if: steps.changed-notebooks.outputs.any_changed == 'true'

--- a/.github/workflows/test_notebooks_pullrequest.yml
+++ b/.github/workflows/test_notebooks_pullrequest.yml
@@ -30,9 +30,10 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           separator: ' '
-          files: '**/*.ipynb'
-          files_ignore: 'How_to_guides/Imagery_on_web_map.ipynb'
-
+          files: '**/*.ipynb'          
+          files_ignore: |
+            How_to_guides/Imagery_on_web_map.ipynb
+            How_to_guides/External_data_ERA5_Climate.ipynb
       - name: Print changed notebook files
         if: steps.changed-notebooks.outputs.any_changed == 'true'
         run: |

--- a/.github/workflows/test_notebooks_pullrequest.yml
+++ b/.github/workflows/test_notebooks_pullrequest.yml
@@ -30,7 +30,7 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           separator: ' '
-          files: '**/*.ipynb'          
+          files: '**/*.ipynb'
           files_ignore: |
             Real_world_examples/Scalable_machine_learning/
             Real_world_examples/Estimate_climate_driver_influence_on_rainfall.ipynb

--- a/.github/workflows/test_notebooks_pullrequest.yml
+++ b/.github/workflows/test_notebooks_pullrequest.yml
@@ -32,6 +32,10 @@ jobs:
           separator: ' '
           files: '**/*.ipynb'          
           files_ignore: |
+            Real_world_examples/Scalable_machine_learning/
+            Real_world_examples/Estimate_climate_driver_influence_on_rainfall.ipynb
+            Real_world_examples/Mapping_inundation_using_stream_gauges.ipynb
+            How_to_guides/Land_cover_pixel_drill.ipynb
             How_to_guides/Imagery_on_web_map.ipynb
             How_to_guides/External_data_ERA5_Climate.ipynb
       - name: Print changed notebook files

--- a/.github/workflows/test_notebooks_pullrequest.yml
+++ b/.github/workflows/test_notebooks_pullrequest.yml
@@ -32,12 +32,12 @@ jobs:
           separator: ' '
           files: '**/*.ipynb'
           files_ignore: |
-            - Real_world_examples/Scalable_machine_learning
-            - Real_world_examples/Estimate_climate_driver_influence_on_rainfall.ipynb
-            - Real_world_examples/Mapping_inundation_using_stream_gauges.ipynb
-            - How_to_guides/Land_cover_pixel_drill.ipynb
-            - How_to_guides/External_data_ERA5_Climate.ipynb
-            - How_to_guides/Imagery_on_web_map.ipynb
+            - **/Scalable_machine_learning/
+            - **/Estimate_climate_driver_influence_on_rainfall.ipynb
+            - **/Mapping_inundation_using_stream_gauges.ipynb
+            - **/Land_cover_pixel_drill.ipynb
+            - **/External_data_ERA5_Climate.ipynb
+            - **/Imagery_on_web_map.ipynb
 
       - name: Print changed notebook files
         if: steps.changed-notebooks.outputs.any_changed == 'true'

--- a/Beginners_guide/04_Loading_data.ipynb
+++ b/Beginners_guide/04_Loading_data.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "source": [
     "## Background\n",
-    "Loading data from the [Digital Earth Australia (DEA)](https://www.ga.gov.au/dea) instance of the [Open Data Cube](https://www.opendatacube.org/) requires the construction of a data query that specifies the what, where, and when of the data request.\n",
+    "Loading data from the [Digital Earth Australia (DEA)](https://www.ga.gov.au/dea) instance of the [Open Data Cube](https://www.opendatacube.org/) requires the construction of a query that specifies the what, where, and when of the data request.\n",
     "Each query returns a [multi-dimensional xarray object](http://xarray.pydata.org/en/stable/) containing the contents of your query.\n",
     "It is essential to understand the `xarray` data structures as they are fundamental to the structure of data loaded from the datacube.\n",
     "Manipulations, transformations and visualisation of `xarray` objects provide datacube users with the ability to explore and analyse DEA datasets, as well as pose and answer scientific questions."

--- a/How_to_guides/Imagery_on_web_map.ipynb
+++ b/How_to_guides/Imagery_on_web_map.ipynb
@@ -25,7 +25,6 @@
     "1. Load some pixel data in `EPSG:3857` projection, same as used by most web maps\n",
     "2. Display image loaded from these datasets on a map\n",
     "3. Display dataset footprints on a map along with image loaded from these datasets on the same map\n",
-    "\n",
     "---"
    ]
   },


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
We have a Github Action that runs tests on the subset of notebooks that were modified by a PR. This was causing problems with interactive notebooks, so we recently tried to ignore these notebooks from being tested, even if they were modified. However, this did not work (see #1321 ).

This PR makes some changes to fix this (removing YAML formatting that wasn't being read correctly).

I've tested these changes by making some minor edits to an ignored notebook (`How_to_guides/Imagery_on_web_map.ipynb`) and a non-ignored notebook (`Beginners_guide/04_Loading_data.ipynb`). The tests now appear to successfully skip the ignored notebook, and only run the non-ignored file:

![image](https://github.com/user-attachments/assets/6d79a620-0dca-40f3-99ae-cb2d441b55f8)


### Closes issues (optional)
- Closes Issue #1321 
