### PR TITLE
Update workflows that publish artifacts to use specific configured environments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: prod_pypi
 
     steps:
       # Check out Git repository with full history

--- a/.github/workflows/trigger_docs.yaml
+++ b/.github/workflows/trigger_docs.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   trigger_docs:
     runs-on: ubuntu-latest
+    environment: prod_dea_knowledge_hub
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
### Proposed changes
This change configures the publish to Pypi and the sync to knowledge hub workflows so they each have a respective environment configuration. This provides DEA teams the flexibility to specify delegates that can approve the execution of these two workflows, protecting against unintentional or unauthorised change.

When a request by members of the repository wish to publish an artifact by either Github workflow, a delegated GA member will be notified by email to grant permission for the workflow to execute and ultimately publish an artifact.

Further info on environment management can be found here: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments