### PR TITLE
Update dea-tools PyPI publish workflow to release-only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,6 @@
 name: Publish dea-tools to PyPI
 
 on:
-  push:
-    branches: [develop, uv_publish]
-    paths:
-      - 'pyproject.toml'
-      - 'README_tools.md'
-      - 'Tools/**'
-      - '.github/workflows/publish.yml'
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Remove automatic PyPI publishing on pushes to `develop` and `uv_publish`.

Publishing will now only occur:

* on GitHub versioned releases
* via manual workflow dispatch

## Reason

PyPI publication now requires CAB approval, so publishing pre-release versions from every develop push is no longer required. The previous behaviour caused unnecessary queued approval steps and eventual workflow failures.

This change aligns the workflow with the current DEA release approval process.
