### PR TITLE
Update `dea_tools.bandindices` to add Chrysostomou 2026 vegetation and water indices

### DIFF
--- a/Tools/dea_tools/bandindices.py
+++ b/Tools/dea_tools/bandindices.py
@@ -15,7 +15,7 @@ here: https://gis.stackexchange.com/questions/tagged/open-data-cube).
 If you would like to report an issue with this script, you can file one
 on GitHub (https://github.com/GeoscienceAustralia/dea-notebooks/issues/new).
 
-Last modified: June 2023
+Last modified: March 2026
 """
 
 # Import required packages
@@ -87,6 +87,8 @@ def calculate_indices(
         * ``'NIRv'`` (Near-Infrared Reflectance of Vegetation, Badgley et al. 2017)
         * ``'kNDVI'`` (Kernel Normalized Difference Vegetation Index, Camps-Valls et al. 2021)
         * ``'SAVI'`` (Soil Adjusted Vegetation Index, Huete 1988)
+        * ``'SRVI'`` (Symbolic Regression Vegetation Index, Chrysostomou 2026)
+        * ``'SRWI'`` (Symbolic Regression Water Index, Chrysostomou 2026)
         * ``'TCB'`` (Tasseled Cap Brightness, Crist 1985)
         * ``'TCG'`` (Tasseled Cap Greeness, Crist 1985)
         * ``'TCW'`` (Tasseled Cap Wetness, Crist 1985)
@@ -105,7 +107,6 @@ def calculate_indices(
 
         * ``'ga_ls_3'`` (for GA Landsat Collection 3)
         * ``'ga_s2_3'`` (for GA Sentinel 2 Collection 3)
-        * ``'ga_gm_3'`` (for GA Geomedian Collection 3)
 
     custom_varname : str, optional
         By default, the original dataset will be returned with
@@ -293,6 +294,12 @@ def calculate_indices(
         "FMR": lambda ds: (ds.swir1 / ds.nir),
         # Iron Oxide Ratio, Segal 1982
         "IOR": lambda ds: (ds.red / ds.blue),
+        # Symbolic Regression Water Index, Chrysostomou 2026
+        "SRWI": lambda ds: ((ds.green + ds.blue) - (ds.nir + ds.swir1))
+        / ((ds.green + ds.blue) + (ds.nir + ds.swir1)),
+        # Symbolic Regression Vegetation Index, Chrysostomou 2026
+        "SRVI": lambda ds: ((2 * ds.nir) - (3 * ds.red))
+        / (ds.nir + ds.red + (0.5 * (ds.green + ds.swir1))),
     }
 
     # If index supplied is not a list, convert to list. This allows us to
@@ -341,7 +348,7 @@ def calculate_indices(
         if collection is None:
             raise ValueError(
                 "'No `collection` was provided. Please specify "
-                "either 'ga_ls_3', 'ga_s2_3' or 'ga_gm_3' "
+                "either 'ga_ls_3' or 'ga_s2_3' "
                 "to ensure the function calculates indices "
                 "using the correct spectral bands"
             )
@@ -394,16 +401,12 @@ def calculate_indices(
                 a: b for a, b in bandnames_dict.items() if a in ds.variables
             }
 
-        elif collection == "ga_gm_3":
-            # Pass an empty dict as no bands need renaming
-            bands_to_rename = {}
-
         # Raise error if no valid collection name is provided:
         else:
             raise ValueError(
                 f"'{collection}' is not a valid option for "
                 "`collection`. Please specify either \n"
-                "'ga_ls_3', 'ga_s2_3' or 'ga_gm_3'"
+                "'ga_ls_3' or 'ga_s2_3'"
             )
 
         # Apply index function


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
This PR updates `dea_tools.bandindices` to add two promising new functions for mapping vegetation and water, recently published in Scientific Reports: https://www.nature.com/articles/s41598-025-34720-x

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5a9b44b8-778e-4f62-8039-5580e9755a60" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6a154327-36dc-4228-884f-6a6140ee763b" />

The new indices seem to produce sensible results from quick testing:

<img width="944" height="456" alt="image" src="https://github.com/user-attachments/assets/f84eb17b-aa0f-4380-b0b3-e233346ca377" />

<img width="834" height="423" alt="image" src="https://github.com/user-attachments/assets/683037d5-aed2-4669-ae62-480c8728bcca" />

### Closes issues (optional)
- Closes Issue #1431 

### Checklist
<!--- (Replace `[ ]` with `[x]` to check off) --->

If this is a notebook, then have you: 
- [x] Checked the structure of the notebook follows our [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/wiki/NotebookTemplate)
- [x] Removed any unused Python packages from `Load packages`
- [x] Removed any unused/empty code cells
- [x] Removed any guidance cells (e.g. `General advice`)
- [x] Ensured that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [x] Included relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [x] Tested notebook on the [DEA Sandbox](https://knowledge.dea.ga.gov.au/guides/setup/Sandbox/sandbox/)
- [x] Cleared all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [x] If applicable, update the `Notebook currently compatible with` line below the notebook title to reflect the environments the notebook is compatible with
- [x] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)

<!--- 
⭐ Did you get stuck? These might help: 
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Getting-started-with-Git
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Create-a-DEA-Notebook
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook
--->
