### PR TITLE
Updates to continental mosaics PR

### DIFF
--- a/How_to_guides/Generating_COG_mosaics.ipynb
+++ b/How_to_guides/Generating_COG_mosaics.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "## Background\n",
     "\n",
-    "DEA products are provided as tiles. The `datacube` library allows users to seamlessly work with these tiles and automatically mosaic them together for the area and time of interest. The data array loaded can then be exported as a standalone file.\n",
+    "DEA products [are provided as tiles](https://knowledge.dea.ga.gov.au/guides/reference/collection_3_summary_grid/). The `datacube` library allows users to seamlessly work with these tiles and automatically mosaic them together for the area and time of interest. The data array loaded can then be exported as a standalone file.\n",
     "\n",
     "An alternative method to generate mosaic files is by using `gdal` to join the tile files into a continental-scale Cloud-Optimised GeoTIFF (COG). COGs are an efficient format of GeoTIFF designed for cloud storage, which can be streamed and visualised more quickly in GIS software. COG data arrays are organised in square chunks, whereas standard GeoTIFFs are organised by bands. This means that, when visualising a region in GIS software, COGs load less data and are more efficient.\n",
     "\n",
@@ -43,8 +43,7 @@
     "* apply a DEA Land Cover colour scheme,\n",
     "* create true-colour composites for the DEA Geomedian.\n",
     "  \n",
-    "It makes use of functions from the DEA Tools library, but it is also possible to executed the Python scripts containing those functions via the command line using the `subprocess` module.\n",
-    "\n",
+    "It makes use of functions from the DEA Tools library, but it is also possible to run the analysis directly from the command line using the `make_cog_mosaic` and `make_styling_vrt` command line tools.\n",
     "***"
    ]
   },
@@ -74,8 +73,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import subprocess\n",
-    "import os\n",
     "from pathlib import Path\n",
     "\n",
     "import sys\n",
@@ -83,6 +80,27 @@
     "\n",
     "from dea_tools.mosaics.mosaic_COGs import make_cog_mosaics\n",
     "from dea_tools.mosaics.colour_scheme_VRTs import make_styling_vrt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91333f91-0acc-45b1-9c97-e664227fac74",
+   "metadata": {},
+   "source": [
+    "### Set output directory\n",
+    "\n",
+    "Set the directory that will be used for the output mosaics.\n",
+    "Both local directories and locations on AWS S3 are supported; by default, this will be your current working directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c124edd8-a459-4ff4-9eab-655b02f4c469",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_dir = Path.cwd()"
    ]
   },
   {
@@ -104,21 +122,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "e7adaecc-983f-4ebf-9747-63a579a4ef4c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# inputs for the mosaic function\n",
-    "bands = ['level4']\n",
+    "# Inputs for the mosaic function\n",
+    "bands = [\"level4\"]\n",
     "years = [2024]\n",
+    "\n",
     "# limit the mosaic to a few tiles\n",
-    "list_tiles = ['x46y47','x46y48','x46y49','x46y50']"
+    "list_tiles = [\"x46y47\", \"x46y48\", \"x46y49\", \"x46y50\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "669e7906-d4a7-4258-9fa4-8b253a668525",
    "metadata": {
     "scrolled": true
@@ -128,10 +147,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:24:00,200 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using parameters {'product': 'ga_ls_landcover_class_cyear_3', 'band': 'level4', 'time': 2024, 'freq': 'P1Y', 'version': '2-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'MODE', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:24:00,200 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:24:00,200 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4] - Output path: /home/jovyan/dev/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif\n",
-      "2025-07-23 05:24:00,201 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Output does not exist. Proceeding with mosaic generation.\n"
+      "2025-07-24 06:15:51,577 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using parameters {'product': 'ga_ls_landcover_class_cyear_3', 'band': 'level4', 'time': 2024, 'freq': 'P1Y', 'version': '2-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': PosixPath('/home/jovyan/Robbi/dea-notebooks/How_to_guides'), 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'MODE', 'compression_algo': 'ZSTD', 'compression_level': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
+      "2025-07-24 06:15:51,578 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using input data product directory: dea-public-data/derivative\n",
+      "2025-07-24 06:15:51,578 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4] Output path: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif\n",
+      "2025-07-24 06:15:51,578 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Output does not exist. Proceeding with mosaic generation.\n",
+      "2025-07-24 06:15:51,579 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Finding data to mosaic\n"
      ]
     },
     {
@@ -145,10 +165,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:24:56,001 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:24:56,002 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Writing data to temporary folder: /tmp/tmpugk87ig1\n",
-      "2025-07-23 05:24:56,003 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Building virtual raster (VRT)\n",
-      "2025-07-23 05:24:56,125 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Converting VRT to COG mosaic\n"
+      "2025-07-24 06:16:47,796 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Number of tiles to mosaic: 4\n",
+      "2025-07-24 06:16:47,797 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Writing data to temporary folder: /tmp/tmpjwywkovm\n",
+      "2025-07-24 06:16:47,797 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Building virtual raster (VRT)\n",
+      "2025-07-24 06:16:47,917 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Converting VRT to COG mosaic\n"
      ]
     },
     {
@@ -157,21 +177,14 @@
      "text": [
       "0...10...20...30...40...50...60...70...80...90...100 - done.\n",
       "Input file size is 3200, 12800\n",
-      "0...10...20...30...40...50.."
+      "0...10...20...30...40...50...60...70...80...90...100 - done.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:24:57,291 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ".60...70...80...90...100 - done.\n"
+      "2025-07-24 06:16:49,105 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Writing data locally: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif\n"
      ]
     }
    ],
@@ -187,16 +200,16 @@
     "            freq=\"P1Y\",\n",
     "            version=\"2-0-0\",\n",
     "            dataset_maturity=\"final\",\n",
-    "            product_dir=\"s3://dea-public-data/derivative/\", # DEA public AWS S3 bucket\n",
-    "            output_dir=os.getcwd(), # use the current directory\n",
+    "            product_dir=\"s3://dea-public-data/derivative/\",  # DEA public AWS S3 bucket\n",
+    "            output_dir=output_dir,\n",
     "            cog_blocksize=1024,\n",
     "            overview_count=7,\n",
-    "            overview_resampling=\"MODE\", # for categorical data, mode is the best algorithm for the resampling\n",
+    "            overview_resampling=\"MODE\",  # for categorical data, mode is the best algorithm for the resampling\n",
     "            compression_algo=\"ZSTD\",\n",
-    "            compression_lvl=9,\n",
+    "            compression_level=9,\n",
     "            aws_unsigned=True,\n",
-    "            skip_existing=True, # Set False if want to overwrite existing files\n",
-    "            list_tiles=list_tiles  # set it to None if need a national mosaic\n",
+    "            skip_existing=True,  # Set False if want to overwrite existing files\n",
+    "            list_tiles=list_tiles,  # set it to None if need a national mosaic\n",
     "        )"
    ]
   },
@@ -205,12 +218,12 @@
    "id": "fac9a336-4925-428d-9014-4523bc0e0ab5",
    "metadata": {},
    "source": [
-    "An equal way to do the same with a command line would be the following."
+    "Running the same analysis via the command line would be the following."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "cec95dea-afa6-42b3-8f20-7287303234a2",
    "metadata": {},
    "outputs": [
@@ -218,21 +231,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:25:05,696 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using parameters {'product': 'ga_ls_landcover_class_cyear_3', 'band': 'level4', 'time': '2024', 'freq': 'P1Y', 'version': '2-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'MODE', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': 'x46y47,x46y48,x46y49,x46y50', 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:25:05,697 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:25:05,697 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4] - Output path: /home/jovyan/dev/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif\n",
-      "2025-07-23 05:25:05,697 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Output already exists at /home/jovyan/dev/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif and skip_existing=True. Skipping generation.\n",
+      "2025-07-24 06:16:51,200 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using parameters {'product': 'ga_ls_landcover_class_cyear_3', 'band': 'level4', 'time': '2024', 'freq': 'P1Y', 'version': '2-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/Robbi/dea-notebooks/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'MODE', 'compression_algo': 'ZSTD', 'compression_level': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
+      "2025-07-24 06:16:51,200 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using input data product directory: dea-public-data/derivative\n",
+      "2025-07-24 06:16:51,200 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4] Output path: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif\n",
+      "2025-07-24 06:16:51,200 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Output already exists at /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif and skip_existing=True. Skipping generation.\n",
       "\u001b[0m"
      ]
     }
    ],
    "source": [
-    "# Quietly install the DEA tools package. -qq suppresses most output (warnings only).\n",
-    "!pip install -qq ../\n",
-    "\n",
-    "bands = ['level4']\n",
+    "bands = [\"level4\"]\n",
     "years = [2024]\n",
-    "list_tiles = ['x46y47','x46y48','x46y49','x46y50']\n",
+    "list_tiles = [\"x46y47\", \"x46y48\", \"x46y49\", \"x46y50\"]\n",
     "\n",
     "for band in bands:\n",
     "    for year in years:\n",
@@ -244,15 +254,15 @@
     "            --version 2-0-0 \\\n",
     "            --dataset_maturity final \\\n",
     "            --product_dir s3://dea-public-data/derivative/ \\\n",
-    "            --output_dir {os.getcwd()} \\\n",
+    "            --output_dir {output_dir} \\\n",
     "            --cog_blocksize 1024 \\\n",
     "            --overview_count 7 \\\n",
     "            --overview_resampling MODE \\\n",
     "            --compression_algo ZSTD \\\n",
-    "            --compression_lvl 9 \\\n",
+    "            --compression_level 9 \\\n",
     "            --aws_unsigned \\\n",
     "            --skip_existing \\\n",
-    "            --list_tiles {','.join(list_tiles)}"
+    "            --list_tiles {','.join(list_tiles)}\n"
    ]
   },
   {
@@ -261,33 +271,35 @@
    "metadata": {},
    "source": [
     "### Geomedian\n",
-    "DEA Geomedian products are split according to the sensor used for the input data (Landsat 5, Landsat 7, or Landsat 8 and 9). The following code cell is designed to generate mosaics for different sets of years for each product, in combination with a list of bands. Currently, RGB bands are mosaicked and will later be used to generate a true-colour VRT."
+    "DEA Geomedian products are split according to the sensor used for the input data (Landsat 5, Landsat 7, or Landsat 8 and 9). The following code cell is designed to generate mosaics for different sets of years for each product, in combination with a list of bands. Currently, RGB bands are mosaicked and will later be used to generate a true-colour VRT.\n",
+    "\n",
+    "For demonstration purposes, the example below will mosaic Landsat 8 and 9 Geomedians only. To mosaic Landsat 5 and Landsat 7, uncomment the relevant lines in `product_years` and re-run the cell below."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "8cc1453f-270f-442c-9980-81e08033540e",
    "metadata": {},
    "outputs": [],
    "source": [
     "# dictionary for defining the years of interest for each geomedian product\n",
     "products_years = {\n",
-    "    'ga_ls5t_gm_cyear_3': [1990],\n",
-    "    'ga_ls7e_gm_cyear_3': [2016],\n",
-    "    'ga_ls8cls9c_gm_cyear_3': [2024],\n",
+    "    # \"ga_ls5t_gm_cyear_3\": [1990],\n",
+    "    # \"ga_ls7e_gm_cyear_3\": [2016],\n",
+    "    \"ga_ls8cls9c_gm_cyear_3\": [2024],\n",
     "}\n",
     "\n",
     "# bands for RGB composites\n",
-    "bands = ['nbart_red','nbart_green','nbart_blue']\n",
+    "bands = [\"nbart_red\", \"nbart_green\", \"nbart_blue\"]\n",
     "\n",
     "# limit the mosaic to a few tiles\n",
-    "list_tiles = ['x46y47','x46y48','x46y49','x46y50']"
+    "list_tiles = [\"x46y47\", \"x46y48\", \"x46y49\", \"x46y50\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "5d26767f-d33c-41ad-bab9-b3080039ce44",
    "metadata": {
     "scrolled": true
@@ -297,14 +309,40 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:25:06,045 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red]: Using parameters {'product': 'ga_ls5t_gm_cyear_3', 'band': 'nbart_red', 'time': '1990', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:25:06,046 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:25:06,046 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red] - Output path: /home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_red.tif\n",
-      "2025-07-23 05:25:06,047 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red]: Output does not exist. Proceeding with mosaic generation.\n",
-      "2025-07-23 05:26:16,809 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:26:16,810 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red]: Writing data to temporary folder: /tmp/tmp7u9cocyu\n",
-      "2025-07-23 05:26:16,811 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red]: Building virtual raster (VRT)\n",
-      "2025-07-23 05:26:16,933 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red]: Converting VRT to COG mosaic\n"
+      "2025-07-24 06:16:51,597 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Using parameters {'product': 'ga_ls8cls9c_gm_cyear_3', 'band': 'nbart_red', 'time': '2024', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': PosixPath('/home/jovyan/Robbi/dea-notebooks/How_to_guides'), 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_level': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
+      "2025-07-24 06:16:51,598 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Using input data product directory: dea-public-data/derivative\n",
+      "2025-07-24 06:16:51,598 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] Output path: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red.tif\n",
+      "2025-07-24 06:16:51,599 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Output does not exist. Proceeding with mosaic generation.\n",
+      "2025-07-24 06:16:51,600 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Finding data to mosaic\n",
+      "2025-07-24 06:17:30,790 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Number of tiles to mosaic: 4\n",
+      "2025-07-24 06:17:30,791 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Writing data to temporary folder: /tmp/tmpmc0awjwy\n",
+      "2025-07-24 06:17:30,791 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Building virtual raster (VRT)\n",
+      "2025-07-24 06:17:30,906 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Converting VRT to COG mosaic\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0...10...20...30...40...50...60...70...80...90...100 - done.\n",
+      "Input file size is 3200, 12800\n",
+      "0...10...20...30...40...50...60...70...80...90...100 - done.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-07-24 06:17:35,539 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Writing data locally: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red.tif\n",
+      "2025-07-24 06:17:35,588 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Using parameters {'product': 'ga_ls8cls9c_gm_cyear_3', 'band': 'nbart_green', 'time': '2024', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': PosixPath('/home/jovyan/Robbi/dea-notebooks/How_to_guides'), 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_level': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
+      "2025-07-24 06:17:35,588 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Using input data product directory: dea-public-data/derivative\n",
+      "2025-07-24 06:17:35,589 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green] Output path: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_green.tif\n",
+      "2025-07-24 06:17:35,589 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Output does not exist. Proceeding with mosaic generation.\n",
+      "2025-07-24 06:17:35,590 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Finding data to mosaic\n",
+      "2025-07-24 06:18:15,186 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Number of tiles to mosaic: 4\n",
+      "2025-07-24 06:18:15,188 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Writing data to temporary folder: /tmp/tmpudznngeu\n",
+      "2025-07-24 06:18:15,188 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Building virtual raster (VRT)\n",
+      "2025-07-24 06:18:15,305 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Converting VRT to COG mosaic\n"
      ]
     },
     {
@@ -320,11 +358,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:26:21,586 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_red.tif\n",
-      "2025-07-23 05:26:21,639 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_green]: Using parameters {'product': 'ga_ls5t_gm_cyear_3', 'band': 'nbart_green', 'time': '1990', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:26:21,640 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_green]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:26:21,640 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_green] - Output path: /home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_green.tif\n",
-      "2025-07-23 05:26:21,640 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_green]: Output does not exist. Proceeding with mosaic generation.\n"
+      "2025-07-24 06:18:19,922 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Writing data locally: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_green.tif\n",
+      "2025-07-24 06:18:19,966 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Using parameters {'product': 'ga_ls8cls9c_gm_cyear_3', 'band': 'nbart_blue', 'time': '2024', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': PosixPath('/home/jovyan/Robbi/dea-notebooks/How_to_guides'), 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_level': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
+      "2025-07-24 06:18:19,967 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Using input data product directory: dea-public-data/derivative\n",
+      "2025-07-24 06:18:19,967 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue] Output path: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_blue.tif\n",
+      "2025-07-24 06:18:19,968 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Output does not exist. Proceeding with mosaic generation.\n",
+      "2025-07-24 06:18:19,968 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Finding data to mosaic\n"
      ]
     },
     {
@@ -338,10 +377,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:27:31,270 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_green]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:27:31,272 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_green]: Writing data to temporary folder: /tmp/tmp99vkiti6\n",
-      "2025-07-23 05:27:31,273 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_green]: Building virtual raster (VRT)\n",
-      "2025-07-23 05:27:31,394 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_green]: Converting VRT to COG mosaic\n"
+      "2025-07-24 06:18:59,231 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Number of tiles to mosaic: 4\n",
+      "2025-07-24 06:18:59,233 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Writing data to temporary folder: /tmp/tmp3zi9ze6a\n",
+      "2025-07-24 06:18:59,234 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Building virtual raster (VRT)\n",
+      "2025-07-24 06:18:59,352 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Converting VRT to COG mosaic\n"
      ]
     },
     {
@@ -357,305 +396,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:27:36,131 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_green]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_green.tif\n",
-      "2025-07-23 05:27:36,181 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_blue]: Using parameters {'product': 'ga_ls5t_gm_cyear_3', 'band': 'nbart_blue', 'time': '1990', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:27:36,181 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_blue]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:27:36,182 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_blue] - Output path: /home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_blue.tif\n",
-      "2025-07-23 05:27:36,183 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_blue]: Output does not exist. Proceeding with mosaic generation.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 - done.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:28:47,017 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_blue]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:28:47,019 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_blue]: Writing data to temporary folder: /tmp/tmp5se8tpuz\n",
-      "2025-07-23 05:28:47,020 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_blue]: Building virtual raster (VRT)\n",
-      "2025-07-23 05:28:47,143 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_blue]: Converting VRT to COG mosaic\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0...10...20...30...40...50...60...70...80...90...100 - done.\n",
-      "Input file size is 3200, 12800\n",
-      "0...10...20...30...40...50...60...70...80...90..."
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:28:51,823 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_blue]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_blue.tif\n",
-      "2025-07-23 05:28:51,865 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red]: Using parameters {'product': 'ga_ls7e_gm_cyear_3', 'band': 'nbart_red', 'time': '2016', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:28:51,866 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:28:51,867 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red] - Output path: /home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_red.tif\n",
-      "2025-07-23 05:28:51,867 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red]: Output does not exist. Proceeding with mosaic generation.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 - done.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:30:03,618 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:30:03,619 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red]: Writing data to temporary folder: /tmp/tmp_o_z0ihq\n",
-      "2025-07-23 05:30:03,620 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red]: Building virtual raster (VRT)\n",
-      "2025-07-23 05:30:03,744 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red]: Converting VRT to COG mosaic\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0...10...20...30...40...50...60...70...80...90...100 - done.\n",
-      "Input file size is 3200, 12800\n",
-      "0...10...20...30...40...50...60...70...80...90..."
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:30:08,446 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_red.tif\n",
-      "2025-07-23 05:30:08,495 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_green]: Using parameters {'product': 'ga_ls7e_gm_cyear_3', 'band': 'nbart_green', 'time': '2016', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:30:08,496 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_green]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:30:08,497 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_green] - Output path: /home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_green.tif\n",
-      "2025-07-23 05:30:08,497 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_green]: Output does not exist. Proceeding with mosaic generation.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 - done.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:31:21,118 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_green]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:31:21,120 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_green]: Writing data to temporary folder: /tmp/tmpa621alee\n",
-      "2025-07-23 05:31:21,121 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_green]: Building virtual raster (VRT)\n",
-      "2025-07-23 05:31:21,250 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_green]: Converting VRT to COG mosaic\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0...10...20...30...40...50...60...70...80...90...100 - done.\n",
-      "Input file size is 3200, 12800\n",
-      "0...10...20...30...40...50...60...70...80...90..."
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:31:25,895 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_green]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_green.tif\n",
-      "2025-07-23 05:31:25,941 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_blue]: Using parameters {'product': 'ga_ls7e_gm_cyear_3', 'band': 'nbart_blue', 'time': '2016', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:31:25,942 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_blue]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:31:25,942 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_blue] - Output path: /home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_blue.tif\n",
-      "2025-07-23 05:31:25,943 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_blue]: Output does not exist. Proceeding with mosaic generation.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 - done.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:32:38,237 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_blue]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:32:38,238 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_blue]: Writing data to temporary folder: /tmp/tmpnrf0mfqx\n",
-      "2025-07-23 05:32:38,239 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_blue]: Building virtual raster (VRT)\n",
-      "2025-07-23 05:32:38,363 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_blue]: Converting VRT to COG mosaic\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0...10...20...30...40...50...60...70...80...90...100 - done.\n",
-      "Input file size is 3200, 12800\n",
-      "0...10...20...30...40...50...60...70...80...90..."
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:32:43,031 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_blue]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_blue.tif\n",
-      "2025-07-23 05:32:43,073 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Using parameters {'product': 'ga_ls8cls9c_gm_cyear_3', 'band': 'nbart_red', 'time': '2024', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:32:43,074 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:32:43,075 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] - Output path: /home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red.tif\n",
-      "2025-07-23 05:32:43,075 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Output does not exist. Proceeding with mosaic generation.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 - done.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:33:18,871 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:33:18,872 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Writing data to temporary folder: /tmp/tmp7v3h9s3k\n",
-      "2025-07-23 05:33:18,873 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Building virtual raster (VRT)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0...10...20...30...40...50"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:33:19,477 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Converting VRT to COG mosaic\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "...60...70...80...90...100 - done.\n",
-      "Input file size is 3200, 12800\n",
-      "0...10...20...30...40...50...60...70...80...90..."
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:33:25,413 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red.tif\n",
-      "2025-07-23 05:33:25,464 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Using parameters {'product': 'ga_ls8cls9c_gm_cyear_3', 'band': 'nbart_green', 'time': '2024', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:33:25,465 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:33:25,465 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green] - Output path: /home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_green.tif\n",
-      "2025-07-23 05:33:25,466 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Output does not exist. Proceeding with mosaic generation.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 - done.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:34:02,133 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:34:02,134 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Writing data to temporary folder: /tmp/tmptck66h0c\n",
-      "2025-07-23 05:34:02,135 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Building virtual raster (VRT)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0...10...20...30...40...50"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:34:02,665 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Converting VRT to COG mosaic\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "...60...70...80...90...100 - done.\n",
-      "Input file size is 3200, 12800\n",
-      "0...10...20...30...40...50...60...70...80...90..."
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:34:09,308 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_green]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_green.tif\n",
-      "2025-07-23 05:34:09,350 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Using parameters {'product': 'ga_ls8cls9c_gm_cyear_3', 'band': 'nbart_blue', 'time': '2024', 'freq': 'P1Y', 'version': '4-0-0', 'dataset_maturity': 'final', 'product_dir': 's3://dea-public-data/derivative/', 'output_dir': '/home/jovyan/dev/How_to_guides', 'cog_blocksize': 1024, 'overview_count': 7, 'overview_resampling': 'BILINEAR', 'compression_algo': 'ZSTD', 'compression_lvl': 9, 'aws_unsigned': True, 'skip_existing': True, 'list_tiles': ['x46y47', 'x46y48', 'x46y49', 'x46y50'], 'log': <Logger dea_tools.mosaics.mosaic_COGs (INFO)>}\n",
-      "2025-07-23 05:34:09,351 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Using input data product directory: dea-public-data/derivative\n",
-      "2025-07-23 05:34:09,351 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue] - Output path: /home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_blue.tif\n",
-      "2025-07-23 05:34:09,352 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Output does not exist. Proceeding with mosaic generation.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "100 - done.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:34:47,182 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Number of tiles to mosaic: 4\n",
-      "2025-07-23 05:34:47,183 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Writing data to temporary folder: /tmp/tmpx5s_k6bk\n",
-      "2025-07-23 05:34:47,183 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Building virtual raster (VRT)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0...10...20...30...40...50"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:34:47,830 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Converting VRT to COG mosaic\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "...60...70...80...90...100 - done.\n",
-      "Input file size is 3200, 12800\n",
-      "0...10...20...30...40...50...60...70...80...90..."
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-23 05:34:53,351 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_blue.tif\n"
+      "2025-07-24 06:19:03,992 - dea_tools.mosaics.mosaic_COGs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_blue]: Writing data locally: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_blue.tif\n"
      ]
     },
     {
@@ -671,23 +412,23 @@
     "    for year in years:\n",
     "        for band in bands:\n",
     "            make_cog_mosaics(\n",
-    "            product=product,\n",
-    "            band=band,\n",
-    "            time=str(year),\n",
-    "            freq=\"P1Y\",\n",
-    "            version=\"4-0-0\",\n",
-    "            dataset_maturity=\"final\",\n",
-    "            product_dir=\"s3://dea-public-data/derivative/\", # DEA public AWS S3 bucket\n",
-    "            output_dir=os.getcwd(), # use the current directory\n",
-    "            cog_blocksize=1024,\n",
-    "            overview_count=7,\n",
-    "            overview_resampling=\"BILINEAR\", # for continuous data, bilinear is usually the best choice for the resampling algorithm\n",
-    "            compression_algo=\"ZSTD\",\n",
-    "            compression_lvl=9,\n",
-    "            aws_unsigned=True,\n",
-    "            skip_existing=True, # Set False if want to overwrite existing files\n",
-    "            list_tiles=list_tiles  # set it to None if need a national mosaic\n",
-    "        )"
+    "                product=product,\n",
+    "                band=band,\n",
+    "                time=str(year),\n",
+    "                freq=\"P1Y\",\n",
+    "                version=\"4-0-0\",\n",
+    "                dataset_maturity=\"final\",\n",
+    "                product_dir=\"s3://dea-public-data/derivative/\",  # DEA public AWS S3 bucket\n",
+    "                output_dir=output_dir,  # use the current directory\n",
+    "                cog_blocksize=1024,\n",
+    "                overview_count=7,\n",
+    "                overview_resampling=\"BILINEAR\",  # for continuous data, bilinear is usually the best choice for the resampling algorithm\n",
+    "                compression_algo=\"ZSTD\",\n",
+    "                compression_level=9,\n",
+    "                aws_unsigned=True,\n",
+    "                skip_existing=True,  # Set False if want to overwrite existing files\n",
+    "                list_tiles=list_tiles,  # set it to None if need a national mosaic\n",
+    "            )"
    ]
   },
   {
@@ -708,35 +449,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "cf5aac41-97da-45fa-ad3f-68f0d451818d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "PosixPath('/home/jovyan/dev/Supplementary_data/Colour_schemes')"
+       "PosixPath('/home/jovyan/Robbi/dea-notebooks/Supplementary_data/Colour_schemes')"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# inputs for the VRT function\n",
-    "bands = ['level4']\n",
+    "bands = [\"level4\"]\n",
     "years = [2024]\n",
     "\n",
     "# define path to folder with colour schemes\n",
-    "base_dir = Path.cwd()\n",
-    "colour_scheme_dir = base_dir.parent / \"Supplementary_data\" / \"Colour_schemes\"\n",
+    "colour_scheme_dir = output_dir.parent / \"Supplementary_data\" / \"Colour_schemes\"\n",
     "colour_scheme_dir"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "d502f793-d63f-4b6e-b115-a19dc49efe31",
    "metadata": {
     "scrolled": true
@@ -746,12 +486,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:34:53,411 - dea_tools.mosaics.colour_scheme_VRTs - INFO - Creating colour VRTs for Land Cover [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using parameters {'product': 'ga_ls_landcover_class_cyear_3', 'version': '2-0-0', 'band': 'level4', 'time': 2024, 'freq': 'P1Y', 'cog_dir': '/home/jovyan/dev/How_to_guides', 'output_dir': '/home/jovyan/dev/How_to_guides', 'col_scheme_dir': PosixPath('/home/jovyan/dev/Supplementary_data/Colour_schemes'), 'log': <Logger dea_tools.mosaics.colour_scheme_VRTs (INFO)>}\n",
-      "2025-07-23 05:34:53,412 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Identifying input data from local file system: /home/jovyan/dev/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif\n",
-      "2025-07-23 05:34:53,413 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4] - Output path: /home/jovyan/dev/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.vrt\n",
-      "2025-07-23 05:34:53,413 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Writing data to temporary folder: /tmp/tmpukz1vux_\n",
-      "2025-07-23 05:34:53,464 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Adding colour scheme to VRT\n",
-      "2025-07-23 05:34:53,477 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.vrt\n"
+      "2025-07-24 06:19:04,048 - dea_tools.mosaics.colour_scheme_VRTs - INFO - Creating colour VRTs for Land Cover [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Using parameters {'product': 'ga_ls_landcover_class_cyear_3', 'version': '2-0-0', 'band': 'level4', 'time': 2024, 'freq': 'P1Y', 'cog_dir': '/home/jovyan/Robbi/dea-notebooks/How_to_guides', 'output_dir': '/home/jovyan/Robbi/dea-notebooks/How_to_guides', 'col_scheme_dir': PosixPath('/home/jovyan/Robbi/dea-notebooks/Supplementary_data/Colour_schemes'), 'log': <Logger dea_tools.mosaics.colour_scheme_VRTs (INFO)>}\n",
+      "2025-07-24 06:19:04,049 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Identifying input data from local file system: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.tif\n",
+      "2025-07-24 06:19:04,050 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4] - Output path: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.vrt\n",
+      "2025-07-24 06:19:04,051 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Writing data to temporary folder: /tmp/tmprrt3pbw7\n",
+      "2025-07-24 06:19:04,102 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Adding colour scheme to VRT\n",
+      "2025-07-24 06:19:04,114 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls_landcover_class_cyear_3] [2-0-0] [2024] [level4]: Writing data locally: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls_landcover_class_cyear_3/2-0-0/continental_mosaics/2024--P1Y/ga_ls_landcover_class_cyear_3_mosaic_2024--P1Y_level4.vrt\n"
      ]
     },
     {
@@ -765,15 +505,15 @@
    "source": [
     "for band in bands:\n",
     "    for year in years:\n",
-    "        make_styling_vrt(    \n",
+    "        make_styling_vrt(\n",
     "            product=\"ga_ls_landcover_class_cyear_3\",\n",
     "            version=\"2-0-0\",\n",
     "            time=year,\n",
     "            freq=\"P1Y\",\n",
-    "            cog_dir=os.getcwd(), # we'll use the same directory used to generate the mosaics\n",
-    "            output_dir=os.getcwd(),\n",
-    "            band = band,\n",
-    "            col_scheme_dir = colour_scheme_dir,\n",
+    "            cog_dir=output_dir,  # we'll use the same directory used to generate the mosaics\n",
+    "            output_dir=output_dir,\n",
+    "            band=band,\n",
+    "            col_scheme_dir=colour_scheme_dir,\n",
     "        )"
    ]
   },
@@ -787,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "ff97d242-f496-4b7c-8724-3ed1d6474886",
    "metadata": {
     "scrolled": true
@@ -797,47 +537,29 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-07-23 05:34:53,483 - dea_tools.mosaics.colour_scheme_VRTs - INFO - Creating colour VRTs for Geomedian [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red] [nbart_green] [nbart_blue]: Using parameters {'product': 'ga_ls5t_gm_cyear_3', 'version': '4-0-0', 'time': 1990, 'freq': 'P1Y', 'cog_dir': '/home/jovyan/dev/How_to_guides', 'output_dir': '/home/jovyan/dev/How_to_guides', 'r_channel_band': 'nbart_red', 'g_channel_band': 'nbart_green', 'b_channel_band': 'nbart_blue', 'log': <Logger dea_tools.mosaics.colour_scheme_VRTs (INFO)>}\n",
-      "2025-07-23 05:34:53,484 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red] [nbart_green] [nbart_blue]: Identifying input data from local file system:\n",
-      "-/home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_red.tif\n",
-      "-/home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_green.tif\n",
-      "-/home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_blue.tif\n",
-      "2025-07-23 05:34:53,484 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red] [nbart_green] [nbart_blue] - Output path: /home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_red-nbart_green-nbart_blue.vrt\n",
-      "2025-07-23 05:34:53,485 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red] [nbart_green] [nbart_blue]: Writing data to temporary folder: /tmp/tmpoc_ahpj_\n",
-      "2025-07-23 05:34:53,540 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls5t_gm_cyear_3] [4-0-0] [1990] [nbart_red] [nbart_green] [nbart_blue]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls5t_gm_cyear_3/4-0-0/continental_mosaics/1990--P1Y/ga_ls5t_gm_cyear_3_mosaic_1990--P1Y_nbart_red-nbart_green-nbart_blue.vrt\n",
-      "2025-07-23 05:34:53,541 - dea_tools.mosaics.colour_scheme_VRTs - INFO - Creating colour VRTs for Geomedian [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red] [nbart_green] [nbart_blue]: Using parameters {'product': 'ga_ls7e_gm_cyear_3', 'version': '4-0-0', 'time': 2016, 'freq': 'P1Y', 'cog_dir': '/home/jovyan/dev/How_to_guides', 'output_dir': '/home/jovyan/dev/How_to_guides', 'r_channel_band': 'nbart_red', 'g_channel_band': 'nbart_green', 'b_channel_band': 'nbart_blue', 'log': <Logger dea_tools.mosaics.colour_scheme_VRTs (INFO)>}\n",
-      "2025-07-23 05:34:53,542 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red] [nbart_green] [nbart_blue]: Identifying input data from local file system:\n",
-      "-/home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_red.tif\n",
-      "-/home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_green.tif\n",
-      "-/home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_blue.tif\n",
-      "2025-07-23 05:34:53,542 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red] [nbart_green] [nbart_blue] - Output path: /home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_red-nbart_green-nbart_blue.vrt\n",
-      "2025-07-23 05:34:53,542 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red] [nbart_green] [nbart_blue]: Writing data to temporary folder: /tmp/tmprh3_bjpz\n",
-      "2025-07-23 05:34:53,597 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls7e_gm_cyear_3] [4-0-0] [2016] [nbart_red] [nbart_green] [nbart_blue]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls7e_gm_cyear_3/4-0-0/continental_mosaics/2016--P1Y/ga_ls7e_gm_cyear_3_mosaic_2016--P1Y_nbart_red-nbart_green-nbart_blue.vrt\n",
-      "2025-07-23 05:34:53,598 - dea_tools.mosaics.colour_scheme_VRTs - INFO - Creating colour VRTs for Geomedian [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue]: Using parameters {'product': 'ga_ls8cls9c_gm_cyear_3', 'version': '4-0-0', 'time': 2024, 'freq': 'P1Y', 'cog_dir': '/home/jovyan/dev/How_to_guides', 'output_dir': '/home/jovyan/dev/How_to_guides', 'r_channel_band': 'nbart_red', 'g_channel_band': 'nbart_green', 'b_channel_band': 'nbart_blue', 'log': <Logger dea_tools.mosaics.colour_scheme_VRTs (INFO)>}\n",
-      "2025-07-23 05:34:53,599 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue]: Identifying input data from local file system:\n",
-      "-/home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red.tif\n",
-      "-/home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_green.tif\n",
-      "-/home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_blue.tif\n",
-      "2025-07-23 05:34:53,599 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue] - Output path: /home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red-nbart_green-nbart_blue.vrt\n",
-      "2025-07-23 05:34:53,600 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue]: Writing data to temporary folder: /tmp/tmplw54jpcw\n",
-      "2025-07-23 05:34:53,655 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue]: Writing data locally: /home/jovyan/dev/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red-nbart_green-nbart_blue.vrt\n"
+      "2025-07-24 06:19:04,121 - dea_tools.mosaics.colour_scheme_VRTs - INFO - Creating colour VRTs for Geomedian [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue]: Using parameters {'product': 'ga_ls8cls9c_gm_cyear_3', 'version': '4-0-0', 'time': 2024, 'freq': 'P1Y', 'cog_dir': '/home/jovyan/Robbi/dea-notebooks/How_to_guides', 'output_dir': '/home/jovyan/Robbi/dea-notebooks/How_to_guides', 'r_channel_band': 'nbart_red', 'g_channel_band': 'nbart_green', 'b_channel_band': 'nbart_blue', 'vrt_name': None, 'log': <Logger dea_tools.mosaics.colour_scheme_VRTs (INFO)>}\n",
+      "2025-07-24 06:19:04,122 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue]: Identifying input data from local file system:\n",
+      "-/home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red.tif\n",
+      "-/home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_green.tif\n",
+      "-/home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_blue.tif\n",
+      "2025-07-24 06:19:04,122 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue] - Output path: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red-nbart_green-nbart_blue.vrt\n",
+      "2025-07-24 06:19:04,124 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue]: Writing data to temporary folder: /tmp/tmpnnuul7lu\n",
+      "2025-07-24 06:19:04,178 - dea_tools.mosaics.colour_scheme_VRTs - INFO - [ga_ls8cls9c_gm_cyear_3] [4-0-0] [2024] [nbart_red] [nbart_green] [nbart_blue]: Writing data locally: /home/jovyan/Robbi/dea-notebooks/How_to_guides/ga_ls8cls9c_gm_cyear_3/4-0-0/continental_mosaics/2024--P1Y/ga_ls8cls9c_gm_cyear_3_mosaic_2024--P1Y_nbart_red-nbart_green-nbart_blue.vrt\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0...10...20...30...40...50...60...70...80...90...100 - done.\n",
-      "0...10...20...30...40...50...60...70...80...90...100 - done.\n",
       "0...10...20...30...40...50...60...70...80...90...100 - done.\n"
      ]
     }
    ],
    "source": [
     "products_years = {\n",
-    "    'ga_ls5t_gm_cyear_3': [1990],\n",
-    "    'ga_ls7e_gm_cyear_3': [2016],\n",
-    "    'ga_ls8cls9c_gm_cyear_3': [2024]\n",
+    "    # 'ga_ls5t_gm_cyear_3': [1990],\n",
+    "    # 'ga_ls7e_gm_cyear_3': [2016],\n",
+    "    \"ga_ls8cls9c_gm_cyear_3\": [2024]\n",
     "}\n",
     "\n",
     "r_channel = \"nbart_red\"\n",
@@ -847,16 +569,16 @@
     "for product, years in products_years.items():\n",
     "    for year in years:\n",
     "\n",
-    "        make_styling_vrt(    \n",
+    "        make_styling_vrt(\n",
     "            product=product,\n",
     "            version=\"4-0-0\",\n",
     "            time=year,\n",
     "            freq=\"P1Y\",\n",
-    "            cog_dir=os.getcwd(), # we'll use the same directory used to generate the mosaics\n",
-    "            output_dir=os.getcwd(),\n",
-    "            r_channel_band = r_channel,\n",
-    "            g_channel_band = g_channel,\n",
-    "            b_channel_band = b_channel,\n",
+    "            cog_dir=output_dir,  # we'll use the same directory used to generate the mosaics\n",
+    "            output_dir=output_dir,\n",
+    "            r_channel_band=r_channel,\n",
+    "            g_channel_band=g_channel,\n",
+    "            b_channel_band=b_channel,\n",
     "        )"
    ]
   },
@@ -871,12 +593,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "ca95f466-59e8-411c-8a5b-8299566de234",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!rm -rf ga_ls_landcover_class_cyear_3 ga_ls5t_gm_cyear_3 ga_ls7e_gm_cyear_3 ga_ls8cls9c_gm_cyear_3"
+    "!rm -rf {output_dir}/ga_ls_landcover_class_cyear_3 {output_dir}/ga_ls5t_gm_cyear_3 {output_dir}/ga_ls7e_gm_cyear_3 {output_dir}/ga_ls8cls9c_gm_cyear_3"
    ]
   },
   {
@@ -932,6 +654,13 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.10.15"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/Tests/dea_tools/test_mosaics.py
+++ b/Tests/dea_tools/test_mosaics.py
@@ -101,7 +101,7 @@ def test_geomedian_rgb_mosaic_and_vrt(tmp_path):
             overview_count=7,
             overview_resampling="BILINEAR",
             compression_algo="ZSTD",
-           compression_level=9,
+            compression_level=9,
             aws_unsigned=True,
             skip_existing=False,
             list_tiles=list_tiles

--- a/Tests/dea_tools/test_mosaics.py
+++ b/Tests/dea_tools/test_mosaics.py
@@ -22,7 +22,7 @@ def test_mosaic_vrt_creation_cat(tmp_path):
         "overview_count": 7,
         "overview_resampling": "MODE",
         "compression_algo": "ZSTD",
-        "compression_lvl": 9,
+        "compression_level": 9,
         "aws_unsigned": True,
         "skip_existing": False,
         "list_tiles": ["x46y47", "x46y48"],
@@ -101,7 +101,7 @@ def test_geomedian_rgb_mosaic_and_vrt(tmp_path):
             overview_count=7,
             overview_resampling="BILINEAR",
             compression_algo="ZSTD",
-            compression_lvl=9,
+           compression_level=9,
             aws_unsigned=True,
             skip_existing=False,
             list_tiles=list_tiles

--- a/Tools/dea_tools/mosaics/README.md
+++ b/Tools/dea_tools/mosaics/README.md
@@ -8,12 +8,13 @@ This submodule provides Python tools for generating Cloud Optimised GeoTIFF (COG
 ---
 
 # Usage examples
+
 ## Generate COG mosaics
 
-Continental mosaic of 2024 DEA Land Cover 2.0.
+To generate a continental mosaic of 2024 DEA Land Cover 2.0, first [install DEA Tools](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop/Tools#installation) and then run the command below:
 
 ```
-python mosaic_COGs.py \
+make_cog_mosaic \
   --product ga_ls_landcover_class_cyear_3 \
   --band level4 \
   --time 2024 \
@@ -26,15 +27,15 @@ python mosaic_COGs.py \
   --overview_count 7 \
   --overview_resampling MODE \
   --compression_algo ZSTD \
-  --compression_lvl 9 \
+  --compression_level 9 \
   --aws_unsigned \
   --skip_existing
 ```
 
-Mosaic only a few tiles.
+Mosaic only a few tiles:
 
 ```
-python mosaic_COGs.py \
+make_cog_mosaic \
   --product ga_ls_landcover_class_cyear_3 \
   --band level4 \
   --time 2024 \
@@ -47,13 +48,13 @@ python mosaic_COGs.py \
   --overview_count 7 \
   --overview_resampling MODE \
   --compression_algo ZSTD \
-  --compression_lvl 9 \
+  --compression_level 9 \
   --aws_unsigned \
   --skip_existing \
   --list_tiles x25y41,x26y42,x27y43
 ```
 
-If DEA Tools package is installed, it is possible to run the function as CLI and replace `python mosaic_COGs.py` in the command above with only `make_cog_mosaic`.
+If DEA Tools package is not installed, it is possible to run the analysis directly via the Python module by replacing `make_cog_mosaic` in the command above with `python mosaic_COGs.py`.
 
 ## Generate colour VRTs
 
@@ -61,7 +62,7 @@ Apply colour scheme to single-band categorical data.
 It is recommended to use the same path where the mosaics are as output directory for the VRTs. Because the VRTs look for the mosaic files in the folder where the VRTs are stored.
 
 ```
-python colour_scheme_VRTs.py \
+make_styling_vrt \
   --product ga_ls_landcover_class_cyear_3 \
   --time 2024 \
   --freq P1Y \
@@ -72,10 +73,10 @@ python colour_scheme_VRTs.py \
   --band level4
 ```
 
-For three-colours composites (in this example, RGB true-colour)
+For three-colours composites (in this example, RGB true-colour):
 
 ```
-python colour_scheme_VRTs.py \
+make_styling_vrt \
   --product ga_ls8cls9c_gm_cyear_3 \
   --time 2024 \
   --freq P1Y \
@@ -87,4 +88,4 @@ python colour_scheme_VRTs.py \
   --b_channel_band nbart_blue
 ```
 
-If DEA Tools package is installed, it is possible to run the function as CLI and replace `python colour_scheme_VRTs.py` in the command above with only `make_styling_vrt`.
+If DEA Tools package is not installed, it is possible to run the analysis directly via the Python module by replacing `make_styling_vrt` in the command above with `python colour_scheme_VRTs.py`.

--- a/Tools/dea_tools/mosaics/colour_scheme_VRTs.py
+++ b/Tools/dea_tools/mosaics/colour_scheme_VRTs.py
@@ -1,12 +1,12 @@
 # colour_scheme_VRTs.py
 """
-Tools for applying colour schemes and generating GDAL VRTs for mosaics of 
-Digital Earth Australia (DEA) products, including single-band categorical 
+Tools for applying colour schemes and generating GDAL VRTs for mosaics of
+Digital Earth Australia (DEA) products, including single-band categorical
 visualisations and three-band composites (e.g., RGB for true or false colour imagery).
 
-In case of categorical data, colour schemes are loaded from JSON files 
-containing RGBA values and labels. The module supports DEA’s mosaic output 
-structure and naming conventions and can operate on mosaic files stored 
+In case of categorical data, colour schemes are loaded from JSON files
+containing RGBA values and labels. The module supports DEA’s mosaic output
+structure and naming conventions and can operate on mosaic files stored
 locally or in the cloud (AWS's S3).
 
 License: The code in this module is licensed under the Apache License,
@@ -26,31 +26,24 @@ GitHub (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 Last modified: July 2025
 """
 
-
-import os
 import json
-import subprocess
-import click
 import logging
-import requests
-import tempfile
+import os
 import shutil
-from urllib.parse import urlparse
-import xml.etree.ElementTree as ET
+import subprocess
+import tempfile
 import xml.dom.minidom
+import xml.etree.ElementTree as ET
+
+import click
+import requests
+
+from dea_tools.mosaics.mosaic_COGs import _is_s3
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
-
-
-def _is_s3(path):
-    """
-    Determine whether output location is on S3.
-    """
-    uu = urlparse(path)
-    return uu.scheme == "s3"
 
 
 def _file_exists_s3(url):
@@ -72,8 +65,7 @@ def _clean_label_dict(label):
     label = label.replace(">", "more than")
     label = label.replace("<", "less than")
     label = label.replace(":", "")
-    label = label.replace("\n", "")
-    return label
+    return label.replace("\n", "")
 
 
 def _get_lc_colour_scheme(band, json_dir=None):
@@ -85,9 +77,7 @@ def _get_lc_colour_scheme(band, json_dir=None):
     if json_dir:
         json_path = os.path.join(json_dir, json_filename)
     else:
-        script_dir = os.path.dirname(
-            os.path.abspath(__file__)
-        )  # directory of the script
+        script_dir = os.path.dirname(os.path.abspath(__file__))  # directory of the script
         json_path = os.path.join(script_dir, json_filename)
 
     with open(json_path, "r") as f:
@@ -118,16 +108,19 @@ def _create_vrt_landcover(
     Builds a VRT from a land cover mosaic, embeds colour palette,
     and saves output locally or to S3.
 
-    The COG path in the VRT is realtive to the VRT location
+    The COG path in the VRT will relative to the VRT location for
+    local COG directories, and absolute S3 paths for COGs on S3.
     """
 
     # first log
     log = logging.getLogger(__name__)
     input_params = locals()
     run_id = f"[{product}] [{version}] [{time}] [{band}]"
-    log.info(
-        f"Creating colour VRTs for Land Cover {run_id}: Using parameters {input_params}"
-    )
+    log.info(f"Creating colour VRTs for Land Cover {run_id}: Using parameters {input_params}")
+
+    # Determine if COG or output directories are located on S3
+    is_cog_dir_s3 = _is_s3(cog_dir)
+    is_out_dir_s3 = _is_s3(output_dir)
 
     # get rgb of land cover classification values as a dictionary
     rgb_values = _get_lc_colour_scheme(band, col_scheme_dir)
@@ -135,8 +128,7 @@ def _create_vrt_landcover(
     # get input continental COG path
     cog_dir = cog_dir.rstrip("/")
 
-    if _is_s3(cog_dir):
-        is_s3 = True
+    if is_cog_dir_s3:
         cog_dir = cog_dir.replace("s3://", "")
         cog_dir = cog_dir.rstrip("/")
         if "dea-public-data-dev/" in cog_dir:
@@ -145,9 +137,7 @@ def _create_vrt_landcover(
                 "/vsicurl/https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/",
             )
         elif "dea-public-data/" in cog_dir:
-            cog_dir = cog_dir.replace(
-                "dea-public-data/", "/vsicurl/https://data.dea.ga.gov.au/"
-            )
+            cog_dir = cog_dir.replace("dea-public-data/", "/vsicurl/https://data.dea.ga.gov.au/")
 
         cog_dir = f"{cog_dir}/{product}/{version}/continental_mosaics/{time}--{freq}"
         input_path = f"{cog_dir}/{product}_mosaic_{time}--{freq}_{band}.tif"
@@ -157,17 +147,10 @@ def _create_vrt_landcover(
             log.info(f"{run_id}: No COG input found")
             return
     else:
-        is_s3 = False
-        cog_dir = os.path.join(
-            cog_dir, product, version, "continental_mosaics", f"{time}--{freq}"
-        )
-        input_path = os.path.join(
-            cog_dir, f"{product}_mosaic_{time}--{freq}_{band}.tif"
-        )
+        cog_dir = os.path.join(cog_dir, product, version, "continental_mosaics", f"{time}--{freq}")
+        input_path = os.path.join(cog_dir, f"{product}_mosaic_{time}--{freq}_{band}.tif")
         if os.path.exists(input_path):
-            log.info(
-                f"{run_id}: Identifying input data from local file system: {input_path}"
-            )
+            log.info(f"{run_id}: Identifying input data from local file system: {input_path}")
         else:
             log.info(f"{run_id}: No COG input found")
             return
@@ -175,19 +158,13 @@ def _create_vrt_landcover(
     # define ouptut VRT name following the standardised naming:
     # /derivative/<product_id>/<version>/continental_mosaics/<time>/<product_id>_mosaic_<time>_<VRT name>.vrt
     output_dir = output_dir.rstrip("/")
-    if _is_s3(output_dir):
-        output_dir = (
-            f"{output_dir}/{product}/{version}/continental_mosaics/{time}--{freq}"
-        )
+    if is_out_dir_s3:
+        output_dir = f"{output_dir}/{product}/{version}/continental_mosaics/{time}--{freq}"
         output_vrt = f"{output_dir}/{product}_mosaic_{time}--{freq}_{band}.vrt"
         log.info(f"{run_id} - Output path: {output_vrt}")
     else:
-        output_dir = os.path.join(
-            output_dir, product, version, "continental_mosaics", f"{time}--{freq}"
-        )
-        output_vrt = os.path.join(
-            output_dir, f"{product}_mosaic_{time}--{freq}_{band}.vrt"
-        )
+        output_dir = os.path.join(output_dir, product, version, "continental_mosaics", f"{time}--{freq}")
+        output_vrt = os.path.join(output_dir, f"{product}_mosaic_{time}--{freq}_{band}.vrt")
         log.info(f"{run_id} - Output path: {output_vrt}")
 
     # Create a temporary directory to house files before syncing
@@ -195,9 +172,7 @@ def _create_vrt_landcover(
         log.info(f"{run_id}: Writing data to temporary folder: {temp_dir}")
 
         # Output paths for intermediate files
-        temp_output_vrt = os.path.join(
-            temp_dir, f"{product}_mosaic_{time}--{freq}_{band}.vrt"
-        )
+        temp_output_vrt = os.path.join(temp_dir, f"{product}_mosaic_{time}--{freq}_{band}.vrt")
 
         # build base VRT
         try:
@@ -212,12 +187,14 @@ def _create_vrt_landcover(
         tree = ET.parse(temp_output_vrt)
         root = tree.getroot()
 
-        # modify all <SourceFilename> elements to keep only the filename (relative path)
-        for src in root.findall(".//SourceFilename"):
-            full_path = src.text
-            filename = os.path.basename(full_path)
-            src.text = filename
-            src.set("relativeToVRT", "1")
+        # If COGs are not on S3, modify all <SourceFilename> elements to
+        # keep only the filename (relative path)
+        if not is_cog_dir_s3:
+            for src in root.findall(".//SourceFilename"):
+                full_path = src.text
+                filename = os.path.basename(full_path)
+                src.text = filename
+                src.set("relativeToVRT", "1")
 
         band_node = root.find("VRTRasterBand")
 
@@ -260,7 +237,7 @@ def _create_vrt_landcover(
         with open(temp_output_vrt, "w", encoding="utf-8") as f:
             f.write(cleaned_xml)
 
-        if is_s3:  # Copy output to S3
+        if is_out_dir_s3:  # Copy output to S3
             log.info(f"{run_id}: Writing VRT to S3: {output_vrt}")
 
             subprocess.run(
@@ -295,6 +272,7 @@ def _create_vrt_3bands_comp(
     r_channel_band,
     g_channel_band,
     b_channel_band,
+    vrt_name=None,
 ):
     """
     Create a three-band composite VRT from separate band COGs.
@@ -302,21 +280,21 @@ def _create_vrt_3bands_comp(
     Builds a multi-band VRT using specified red, green, and blue channels,
     and writes output locally or to S3.
 
-    The COGs paths in the VRT is realtive to the VRT location
+    The COG path in the VRT will relative to the VRT location for
+    local COG directories, and absolute S3 paths for COGs on S3.
     """
 
     # first log
     log = logging.getLogger(__name__)
     input_params = locals()
     run_id = f"[{product}] [{version}] [{time}] [{r_channel_band}] [{g_channel_band}] [{b_channel_band}]"
-    log.info(
-        f"Creating colour VRTs for Geomedian {run_id}: Using parameters {input_params}"
-    )
+    log.info(f"Creating colour VRTs for Geomedian {run_id}: Using parameters {input_params}")
 
-    # get input continental COG path
-    cog_dir = cog_dir.rstrip("/")
+    # Determine if COG or output directories are located on S3
+    is_cog_dir_s3 = _is_s3(cog_dir)
+    is_out_dir_s3 = _is_s3(output_dir)
 
-    if _is_s3(cog_dir):
+    if is_cog_dir_s3:
         cog_dir = cog_dir.replace("s3://", "")
         cog_dir = cog_dir.rstrip("/")
         if "dea-public-data-dev/" in cog_dir:
@@ -325,21 +303,18 @@ def _create_vrt_3bands_comp(
                 "/vsicurl/https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/",
             )
         elif "dea-public-data/" in cog_dir:
-            cog_dir = cog_dir.replace(
-                "dea-public-data/", "/vsicurl/https://data.dea.ga.gov.au/"
-            )
+            cog_dir = cog_dir.replace("dea-public-data/", "/vsicurl/https://data.dea.ga.gov.au/")
 
         cog_dir = f"{cog_dir}/{product}/{version}/continental_mosaics/{time}--{freq}"
         input_path_r = f"{cog_dir}/{product}_mosaic_{time}--{freq}_{r_channel_band}.tif"
         input_path_g = f"{cog_dir}/{product}_mosaic_{time}--{freq}_{g_channel_band}.tif"
         input_path_b = f"{cog_dir}/{product}_mosaic_{time}--{freq}_{b_channel_band}.tif"
-        if all(
-            [
-                _file_exists_s3(input_path_r),
-                _file_exists_s3(input_path_g),
-                _file_exists_s3(input_path_b),
-            ]
-        ):
+
+        if all([
+            _file_exists_s3(input_path_r),
+            _file_exists_s3(input_path_g),
+            _file_exists_s3(input_path_b),
+        ]):
             log.info(
                 f"{run_id}: Identifying input data from S3 bucket:\n-{input_path_r}\n-{input_path_g}\n-{input_path_b}"
             )
@@ -347,25 +322,15 @@ def _create_vrt_3bands_comp(
             log.info(f"{run_id}: One or more input COGs not found")
             return
     else:
-        cog_dir = os.path.join(
-            cog_dir, product, version, "continental_mosaics", f"{time}--{freq}"
-        )
-        input_path_r = os.path.join(
-            cog_dir, f"{product}_mosaic_{time}--{freq}_{r_channel_band}.tif"
-        )
-        input_path_g = os.path.join(
-            cog_dir, f"{product}_mosaic_{time}--{freq}_{g_channel_band}.tif"
-        )
-        input_path_b = os.path.join(
-            cog_dir, f"{product}_mosaic_{time}--{freq}_{b_channel_band}.tif"
-        )
-        if all(
-            [
-                os.path.exists(input_path_r),
-                os.path.exists(input_path_g),
-                os.path.exists(input_path_b),
-            ]
-        ):
+        cog_dir = os.path.join(cog_dir, product, version, "continental_mosaics", f"{time}--{freq}")
+        input_path_r = os.path.join(cog_dir, f"{product}_mosaic_{time}--{freq}_{r_channel_band}.tif")
+        input_path_g = os.path.join(cog_dir, f"{product}_mosaic_{time}--{freq}_{g_channel_band}.tif")
+        input_path_b = os.path.join(cog_dir, f"{product}_mosaic_{time}--{freq}_{b_channel_band}.tif")
+        if all([
+            os.path.exists(input_path_r),
+            os.path.exists(input_path_g),
+            os.path.exists(input_path_b),
+        ]):
             log.info(
                 f"{run_id}: Identifying input data from local file system:\n-{input_path_r}\n-{input_path_g}\n-{input_path_b}"
             )
@@ -373,25 +338,17 @@ def _create_vrt_3bands_comp(
             log.info(f"{run_id}: One or more input COGs not found in local filesystem")
             return
 
-    # define ouptut VRT name following the standardised naming:
+    # define output VRT name following the standardised naming:
     # /derivative/<product_id>/<version>/continental_mosaics/<time>/<product_id>_mosaic_<time>_<VRT name>.vrt
     output_dir = output_dir.rstrip("/")
-    if _is_s3(output_dir):
-        out_is_s3 = True
-        output_dir = (
-            f"{output_dir}/{product}/{version}/continental_mosaics/{time}--{freq}"
-        )
-        output_vrt = f"{output_dir}/{product}_mosaic_{time}--{freq}_{r_channel_band}-{g_channel_band}-{b_channel_band}.vrt"
+    vrt_name = vrt_name if vrt_name else f"{r_channel_band}-{g_channel_band}-{b_channel_band}"
+    if is_out_dir_s3:
+        output_dir = f"{output_dir}/{product}/{version}/continental_mosaics/{time}--{freq}"
+        output_vrt = f"{output_dir}/{product}_mosaic_{time}--{freq}_{vrt_name}.vrt"
         log.info(f"{run_id} - Output path: {output_vrt}")
     else:
-        out_is_s3 = False
-        output_dir = os.path.join(
-            output_dir, product, version, "continental_mosaics", f"{time}--{freq}"
-        )
-        output_vrt = os.path.join(
-            output_dir,
-            f"{product}_mosaic_{time}--{freq}_{r_channel_band}-{g_channel_band}-{b_channel_band}.vrt",
-        )
+        output_dir = os.path.join(output_dir, product, version, "continental_mosaics", f"{time}--{freq}")
+        output_vrt = os.path.join(output_dir, f"{product}_mosaic_{time}--{freq}_{vrt_name}.vrt")
         log.info(f"{run_id} - Output path: {output_vrt}")
 
     # Create a temporary directory to house files before syncing
@@ -426,12 +383,14 @@ def _create_vrt_3bands_comp(
         tree = ET.parse(temp_output_vrt)
         root = tree.getroot()
 
-        # modify all <SourceFilename> elements to keep only the filename (relative path)
-        for src in root.findall(".//SourceFilename"):
-            full_path = src.text
-            filename = os.path.basename(full_path)
-            src.text = filename
-            src.set("relativeToVRT", "1")
+        # If COGs are not on S3, modify all <SourceFilename> elements to
+        # keep only the filename (relative path)
+        if not is_cog_dir_s3:
+            for src in root.findall(".//SourceFilename"):
+                full_path = src.text
+                filename = os.path.basename(full_path)
+                src.text = filename
+                src.set("relativeToVRT", "1")
 
         # make xml more readable
         xml_str = ET.tostring(root, encoding="utf-8")
@@ -448,7 +407,7 @@ def _create_vrt_3bands_comp(
         with open(temp_output_vrt, "w", encoding="utf-8") as f:
             f.write(cleaned_xml)
 
-        if out_is_s3:  # Copy output to S3
+        if is_out_dir_s3:  # Copy output to S3
             log.info(f"{run_id}: Writing VRT to S3: {output_vrt}")
 
             subprocess.run(
@@ -485,6 +444,7 @@ def make_styling_vrt(
     r_channel_band=None,
     g_channel_band=None,
     b_channel_band=None,
+    vrt_name=None,
 ):
     """
     Create a virtual raster (VRT) for DEA products.
@@ -496,38 +456,52 @@ def make_styling_vrt(
     Parameters:
     -----------
     product : str
-        DEA product name (e.g., 'ga_ls_landcover_class_cyear_3').
+        DEA product name (e.g. 'ga_ls_landcover_class_cyear_3').
     version : str
-        Product version (e.g., '2-0-0').
+        Product version (e.g. '2-0-0').
     time : int or str
-        The target time of the mosaic, year if annual summaries (e.g., 2023),
+        The target time of the mosaic, year if annual summaries (e.g. 2023),
         year-month for seasonal (e.g., water observations nov_mar --> '2024-11')
     freq : str
-        The frequency of the summary product (e.g.,P1Y).
+        The frequency of the summary product (e.g. P1Y).
     cog_dir : str
-        path to directory with continental COG. E.g. 's3://dea-public-data/derivative/'
+        Path to directory with continental COG. E.g. 's3://dea-public-data/derivative/'
     output_dir : str
-        local directory or s3 directory where to save ouptut.
-    band : str
-        Band name (e.g., 'level4').
+        Local directory or s3 directory where to save ouptut.
+    band : str, optional
+        Band name (e.g. 'level4').
         Use None (default) if need a three-bands composite
-    col_scheme_dir : str
-        path to folder containing json files with colour schemes.
+    col_scheme_dir : str, optional
+        Path to folder containing json files with colour schemes.
         Use None (default) for using the same directory of this python script.
-    r_channel_band : str
+    r_channel_band : str, optional
         Band to use in the RED channel for a three-bands composite.
         Use None (default) if need a single-band categorical view
     g_channel_band : str
         Band to use in the GREEN channel for a three-bands composite.
         Use None (default) if need a single-band categorical view
-    b_channel_band : str
+    b_channel_band : str, optional
         Band to use in the BLUE channel for a three-bands composite.
         Use None (default) if need a single-band categorical view
+    vrt_name : str, optional
+        An optional name used for the output VRT. If not provided,
+        will default to {r_channel_band}-{g_channel_band}-{b_channel_band}.,
     """
+    # Set product and output paths to plain strings
+    # TODO: refactor code to use pathlib throughout
+    cog_dir = str(cog_dir)
+    output_dir = str(output_dir)
 
     if product == "ga_ls_landcover_class_cyear_3" and band:
         _create_vrt_landcover(
-            product, version, band, time, freq, cog_dir, output_dir, col_scheme_dir
+            product,
+            version,
+            band,
+            time,
+            freq,
+            cog_dir,
+            output_dir,
+            col_scheme_dir,
         )
 
     elif all([r_channel_band, g_channel_band, b_channel_band]):
@@ -541,6 +515,7 @@ def make_styling_vrt(
             r_channel_band,
             g_channel_band,
             b_channel_band,
+            vrt_name,
         )
 
     else:
@@ -620,6 +595,13 @@ def make_styling_vrt(
     required=False,
     help="Band to use in the BLUE channel for RGB composite e.g., 'nbart_blue')",
 )
+@click.option(
+    "--vrt_name",
+    type=str,
+    required=False,
+    help="An optional name used for the output three-band VRT. "
+    "If not provided, will default to {r_channel_band}-{g_channel_band}-{b_channel_band}.",
+)
 def make_styling_vrt_cli(
     product,
     version,
@@ -632,6 +614,7 @@ def make_styling_vrt_cli(
     r_channel_band=None,
     g_channel_band=None,
     b_channel_band=None,
+    vrt_name=None,
 ):
     """
     CLI entry point for creating VRT files with color schemes or composites.
@@ -639,9 +622,18 @@ def make_styling_vrt_cli(
     """
 
     make_styling_vrt(
-        product,version,time,freq,cog_dir,output_dir,
-        band,col_scheme_dir,r_channel_band,
-        g_channel_band,b_channel_band,
+        product,
+        version,
+        time,
+        freq,
+        cog_dir,
+        output_dir,
+        band,
+        col_scheme_dir,
+        r_channel_band,
+        g_channel_band,
+        b_channel_band,
+        vrt_name,
     )
 
 

--- a/Tools/dea_tools/mosaics/mosaic_COGs.py
+++ b/Tools/dea_tools/mosaics/mosaic_COGs.py
@@ -9,8 +9,12 @@ local disk and public S3 buckets (e.g., `dea-public-data` or `dea-public-data-de
 
 Input Format
 ------------
-Input products must follow the DEA tiling convention:
-`s3://dea-public-data/derivative/<product>/<version>/<tile path>/<year>--<freq>/<product>_<tile path>_<year>--<freq>_<dataset maturity>_<band>.tif` 
+Input products must follow the DEA Collection 3 naming conventions and file structure, e.g.:
+`s3://dea-public-data/derivative/<product>/<version>/<tile path>/<year>--<freq>/<product>_<tile path>_<year>--<freq>_<dataset maturity>_<band>.tif`
+
+For more information:
+https://knowledge.dea.ga.gov.au/guides/reference/collection_3_naming/
+https://knowledge.dea.ga.gov.au/guides/reference/collection_3_summary_grid/
 
 Output Format
 -------------
@@ -34,20 +38,21 @@ GitHub (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 Last modified: July 2025
 """
 
-import s3fs
-import os
-import subprocess
 import glob
-import tempfile
-import shutil
-import click
 import logging
+import os
+import shutil
+import subprocess
+import tempfile
 from urllib.parse import urlparse
-from datacube.utils.aws import configure_s3_access
+
+import click
+import s3fs
+from odc.stac import configure_rio
 
 logging.basicConfig(
-    level=logging.INFO,  
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 
 
@@ -59,23 +64,22 @@ def _is_s3(path):
     return uu.scheme == "s3"
 
 
-def _get_tiles( 
+def _get_tiles(
     product_dir,
     product,
-    version, 
+    version,
     time,
     freq,
     dataset_maturity,
-    band, 
+    band,
     is_s3,
     aws_unsigned,
-    list_tiles = None, # example ['x25y41', 'x25y41']
+    list_tiles=None,  # example ['x25y41', 'x25y41']
 ):
     """
     Search for matching tile files from local or S3 paths based on product metadata.
     Optionally filters to a subset of specified tiles (e.g., ['x25y41', 'x25y41']).
     """
-
     tiles_pattern = (
         f"{product_dir}/"
         f"{product}/"
@@ -83,27 +87,20 @@ def _get_tiles(
         "**/**/"
         f"{time}--{freq}/"
         f"{product}_*{time}--{freq}_{dataset_maturity}_{band}.tif"
-    ) 
+    )
 
+    # Return list of tiles on either S3 or local directory
     if is_s3:
-        fs = s3fs.S3FileSystem(anon=True) #s3fs.S3FileSystem(anon=aws_unsigned) 
-        configure_s3_access(cloud_defaults=True, aws_unsigned=aws_unsigned)
+        fs = s3fs.S3FileSystem(anon=True)
+        configure_rio(cloud_defaults=True, aws={"aws_unsigned": aws_unsigned})
         tiles_list = fs.glob(tiles_pattern)
     else:
         tiles_list = glob.glob(tiles_pattern, recursive=True)
 
+    # Optionally filter list of tiles if requested
     if list_tiles:
-        xy_patterns = []
-        for xy in list_tiles:
-            xy_patterns.append(xy.replace('y','/y')) # i.e. from 'x25y41' to 'x25/y41'
-        
-        filtered_tiles = []
-        for tile in tiles_list:
-            if any(xy_pattern in tile for xy_pattern in xy_patterns):
-                filtered_tiles.append(tile)
-
-        tiles_list = filtered_tiles
-        
+        xy_patterns = [xy.replace("y", "/y") for xy in list_tiles]  # i.e. from 'x25y41' to 'x25/y41'
+        tiles_list = [tile for tile in tiles_list if any(xy in tile for xy in xy_patterns)]
 
     return tiles_list
 
@@ -112,151 +109,169 @@ def _get_vsicurlhttp_from_s3(s3_url):
     """
     Convert an S3 URL to a GDAL-compatible /vsicurl/ HTTPS path.
     """
-    
+
     if "dea-public-data-dev/" in s3_url:
         return s3_url.replace(
-            "dea-public-data-dev/",
-            "/vsicurl/https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/"
+            "dea-public-data-dev/", "/vsicurl/https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/"
         )
-    elif "dea-public-data/" in s3_url:
-        return s3_url.replace(
-            "dea-public-data/",
-            "/vsicurl/https://data.dea.ga.gov.au/"
-        )
-    else:
-        raise ValueError(f"Unexpected S3 URL structure: {s3_url}")
-
+    if "dea-public-data/" in s3_url:
+        return s3_url.replace("dea-public-data/", "/vsicurl/https://data.dea.ga.gov.au/")
+    raise ValueError(f"Unexpected S3 URL structure: {s3_url}")
 
 
 def make_cog_mosaics(
     product,
-    band,  
+    band,
     time,
-    freq, 
+    freq,
     version,
     dataset_maturity,
     product_dir,
-    output_dir, 
+    output_dir,
     cog_blocksize,
-    overview_count,  
+    overview_count,
     overview_resampling,
     compression_algo,
-    compression_lvl,
+    compression_level,
     aws_unsigned,
     skip_existing,
-    list_tiles = None,
+    list_tiles=None,
 ):
     """
-    Generate a COG mosaic for a given DEA tiles product.
+    Generate a COG mosaic for a given tiled DEA product.
+
+    Products must follow the DEA Collection 3 naming
+    conventions and file structure:
+    https://knowledge.dea.ga.gov.au/guides/reference/collection_3_naming/
+    https://knowledge.dea.ga.gov.au/guides/reference/collection_3_summary_grid/
 
     Parameters:
     ----------
     product : str
-        The name of the DEA product (e.g., 'ga_ls_landcover_class_cyear_3').
+        The name of the DEA product (e.g. 'ga_ls_landcover_class_cyear_3').
     band : str
         The variable or band to extract.
     time : int or str
-        The target time of the mosaic, year if annual summaries (e.g., 2023),
-        year-month for seasonal (e.g., water observations nov_mar --> '2024-11')
+        The target time of the mosaic, year if annual summaries (e.g. '2023'),
+        year-month for seasonal (e.g. water observations nov_mar --> '2024-11')
     freq : str
-        The frequency of the summary product (e.g.,P1Y).
+        The frequency of the summary product (e.g. 'P1Y').
     version : str
-        Product version (e.g., '2-0-0').  
+        Product version (e.g. '2-0-0').
     dataset_maturity : str
-        Dataset maturity stage. Usually: 'final'.        
+        Dataset maturity stage. Usually: 'final'.
     product_dir : str
         S3 directory for the product. Usually 's3://dea-public-data/derivative/',
         which is the DEA public bucket and derivates products folder,
-        which corresponds with https://data.dea.ga.gov.au/derivative/ HTTPS endpoint. 
+        which corresponds with https://data.dea.ga.gov.au/derivative/
+        HTTPS endpoint.
     output_dir : str
-        local directory or s3 directory where to save ouptut. 
+        local directory or s3 directory where to save output.
     cog_blocksize : int or str
-        Size of COG tiles.
-        Use 1024, unless there are specific reasons to use a different value.
+        Size of internal COG tiling. Use 1024, unless there are specific reasons to
+        use a different value.
     overview_count : int or str
         Number of image overviews to generate.
-        Use 7 for 30m resolution products (like Landsat),
-        use 8 for 10m resolution products (like Sentinel-2).
+        Use 7 for 30 m resolution products (like Landsat),
+        use 8 for 10 m resolution products (like Sentinel-2).
     overview_resampling : str
-        gdal_translate resampling method used when building overviews. Use all capital letters
-        - 'MODE' for categorical data (e.g., land cover),
+        GDAL resampling method used when building overviews.
+        Options include (use all capital letters):
+        - 'MODE' for categorical data (e.g. land cover),
         - 'BILINEAR' for continuous data,
-        - 'NEAREST' for "narrow" continuos data with many no-data pixels (e.g., coastal products).
+        - 'NEAREST' for narrow continuous data with many nodata pixels (e.g., coastal products).
     compression_algo : str
-        gdal_translate resampling algorithm. 
+        GDAL compression algorithm used for output COG.
         Use 'ZSTD', unless there are specific reasons to use a different algorithm.
-    compression_lvl : int or str
-        Level of compression of output COG
+    compression_level : int or str
+        Level of compression of output COG.
         Use 9, unless there are specific reasons to use a different level.
     aws_unsigned : bool
-        Whether to sign AWS requests for S3 access
+        Whether to sign AWS requests for S3 access.
     skip_existing : bool
-        Wheter to skip generation if output already exists.
-    list_tiles : list of strings
+        Whether to skip generation if output already exists.
+    list_tiles : list of strings, optional
         List including tiles of interest to include in the output mosaic.
-        For example: ['x25y41','x25y41'].
+        For example: ['x25y41', 'x25y41'].
         Defaults to None --> use all tiles available.
 
     Notes:
     ------
-    All other `gdal_translate` parameters
-    are intentionally omitted in this function.
-    These options should be standardized across all products,
-    and are applied consistently as part of downstream processing.
+    All other `gdal_translate` parameters are intentionally
+    omitted in this function. These options should be standardized
+    across all products, and are applied consistently as part of
+    downstream processing.
     """
-
     # first log
     log = logging.getLogger(__name__)
     input_params = locals()
     run_id = f"[{product}] [{version}] [{time}] [{band}]"
     log.info(f"{run_id}: Using parameters {input_params}")
 
-    # determine if input data is located on S3
+    # Set product and output paths to plain strings
+    # TODO: refactor code to use pathlib throughout
+    product_dir = str(product_dir)
+    output_dir = str(output_dir)
+
+    # Determine if input data is located on S3
     is_input_dir_s3 = _is_s3(product_dir)
+    is_out_dir_s3 = _is_s3(output_dir)
 
     # Clean string to prepare for analysis
-    product_dir = product_dir.replace("s3://", "")
+    product_dir = product_dir.removeprefix("s3://")
     product_dir = product_dir.rstrip("/")
     log.info(f"{run_id}: Using input data product directory: {product_dir}")
 
     # Determine output directory and file path following naming convention
     # /derivative/<product_id>/<version>/continental_mosaics/<time>/<product_id>_mosaic_<time>_<band name>.tif
     output_dir = output_dir.rstrip("/")
-    if _is_s3(output_dir):
+    if is_out_dir_s3:
         output_dir = f"{output_dir}/{product}/{version}/continental_mosaics/{time}--{freq}"
         output_file_path = f"{output_dir}/{product}_mosaic_{time}--{freq}_{band}.tif"
-        log.info(f"{run_id} - Output path: {output_file_path}")
+        log.info(f"{run_id} Output path: {output_file_path}")
     else:
         output_dir = os.path.join(output_dir, product, version, "continental_mosaics", f"{time}--{freq}")
         output_file_path = os.path.join(output_dir, f"{product}_mosaic_{time}--{freq}_{band}.tif")
-        log.info(f"{run_id} - Output path: {output_file_path}")
+        log.info(f"{run_id} Output path: {output_file_path}")
 
-    # check if output file already exists
-    output_exists = False
-    if _is_s3(output_file_path):
+    # Check if output file already exists
+    if is_out_dir_s3:
         fs = s3fs.S3FileSystem(anon=aws_unsigned)
-        output_exists = fs.exists(output_file_path.replace("s3://", ""))
+        output_exists = fs.exists(output_file_path.removeprefix("s3://"))
     else:
         output_exists = os.path.exists(output_file_path)
 
+    # If output exists, either skip processing or overwrite
     if output_exists:
         if skip_existing:
-            log.info(f"{run_id}: Output already exists at {output_file_path} and skip_existing=True. Skipping generation.")
+            log.info(
+                f"{run_id}: Output already exists at {output_file_path} and skip_existing=True. Skipping generation."
+            )
             return
-        else:
-            log.warning(f"{run_id}: Output already exists at {output_file_path} but skip_existing=False. Overwriting.")
+        log.warning(f"{run_id}: Output already exists at {output_file_path} but skip_existing=False. Overwriting.")
     else:
         log.info(f"{run_id}: Output does not exist. Proceeding with mosaic generation.")
 
-    # get list of paths to tiles
-    tiles_list = _get_tiles(product_dir, product,version, time, freq,dataset_maturity, band, is_input_dir_s3, aws_unsigned, list_tiles)
-    
-    # use /vsicurl/ path for `gdalbuildvrt` compatibility
+    # Get list of paths
+    log.info(f"{run_id}: Finding data to mosaic")
+    tiles_list = _get_tiles(
+        product_dir,
+        product,
+        version,
+        time,
+        freq,
+        dataset_maturity,
+        band,
+        is_input_dir_s3,
+        aws_unsigned,
+        list_tiles=list_tiles,
+    )
+
+    # Use /vsicurl/ path for `gdalbuildvrt` compatibility
     tiles_list = [_get_vsicurlhttp_from_s3(tile) for tile in tiles_list]
     log.info(f"{run_id}: Number of tiles to mosaic: {len(tiles_list)}")
 
     if len(tiles_list) > 0:
-
         # Create a temporary directory to house files before syncing
         with tempfile.TemporaryDirectory() as temp_dir:
             log.info(f"{run_id}: Writing data to temporary folder: {temp_dir}")
@@ -271,8 +286,8 @@ def make_cog_mosaics(
             with open(file_list_name, "w") as f:
                 for tile in tiles_list:
                     f.write(f"{tile}\n")
-            
-            # build VRT
+
+            # Build VRT that will subsequently be used to generate COG
             log.info(f"{run_id}: Building virtual raster (VRT)")
             try:
                 subprocess.run(
@@ -283,33 +298,35 @@ def make_cog_mosaics(
                 log.error(f"{run_id}: gdalbuildvrt failed with error: {e}")
                 raise
 
-            # convert VRT to Cloud Optimized GeoTIFF (COG)
+            # Convert VRT to Cloud Optimized GeoTIFF (COG)
             log.info(f"{run_id}: Converting VRT to COG mosaic")
+            # fmt: off
             try:
                 subprocess.run(
                     [
                         "gdal_translate",
                         vrt_name,
                         output_name,
-                        "-co", "NUM_THREADS=ALL_CPUS",                    # Parallelisation
-                        "-of", "COG",                                     # Output format
-                        "-co", "BIGTIFF=YES",                             # Allow large TIFFs
-                        "-co", f"BLOCKSIZE={cog_blocksize}",              # Tiling
-                        "-co", "OVERVIEWS=IGNORE_EXISTING",               # Force overview regen
-                        "-co", f"OVERVIEW_RESAMPLING={overview_resampling}",# Resampling for overviews
-                        "-co", f"OVERVIEW_COUNT={overview_count}",        # Number of overviews
-                        "-co", f"COMPRESS={compression_algo}",            # Compression
-                        "-co", f"LEVEL={compression_lvl}",                # Compression level
-                        "-co", "PREDICTOR=YES",                           # Compression predictor
+                        "-co", "NUM_THREADS=ALL_CPUS",                        # Parallelisation
+                        "-of", "COG",                                         # Output format
+                        "-co", "BIGTIFF=YES",                                 # Allow large TIFFs
+                        "-co", f"BLOCKSIZE={cog_blocksize}",                  # Tiling
+                        "-co", "OVERVIEWS=IGNORE_EXISTING",                   # Force overview regen
+                        "-co", f"OVERVIEW_RESAMPLING={overview_resampling}",  # Resampling for overviews
+                        "-co", f"OVERVIEW_COUNT={overview_count}",            # Number of overviews
+                        "-co", f"COMPRESS={compression_algo}",                # Compression
+                        "-co", f"LEVEL={compression_level}",                    # Compression level
+                        "-co", "PREDICTOR=YES",                               # Compression predictor
                     ],
                     check=True,
                 )
             except subprocess.CalledProcessError as e:
                 log.error(f"{run_id}: gdal_translate failed with error: {e}")
                 raise
+            # fmt: on
 
             # Copy output to S3
-            if _is_s3(output_file_path):
+            if is_out_dir_s3:
                 log.info(f"{run_id}: Writing COG to S3: {output_file_path}")
 
                 subprocess.run(
@@ -326,9 +343,11 @@ def make_cog_mosaics(
                     check=True,
                 )
 
-            else: # copy locally to output folder
-                os.makedirs(output_dir, exist_ok=True)
+            # Copy locally to output folder
+            else:
                 log.info(f"{run_id}: Writing data locally: {output_file_path}")
+
+                os.makedirs(output_dir, exist_ok=True)
                 shutil.copy(output_name, output_file_path)
 
     else:
@@ -340,38 +359,38 @@ def make_cog_mosaics(
     "--product",
     type=str,
     required=True,
-    help="The name of the product to be mosaicked (e.g., 'ga_ls_landcover_class_cyear_3')."
+    help="The name of the product to be mosaicked (e.g. 'ga_ls_landcover_class_cyear_3').",
 )
 @click.option(
     "--band",
     type=str,
     required=True,
-    help="The variable or band to extract (e.g., 'level4')"
+    help="The variable or band to extract (e.g. 'level4')",
 )
 @click.option(
     "--time",
     type=str,
     required=True,
-    help="The target time of the mosaic (e.g., '2022')."
+    help="The target time of the mosaic (e.g. '2022').",
 )
 @click.option(
     "--freq",
     type=str,
     required=True,
-    help="The frequency of the summary product (e.g., 'P1Y')."
+    help="The frequency of the summary product (e.g. 'P1Y').",
 )
 @click.option(
     "--version",
     type=str,
     required=True,
-    help="The version number of the product (e.g., '2-0-0')."
+    help="The version number of the product (e.g. '2-0-0').",
 )
 @click.option(
     "--dataset_maturity",
     type=str,
     default="final",
     show_default=True,
-    help="Dataset maturity of the data to be mosaicked. Usually: 'final'."
+    help="Dataset maturity of the data to be mosaicked. Usually: 'final'.",
 )
 @click.option(
     "--product_dir",
@@ -380,55 +399,53 @@ def make_cog_mosaics(
     show_default=True,
     help="The directory/location to read the tile COGs from; supports "
     "both local disk and S3 locations. E.g. 's3://dea-public-data/derivative/', "
-    "corresponding to https://data.dea.ga.gov.au/derivative/."
+    "corresponding to https://data.dea.ga.gov.au/derivative/.",
 )
 @click.option(
     "--output_dir",
     type=str,
     required=True,
     help="Local or S3 directory where to save output. "
-    "The function will add on `{product}/{version}/continental_mosaics/{time}--{freq}` "
+    "The function will add on `{product}/{version}/continental_mosaics/{time}--{freq}` ",
 )
 @click.option(
     "--cog_blocksize",
     type=int,
     default=1024,
     show_default=True,
-    help="Size of COG tiles."
-         "Use 1024, unless there are specific reasons to use a different value."
+    help="Size of internal COG tiling. Use 1024, unless there are specific reasons to use a different value.",
 )
 @click.option(
     "--overview_count",
     type=int,
     required=True,
     help="Number of image overviews to generate. "
-         "Use 7 for 30m resolution products (e.g., Landsat), "
-         "or 8 for 10m resolution products (e.g., Sentinel-2)."
+    "Use 7 for 30m resolution products (e.g., Landsat), "
+    "or 8 for 10m resolution products (e.g., Sentinel-2).",
 )
 @click.option(
     "--overview_resampling",
     type=str,
     required=True,
     help="GDAL resampling method used for overviews. Use uppercase values: "
-         "'MODE' for categorical data (e.g., land cover), "
-         "'BILINEAR' for continuous data, "
-         "'NEAREST' for sparse/narrow continuous data."
+    "'MODE' for categorical data (e.g., land cover), "
+    "'BILINEAR' for continuous data, "
+    "'NEAREST' for sparse/narrow continuous data.",
 )
 @click.option(
     "--compression_algo",
     type=str,
     default="ZSTD",
     show_default=True,
-    help="gdal_translate resampling algorithm."
-         "Use 'ZSTD', unless there are specific reasons to use a different algorithm."
+    help="GDAL compression algorithm used for output COG."
+    "Use 'ZSTD', unless there are specific reasons to use a different algorithm.",
 )
 @click.option(
-    "--compression_lvl",
+    "--compression_level",
     type=int,
     default=9,
     show_default=True,
-    help="Level of compression of output COG"
-         "Use '9', unless there are specific reasons to use a different level."
+    help="Level of compression of output COG. Use '9', unless there are specific reasons to use a different level.",
 )
 @click.option(
     "--aws_unsigned/--no-aws_unsigned",
@@ -442,15 +459,14 @@ def make_cog_mosaics(
     is_flag=True,
     default=False,
     show_default=True,
-    help="Skip generation if output already exists."
-    "Defaults to False"
+    help="Skip generation if output already exists.Defaults to False",
 )
 @click.option(
     "--list_tiles",
     type=str,
     required=False,
-     help="Comma-separated list of tiles to include in the mosaic. Example: x25y41,x26y42. "
-    "If omitted, all tiles will be used."
+    help="Comma-separated list of tiles to include in the mosaic. Example: x25y41,x26y42. "
+    "If omitted, all tiles will be used.",
 )
 def make_cog_mosaic_cli(
     product,
@@ -465,22 +481,38 @@ def make_cog_mosaic_cli(
     overview_count,
     overview_resampling,
     compression_algo,
-    compression_lvl,
+    compression_level,
     aws_unsigned,
     skip_existing,
-    list_tiles=None,
+    list_tiles,
 ):
     """
     CLI entry point for generating DEA COG mosaics from tiled datasets.
     Passes user inputs to the core mosaic generation function.
     """
-    
+    # Convert string of tiles to list
+    list_tiles = list_tiles.split(",") if list_tiles else None
+
+    # Run analysis function
     make_cog_mosaics(
-        product, band, time, freq, version, dataset_maturity,
-        product_dir, output_dir, cog_blocksize, overview_count,
-        overview_resampling, compression_algo, compression_lvl,
-        aws_unsigned, skip_existing, list_tiles
+        product,
+        band,
+        time,
+        freq,
+        version,
+        dataset_maturity,
+        product_dir,
+        output_dir,
+        cog_blocksize,
+        overview_count,
+        overview_resampling,
+        compression_algo,
+        compression_level,
+        aws_unsigned,
+        skip_existing,
+        list_tiles,
     )
+
 
 if __name__ == "__main__":
     make_cog_mosaic_cli()


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
This PR makes a number of updates to the COG mosaicking code in #1362:

- Removed custom install of DEA Tools (once the Sandbox image is updated it will be installed by default)
- Renamed `compression_lvl` to `compression_level` for readability
- Used CLI utility commands by default in readme, instread of `python ...` approach
- Moved checks for S3 up to the top of functions, and re-used `_is_s3` function rather than copying it into both scripts
- Only use relative VRT links if COGs are local. Use absolute links if COGs are on S3.
- Added new `vrt_name` param to allow passing in a custom name for VRTs instead of using the default `{red-green-blue}` band names (e.g. `ga_s2_tidal_composites_cyear_3_2022_vrt-low-truecolour.vrt`)
- Fixed bug where `list_tiles` was not actually filtering the tile list
- Use `configure_rio` from `odc.stac` instead of `configure_s3_access` from datacube
- Formatted and linted code with Ruff, minor docs updates

