### PR TITLE
Replace `np.NaN` with `np.nan` for Numpy 2.0 compatibility

### DIFF
--- a/Tools/dea_tools/datahandling.py
+++ b/Tools/dea_tools/datahandling.py
@@ -1501,7 +1501,7 @@ def load_reproject(
         resolution=resolution,
         tight=tight,
         resampling=resampling,
-        dst_nodata=np.NaN if masked else None,
+        dst_nodata=np.nan if masked else None,
         **reproject_kwds,
     )
 


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
`np.NaN` has been deprecated in Numpy v2.0. This PR replaces it with `np.nan` (which should work on both Numpy v1.X and v2.X.
