### PR TITLE
Fix contiguity masking in `load_ard` by applying fuse function

### DIFF
--- a/Tools/dea_tools/datahandling.py
+++ b/Tools/dea_tools/datahandling.py
@@ -17,7 +17,7 @@ here: https://gis.stackexchange.com/questions/tagged/open-data-cube).
 If you would like to report an issue with this script, you can file one
 on GitHub (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 
-Last modified: February 2025
+Last modified: April 2025
 """
 
 import datetime
@@ -93,6 +93,16 @@ def _common_bands(dc, products):
         else:
             common = common.intersection(set(p.measurements))
     return [band for band in bands if band in common]
+
+
+def _contiguity_fuser(dst: np.ndarray, src: np.ndarray) -> None:
+    """
+    Ensure contiguity data is properly combined by replacing
+    pixels in `dst` that are either 0 (non-contiguous) or 255
+    (nodata) with the corresponding value from `src`, propogating
+    1 (valid contiguous data) if it exists.
+    """
+    np.copyto(dst, src, where=np.isin(dst, (255, 0)))
 
 
 def load_ard(
@@ -389,6 +399,12 @@ def load_ard(
             else pq_band
         )
 
+    # Use custom fuse function to ensure contiguity is combined correctly
+    # when grouping data by solar day. Without this, contiguity data from
+    # neighbouring images is pasted semi-randomly over each other,
+    # producing artefacts in the output.
+    kwargs["fuse_func"] = {contiguity_band: _contiguity_fuser}
+
     # If `measurements` are specified but do not include PQ or
     # contiguity variables, add these to `measurements`
     if pq_band not in measurements:
@@ -413,7 +429,7 @@ def load_ard(
     # If predicate is specified, use this function to filter the list
     # of datasets prior to load
     if verbose:
-       if predicate:
+        if predicate:
             print(
                 "The 'predicate' parameter will be deprecated in future "
                 "versions of this function as this functionality has now "
@@ -426,7 +442,7 @@ def load_ard(
     dataset_list = []
 
     # Get list of datasets for each product
-    if verbose:    
+    if verbose:
         print("Finding datasets")
     for product in products:
         # Obtain list of datasets for product
@@ -494,7 +510,7 @@ def load_ard(
         total_obs = len(ds.time)
         ds = ds.sel(time=keep)
         pq_mask = pq_mask.sel(time=keep)
-        
+
         if verbose:
             print(
                 f"Filtering to {len(ds.time)} out of {total_obs} "
@@ -505,8 +521,10 @@ def load_ard(
     # Morphological filtering on cloud masks
     if (mask_filters is not None) & (mask_pixel_quality != False):
         if verbose:
-            print(f"Applying morphological filters to pixel quality mask: {mask_filters}")
-        
+            print(
+                f"Applying morphological filters to pixel quality mask: {mask_filters}"
+            )
+
         pq_mask = ~mask_cleanup(~pq_mask, mask_filters=mask_filters)
 
         warnings.warn(
@@ -531,14 +549,14 @@ def load_ard(
     if mask_pixel_quality:
         if verbose:
             print(f"Applying {cloud_mask} pixel quality/cloud mask")
-        
+
         mask = pq_mask
 
     # Add contiguity mask to combined mask
     if mask_contiguity:
         if verbose:
             print(f"Applying contiguity mask ({contiguity_band})")
-        
+
         cont_mask = ds[contiguity_band] == 1
 
         # If mask already has data if mask_pixel_quality == True,


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
Contiguity is a band in our ARD that identifies whether a pixel was missing data in _any_ of our surface reflectance bands (e.g. a pixel that is missing data in at least one band is considered "non-contiguous"). Masking by contiguity (`mask_contiguity=True` in `load_ard`) is important for applications like Geomedian, where missing data from individual bands can result in a biased output (particularly when some timesteps might be missing data in one band but others do not).

A bug in `load_ard` (#1337) however meant that contiguity band data was being combined incorrectly when multiple timesteps where merged using `group_by="solar_day"`, due to contiguity data from neighbouring images is pasted semi-randomly over each other. This produced nasty wedge-shaped artefacts like this:

![image](https://github.com/user-attachments/assets/a5f560b8-0346-4d68-b5f8-4d1ff1377da5)

This PR fixes this bug by adding a custom "fuse function", which ensures contiguity data is merged correctly. This now produces correct outputs:
![image](https://github.com/user-attachments/assets/292a8d46-e628-42f5-b0ee-5423df9c23d1)

### Closes issues (optional)
- Closes Issue #1337

### Checklist
<!--- (Replace `[ ]` with `[x]` to check off) --->

If this is a notebook, then have you: 
- [x] Ensured that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)

<!--- 
⭐ Did you get stuck? These might help: 
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Getting-started-with-Git
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Create-a-DEA-Notebook
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook
--->
