### PR TITLE
Update dask client to correctly configure s3 access

### DIFF
--- a/Tools/dea_tools/dask.py
+++ b/Tools/dea_tools/dask.py
@@ -106,9 +106,12 @@ def create_local_dask_cluster(
     if configure_rio:
         try:
             from datacube.utils.aws import configure_s3_access
+            configure_s3_access(cloud_defaults=True, aws_unsigned=True, client=client)
+        
         except ImportError:
             from odc.stac import configure_s3_access
-        configure_s3_access(cloud_defaults=True, aws_unsigned=True, client=client)
+            #notethat odc.stac version does not accept client param
+            configure_s3_access(cloud_defaults=True, aws_unsigned=True)
 
     # Show the dask cluster settings
     if display_client:

--- a/Tools/dea_tools/dask.py
+++ b/Tools/dea_tools/dask.py
@@ -110,7 +110,7 @@ def create_local_dask_cluster(
         
         except ImportError:
             from odc.stac import configure_s3_access
-            #notethat odc.stac version does not accept client param
+            # Note that odc.stac version does not accept client param
             configure_s3_access(cloud_defaults=True, aws_unsigned=True)
 
     # Show the dask cluster settings


### PR DESCRIPTION
### Proposed changes,
The `odc.stac` version of [configure_S3_access](https://github.com/opendatacube/odc-loader/blob/b9e0ca8ec970f09da3b749d492ceca8f0419e0e8/src/odc/loader/_rio.py#L370) does not accept a `client=` parameter, and doing so causes a serialisation error. See this thread: https://github.com/opendatacube/odc-stac/issues/237


