### PR TITLE
Add `s3fs` mosaicing dependency to DEA Tools

### DIFF
--- a/Tools/mock_imports.txt
+++ b/Tools/mock_imports.txt
@@ -46,6 +46,7 @@ requests
 rios
 rioxarray
 rsgislib
+s3fs
 scikit_learn
 seaborn
 sklearn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "rasterstats>=0.16.0",
     "requests>=2.25.0",
     "rioxarray>=0.10.0",
+    "s3fs>=2024.9.0",
     "seaborn>=0.10.0",
     "scikit-image>=0.22.0",
     "scikit-learn>=1.4.0",


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
Added s3fs to dea-tools, which is needed by the mosaics submodule. I have used the version currently installed in the Sandbox as minimum version required

### Closes issues (optional)
- Closes Issue #1373
