### PR TITLE
Fix dask performance issue by using `configure_s3_access` function

### DIFF
--- a/Tools/dea_tools/dask.py
+++ b/Tools/dea_tools/dask.py
@@ -27,7 +27,6 @@ import dask
 import dask.distributed
 from aiohttp import ClientConnectionError
 from odc.io.cgroups import get_cpu_quota
-from odc.stac import configure_rio as cfg_rio
 
 _HAVE_PROXY = bool(find_spec("jupyter_server_proxy"))
 
@@ -103,9 +102,16 @@ def create_local_dask_cluster(
         **kwargs,
     )
 
-    # configure aws access
+    # Configure AWS and GDAL/rasterio access. Use datacube `configure_s3_access`
+    # function preferentially if datacube is installed, as this function will
+    # choose the correct settings automatically. If datacube is not installed,
+    # use version of function from odc.loader > odc.stac.
     if configure_rio:
-        cfg_rio(cloud_defaults=True, aws={"aws_unsigned": True}, client=client)
+        try:
+            from datacube.utils.aws import configure_s3_access
+        except:
+            from odc.stac import configure_s3_access
+        configure_s3_access(cloud_defaults=True, aws_unsigned=True, client=client)
 
     # Show the dask cluster settings
     if display_client:

--- a/Tools/dea_tools/dask.py
+++ b/Tools/dea_tools/dask.py
@@ -85,10 +85,7 @@ def create_local_dask_cluster(
 
     # Count cpus if threads_per_worker not provided
     if threads_per_worker is None:
-        if get_cpu_quota() is not None:
-            threads_per_worker = round(get_cpu_quota())
-        else:
-            threads_per_worker = os.cpu_count()
+        threads_per_worker = round(get_cpu_quota()) if get_cpu_quota() is not None else os.cpu_count()
 
     # by default split 95% of system memory by the n_workers.
     if memory_limit == "spare_mem":
@@ -109,7 +106,7 @@ def create_local_dask_cluster(
     if configure_rio:
         try:
             from datacube.utils.aws import configure_s3_access
-        except:
+        except ImportError:
             from odc.stac import configure_s3_access
         configure_s3_access(cloud_defaults=True, aws_unsigned=True, client=client)
 
@@ -177,9 +174,7 @@ def create_dask_gateway_cluster(profile="r5_L", workers=2):
 
         # limit username to alphanumeric characters
         # kubernetes pods won't launch if labels contain anything other than [a-Z, -, _]
-        options["jupyterhub_user"] = "".join(
-            c if c.isalnum() else "-" for c in os.getenv("JUPYTERHUB_USER")
-        )
+        options["jupyterhub_user"] = "".join(c if c.isalnum() else "-" for c in os.getenv("JUPYTERHUB_USER"))
 
         cluster = gateway.new_cluster(options)
         cluster.scale(workers)


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
I recently found that notebooks were running significantly slower on the latest version of DEA Tools than they used to in the past (e.g. our integration tests going from ~1 hour to ~2 hours).

Looking into this deeper, the problem seems to be using the `configure_rio` function in `create_local_dask_cluster`. If we replace this function with `configure_s3_access`, everything runs far more quickly (e.g. 2 minutes vs. 12 minutes for the same size data load).

To make things a little more complicated, there's two `configure_s3_access` functions that both work differently: one from `datacube` and one from `odc-stac`. Only the `datacube` version of the function works on the Sandbox, so this PR updates our code to first try to import the function from `datacube`, and if this fails, use the version from `odc.stac`.
