### PR TITLE
Fix rgb() titles for single-panel plots

### DIFF
--- a/Tests/dea_tools/test_plotting.py
+++ b/Tests/dea_tools/test_plotting.py
@@ -1,0 +1,65 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import xarray as xr
+import pytest
+import matplotlib.pyplot as plt
+from odc.geo.xr import assign_crs
+
+from dea_tools.plotting import rgb
+
+
+@pytest.fixture
+def rgb_dataset():
+    """A small synthetic 3-band dataset with a length-2 `time` dim."""
+    nt, ny, nx = 2, 8, 10
+    rng = np.random.default_rng(0)
+    bands = ["nbart_red", "nbart_green", "nbart_blue"]
+    ds = xr.Dataset(
+        {b: (("time", "y", "x"), rng.integers(0, 3000, (nt, ny, nx)).astype("int16")) for b in bands},
+        coords={
+            "time": np.arange(nt),
+            "y": np.linspace(-2e6, -2.001e6, ny),
+            "x": np.linspace(1e6, 1.001e6, nx),
+        },
+    )
+    return assign_crs(ds, crs="EPSG:3577")
+
+
+def test_rgb_titles_single_composite(rgb_dataset):
+    """Regression test for #1334: a single composite (no index dim) with
+    custom titles must not raise (previously `AttributeError: 'AxesImage'
+    object has no attribute 'axs'`). `rgb()` returns None and sets the
+    title on the current axes."""
+    composite = rgb_dataset.isel(time=0)
+    rgb(composite, titles=["2021"])
+    assert plt.gca().get_title() == "2021"
+    plt.close("all")
+
+
+def test_rgb_titles_single_index(rgb_dataset):
+    """Regression test for #1334: selecting a single observation via
+    `index=0` with custom titles must not raise."""
+    rgb(rgb_dataset, index=0, titles=["2021"])
+    assert plt.gca().get_title() == "2021"
+    plt.close("all")
+
+
+def test_rgb_titles_faceted(rgb_dataset):
+    """The faceted path (multiple indices) must continue to work with a
+    list of titles."""
+    rgb(rgb_dataset, index=[0, 1], titles=["a", "b"])
+    titles = {ax.get_title() for ax in plt.gcf().axes if ax.get_title()}
+    assert titles == {"a", "b"}
+    plt.close("all")
+
+
+def test_rgb_titles_bare_string(rgb_dataset):
+    """A bare string `titles` on a single panel should set the whole
+    string as the title (not the first character via list-indexing)."""
+    composite = rgb_dataset.isel(time=0)
+    rgb(composite, titles="2021")
+    assert plt.gca().get_title() == "2021"
+    plt.close("all")

--- a/Tools/dea_tools/plotting.py
+++ b/Tools/dea_tools/plotting.py
@@ -180,8 +180,10 @@ def rgb(
             **kwargs,
         )
         if titles is not None:
-            for ax, title in zip(img.axs.flat, titles):
-                ax.set_title(title)
+            # Single-panel plots return a matplotlib `AxesImage` (no `.axs`),
+            # so set the title on its parent axes directly
+            title = titles[0] if isinstance(titles, (list, tuple)) else titles
+            img.axes.set_title(title)
 
     # If values provided for `index`, extract corresponding observations and
     # plot as either single image or facet plot
@@ -232,8 +234,10 @@ def rgb(
                 robust=robust, **aspect_size_kwarg, **kwargs
             )
             if titles is not None:
-                for ax, title in zip(img.axs.flat, titles):
-                    ax.set_title(title)
+                # Single-panel plots return a matplotlib `AxesImage` (no `.axs`),
+                # so set the title on its parent axes directly
+                title = titles[0] if isinstance(titles, (list, tuple)) else titles
+                img.axes.set_title(title)
 
     # If an export path is provided, save image to file. Individual and
     # faceted plots have a different API (figure vs fig) so we get around this


### PR DESCRIPTION
Single-panel rgb() plots return an AxesImage rather than a FacetGrid, so setting custom titles via img.axs raised an AttributeError. This PR sets single-panel titles via img.axes, leaves faceted title handling as-is, and adds regression tests.

References Issue #1334: dea_tool.plotting.rgb adding custom titles causes error due to attribute error "missing axs object".

### Proposed changes

- Sets the title via `img.axes` on the two single-panel branches.
- Uses a bare string or scalar title directly instead of indexing into it, so `titles=pd.Timestamp(ds.time.values[0]).year` and similar inputs work.
- Leaves the faceted branch unchanged.
- Adds `Tests/dea_tools/test_plotting.py` covering the single-composite, `index=0`, faceted, and bare-string cases.

### Checklist
 - [x] Reproduced the original AttributeError and confirmed the fix resolves it
 - [x] Faceted (multi-image) title behaviour left unchanged
 - [x] Added regression tests (Tests/dea_tools/test_plotting.py)