### PR TITLE
Add recent notebook to readme.rst

### DIFF
--- a/How_to_guides/README.rst
+++ b/How_to_guides/README.rst
@@ -12,6 +12,7 @@ A recipe book of simple code examples demonstrating how to perform common geospa
    Calculating_band_indices.ipynb
    COG_mosaics.ipynb
    COG_overviews.ipynb
+   Collect_training_and_validation_data.ipynb
    Contour_extraction.ipynb
    Continental_scale_animations.ipynb
    Detecting_seasonality.ipynb


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
In the recently merged PR #1474, the new notebook 'Collect_training_and_validation_data" was not added to the how-to-guide README.rst, which means it is not built into the Knowledge Hub. 
