### PR TITLE
collect_data_from_shp_more_robust

### DIFF
--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -533,6 +533,9 @@ def _get_training_data_for_shp(
     # Use input feature function and run checks on output
     data = feature_func(dc_query)
 
+    # infer coordinate names
+    x_name, y_name = _find_xy_coords(data)
+
     if not isinstance(data, (xr.Dataset, xr.DataArray)):
         raise TypeError("feature_func must return xarray Dataset or DataArray")
 
@@ -549,10 +552,7 @@ def _get_training_data_for_shp(
         mask = xr_rasterize(dff, data)
         data = data.where(mask)
 
-    if return_coords:
-        # infer coordinate names
-        x_name, y_name = _find_xy_coords(data)
-    
+    if return_coords:    
         # turn coords into variables
         data["x_coord"] = data[x_name] + 0 * data[y_name]
         data["y_coord"] = data[y_name] + 0 * data[x_name]
@@ -574,10 +574,7 @@ def _get_training_data_for_shp(
 
     elif zonal_stats in ["mean", "median", "max", "min"]:
         method_to_call = getattr(data, zonal_stats)
-        if 'x' in data.coords and 'y' in data.coords:
-            stacked = method_to_call(["x", "y"])  # will keep time as dim if present
-        else: 
-            stacked = method_to_call(["longitude", "latitude"]) 
+        stacked = method_to_call([x_name, y_name])  # will keep time as dim if present
         stacked = stacked.to_dataframe().reset_index(drop=True)
         stacked[field] = row[field]
 

--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -514,8 +514,8 @@ def _get_training_data_for_shp(
             data["x_coord"] = data.x + 0 * data.y
             data["y_coord"] = data.y + 0 * data.x   
         else:
-            data["x_coord"] = data.longitude
-            data["y_coord"] = data.latitude
+            data["x_coord"] = data.longitude + 0 * data.latitude
+            data["y_coord"] = data.latitude + 0 * data.longitude 
 
     # append ID measurement to dataset for tracking failures
     band = list(data.data_vars)[0]
@@ -533,7 +533,10 @@ def _get_training_data_for_shp(
 
     elif zonal_stats in ["mean", "median", "max", "min"]:
         method_to_call = getattr(data, zonal_stats)
-        stacked = method_to_call(["x", "y"])  # will keep time as dim if present
+        if 'x' in data.coords and 'y' in data.coords:
+            stacked = method_to_call(["x", "y"])  # will keep time as dim if present
+        else: 
+            stacked = method_to_call(["longitude", "latitude"]) 
         stacked = stacked.to_dataframe().reset_index(drop=True)
         stacked[field] = row[field]
 
@@ -659,6 +662,8 @@ def collect_training_data(
     dc_query : dictionary
         Datacube query object, should not contain lat and long (x or y) variables as these
         are supplied by the geopolygon column in the 'gdf'.
+        N.B.: if the query includes a lat/lon `output_crs`, it is necessary to specify the 
+        `resolution` as lat/lon degrees too.
     ncpus : int
         The number of cpus/processes over which to parallelize the gathering
         of training data (only if ncpus is > 1). Defaults to 1.

--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -551,7 +551,7 @@ def _get_training_data_for_shp(
 
     if return_coords:
         # infer coordinate names
-        x_name, y_name = find_xy_coords(data)
+        x_name, y_name = _find_xy_coords(data)
     
         # turn coords into variables
         data["x_coord"] = data[x_name] + 0 * data[y_name]

--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -424,6 +424,47 @@ class HiddenPrints:
         sys.stdout = self._original_stdout
 
 
+def _find_xy_coords(data):
+    """
+    Infer x and y coordinate names from an xarray Dataset or DataArray
+    using lowercase substring matching.
+
+    Parameters
+    ----------
+    data : xr.Dataset or xr.DataArray
+
+    Returns
+    -------
+    tuple
+        (x_coord_name, y_coord_name)
+
+    Raises
+    ------
+    ValueError
+        If x or y coordinates cannot be inferred.
+    """
+
+    X_TOKENS = ("lon", "x", "east")
+    Y_TOKENS = ("lat", "y", "north")
+
+    x_coord = None
+    y_coord = None
+
+    for cname in data.coords:
+        name = cname.lower()
+
+        if x_coord is None and any(token in name for token in X_TOKENS):
+            x_coord = cname
+
+        if y_coord is None and any(token in name for token in Y_TOKENS):
+            y_coord = cname
+
+    if x_coord is None or y_coord is None:
+        raise ValueError("Could not infer x/y coords")
+
+    return x_coord, y_coord
+
+
 def _get_training_data_for_shp(
     row: gpd.GeoSeries,
     crs: pyproj.CRS,
@@ -509,13 +550,13 @@ def _get_training_data_for_shp(
         data = data.where(mask)
 
     if return_coords:
-        # turn coords into a variable in the 
-        if 'x' in data.coords and 'y' in data.coords:
-            data["x_coord"] = data.x + 0 * data.y
-            data["y_coord"] = data.y + 0 * data.x   
-        else:
-            data["x_coord"] = data.longitude + 0 * data.latitude
-            data["y_coord"] = data.latitude + 0 * data.longitude 
+        # infer coordinate names
+        x_name, y_name = find_xy_coords(data)
+    
+        # turn coords into variables
+        data["x_coord"] = data[x_name] + 0 * data[y_name]
+        data["y_coord"] = data[y_name] + 0 * data[x_name]
+
 
     # append ID measurement to dataset for tracking failures
     band = list(data.data_vars)[0]

--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -35,7 +35,7 @@ from tqdm.auto import tqdm
 import multiprocessing as mp
 import dask.distributed as dd
 from functools import partial
-from datetime import datetime, timedelta
+from datetime import datetime
 from abc import ABCMeta, abstractmethod
 from dask_ml.wrappers import ParallelPostFit
 

--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -509,9 +509,13 @@ def _get_training_data_for_shp(
         data = data.where(mask)
 
     if return_coords:
-        # turn coords into a variable in the ds
-        data["x_coord"] = data.x + 0 * data.y
-        data["y_coord"] = data.y + 0 * data.x
+        # turn coords into a variable in the 
+        if 'x' in ds_ard.coords and 'y' in ds_ard.coords:
+            data["x_coord"] = data.x + 0 * data.y
+            data["y_coord"] = data.y + 0 * data.x   
+        else:
+            data["x_coord"] = data.longitude + 0 * data.latitude
+            data["y_coord"] = data.latitude + 0 * data.longitude
 
     # append ID measurement to dataset for tracking failures
     band = list(data.data_vars)[0]

--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -514,8 +514,8 @@ def _get_training_data_for_shp(
             data["x_coord"] = data.x + 0 * data.y
             data["y_coord"] = data.y + 0 * data.x   
         else:
-            data["x_coord"] = data.longitude + 0 * data.latitude
-            data["y_coord"] = data.latitude + 0 * data.longitude
+            data["x_coord"] = data.longitude
+            data["y_coord"] = data.latitude
 
     # append ID measurement to dataset for tracking failures
     band = list(data.data_vars)[0]

--- a/Tools/dea_tools/classification.py
+++ b/Tools/dea_tools/classification.py
@@ -510,7 +510,7 @@ def _get_training_data_for_shp(
 
     if return_coords:
         # turn coords into a variable in the 
-        if 'x' in ds_ard.coords and 'y' in ds_ard.coords:
+        if 'x' in data.coords and 'y' in data.coords:
             data["x_coord"] = data.x + 0 * data.y
             data["y_coord"] = data.y + 0 * data.x   
         else:


### PR DESCRIPTION
<!--- ⭐ This is a template you can follow to help construct a good pull request! --->

### Proposed changes
Small change to make collect_training_data more robust. 

Previously, if the feat_func or the query passed to collect_training_data included setting the output CRS to EPSG:4326 for example, the function _get_training_data_for_shp would fail when searching for x and y.

Now it first checks if the ds coords are x/y. If not, it extracts latitude/longitude

Also, I added a note to the doc string of collect_training_data to remind that, if the query includes a lat/lon output_crs, also the resolution needs to be in degrees. As this gave me some trouble when testing the changes made and getting unexpected results, so I thought it could be useful for users too. 

### Checklist

If this is a notebook, then have you: 
- [na] Checked the structure of the notebook follows our [DEA-notebooks template](https://github.com/GeoscienceAustralia/dea-notebooks/wiki/NotebookTemplate)
- [x] Removed any unused Python packages from `Load packages`
- [na] Removed any unused/empty code cells
- [na] Removed any guidance cells (e.g. `General advice`)
- [x] Ensured that all code cells follow the [PEP8 standard](https://www.python.org/dev/peps/pep-0008/) for code. The `jupyterlab_code_formatter` tool can be used to format code cells to a consistent style: select each code cell, then click `Edit` and then one of the `Apply X Formatter` options (`YAPF` or `Black` are recommended).
- [na] Included relevant tags in the final notebook cell (refer to the [DEA Tags Index](https://knowledge.dea.ga.gov.au/genindex/), and re-use tags if possible)
- [na] Tested notebook on the [DEA Sandbox](https://knowledge.dea.ga.gov.au/guides/setup/Sandbox/sandbox/)
- [na] Cleared all outputs, run notebook from start to finish, and save the notebook in the state where all cells have been sequentially evaluated
- [na] If applicable, update the `Notebook currently compatible with` line below the notebook title to reflect the environments the notebook is compatible with
- [na] Check for any spelling mistakes using the DEA Sandbox's built-in spellchecker (double click on markdown cells then right-click on pink highlighted words). For example:

![sandbox_spellchecker](https://github.com/GeoscienceAustralia/dea-notebooks/assets/17680388/c5e5848b-fd54-4eb5-aae9-29838761f2af)

<!--- 
⭐ Did you get stuck? These might help: 
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Getting-started-with-Git
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Create-a-DEA-Notebook
- https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook
--->
